### PR TITLE
feat(frontend): port static HTML features to Vue — stale badges, priority, lifecycle, introspect

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   InterruptMetrics,
   Interrupt,
   StatusSnapshot,
+  IntrospectResponse,
 } from '@/types'
 
 class ApiClient {
@@ -185,6 +186,39 @@ class ApiClient {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ type, index }),
       },
+    )
+  }
+
+  // --------------- Lifecycle ---------------
+
+  spawnAgent(space: string, agent: string, command?: string): Promise<{ ok: boolean; tmux_session: string }> {
+    return this.request(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/spawn`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Agent-Name': agent },
+        body: JSON.stringify(command ? { command } : {}),
+      },
+    )
+  }
+
+  stopAgent(space: string, agent: string): Promise<void> {
+    return this.requestVoid(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/stop`,
+      { method: 'POST', headers: { 'X-Agent-Name': agent } },
+    )
+  }
+
+  restartAgent(space: string, agent: string): Promise<{ ok: boolean; tmux_session: string }> {
+    return this.request(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/restart`,
+      { method: 'POST', headers: { 'X-Agent-Name': agent } },
+    )
+  }
+
+  introspectAgent(space: string, agent: string): Promise<IntrospectResponse> {
+    return this.request(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/introspect`,
     )
   }
 }

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AgentUpdate, TmuxAgentStatus, TmuxDisplayState } from '@/types'
+import type { AgentUpdate, TmuxAgentStatus, TmuxDisplayState, IntrospectResponse } from '@/types'
 import { TMUX_STATUS_DISPLAY, getTmuxDisplayState } from '@/types'
 import { ref, computed } from 'vue'
 import { Card, CardContent } from '@/components/ui/card'
@@ -22,12 +22,13 @@ import {
 } from '@/components/ui/alert-dialog'
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Bell, Trash2, ShieldCheck, Terminal, ChevronRight, X, HelpCircle, AlertTriangle, MessageSquareReply } from 'lucide-vue-next'
+import { Bell, Trash2, ShieldCheck, Terminal, ChevronRight, X, HelpCircle, AlertTriangle, MessageSquareReply, Play, Square, RotateCcw, Search } from 'lucide-vue-next'
 import StatusBadge from './StatusBadge.vue'
 import AgentMessages from './AgentMessages.vue'
 import AgentAvatar from './AgentAvatar.vue'
 import { relativeTime, formatFullDate } from '@/composables/useTime'
 import { renderMarkdown, renderMarkdownInline } from '@/lib/markdown'
+import api from '@/api/client'
 
 const props = defineProps<{
   agent: AgentUpdate
@@ -167,6 +168,70 @@ const attentionSectionClass = computed(() => {
   if (hasBlockers.value && !hasQuestions.value) return 'bg-orange-500/10 border-orange-500/30'
   return 'bg-amber-500/10 border-amber-500/30'
 })
+
+// --------------- Lifecycle ---------------
+const lifecycleLoading = ref<'spawn' | 'stop' | 'restart' | null>(null)
+const lifecycleError = ref<string | null>(null)
+
+async function handleSpawn() {
+  lifecycleLoading.value = 'spawn'
+  lifecycleError.value = null
+  try {
+    await api.spawnAgent(props.spaceName, props.agentName)
+  } catch (e) {
+    lifecycleError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    lifecycleLoading.value = null
+  }
+}
+
+async function handleStop() {
+  lifecycleLoading.value = 'stop'
+  lifecycleError.value = null
+  try {
+    await api.stopAgent(props.spaceName, props.agentName)
+  } catch (e) {
+    lifecycleError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    lifecycleLoading.value = null
+  }
+}
+
+async function handleRestart() {
+  lifecycleLoading.value = 'restart'
+  lifecycleError.value = null
+  try {
+    await api.restartAgent(props.spaceName, props.agentName)
+  } catch (e) {
+    lifecycleError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    lifecycleLoading.value = null
+  }
+}
+
+// --------------- Introspection ---------------
+const introspectOpen = ref(false)
+const introspectLoading = ref(false)
+const introspectData = ref<IntrospectResponse | null>(null)
+const introspectError = ref<string | null>(null)
+
+async function loadIntrospect() {
+  if (introspectLoading.value) return
+  introspectLoading.value = true
+  introspectError.value = null
+  try {
+    introspectData.value = await api.introspectAgent(props.spaceName, props.agentName)
+  } catch (e) {
+    introspectError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    introspectLoading.value = false
+  }
+}
+
+function toggleIntrospect() {
+  introspectOpen.value = !introspectOpen.value
+  if (introspectOpen.value) loadIntrospect()
+}
 </script>
 
 <template>
@@ -179,6 +244,22 @@ const attentionSectionClass = computed(() => {
             <AgentAvatar :name="agentName" :size="36" />
             <h1 class="text-2xl font-semibold tracking-tight">{{ agentName }}</h1>
             <StatusBadge :status="agent.status" />
+            <Tooltip v-if="agent.stale">
+              <TooltipTrigger as-child>
+                <Badge variant="outline" class="border-orange-500/50 text-orange-500 text-[10px] h-5 px-1.5">
+                  Stale
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>Agent has not posted an update recently</TooltipContent>
+            </Tooltip>
+            <Tooltip v-if="agent.inferred_status && agent.inferred_status !== 'working'">
+              <TooltipTrigger as-child>
+                <Badge variant="outline" class="border-muted-foreground/40 text-muted-foreground text-[10px] h-5 px-1.5 capitalize">
+                  {{ agent.inferred_status.replace('_', ' ') }}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>Server-inferred status from tmux observation</TooltipContent>
+            </Tooltip>
             <Tooltip v-if="agent.test_count != null">
               <TooltipTrigger as-child>
                 <div class="flex items-center gap-1 rounded-full bg-emerald-500/10 border border-emerald-500/30 px-2.5 py-0.5 text-xs font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums cursor-default">
@@ -244,6 +325,90 @@ const attentionSectionClass = computed(() => {
               Remove this agent from the space
             </TooltipContent>
           </Tooltip>
+
+          <!-- Lifecycle buttons -->
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="outline" size="sm"
+                :disabled="lifecycleLoading !== null"
+                @click="handleSpawn"
+              >
+                <Play class="size-4" />
+                {{ lifecycleLoading === 'spawn' ? '…' : 'Spawn' }}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Create tmux session and launch agent</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="outline" size="sm"
+                :disabled="lifecycleLoading !== null"
+                @click="handleRestart"
+              >
+                <RotateCcw class="size-4" />
+                {{ lifecycleLoading === 'restart' ? '…' : 'Restart' }}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Kill and respawn agent session</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="outline" size="sm"
+                :disabled="lifecycleLoading !== null"
+                @click="handleStop"
+              >
+                <Square class="size-4" />
+                {{ lifecycleLoading === 'stop' ? '…' : 'Stop' }}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Kill the agent's tmux session</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button variant="outline" size="sm" @click="toggleIntrospect">
+                <Search class="size-4" />
+                Inspect
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Capture live tmux pane output</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      <!-- Lifecycle error -->
+      <div v-if="lifecycleError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+        {{ lifecycleError }}
+        <button class="ml-2 underline" @click="lifecycleError = null">dismiss</button>
+      </div>
+
+      <!-- Introspection panel -->
+      <div v-if="introspectOpen" class="rounded-lg border bg-muted/30 p-4 space-y-2">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live Pane — {{ agent.tmux_session || 'no session' }}</span>
+          <div class="flex items-center gap-2">
+            <Button variant="ghost" size="sm" class="h-6 text-xs" :disabled="introspectLoading" @click="loadIntrospect">
+              {{ introspectLoading ? 'Loading…' : 'Refresh' }}
+            </Button>
+            <button class="text-muted-foreground hover:text-foreground" @click="introspectOpen = false">
+              <X class="size-4" />
+            </button>
+          </div>
+        </div>
+        <div v-if="introspectError" class="text-xs text-destructive">{{ introspectError }}</div>
+        <div v-else-if="!introspectData" class="text-xs text-muted-foreground italic">Loading…</div>
+        <div v-else>
+          <div class="flex gap-3 mb-2 text-[11px] text-muted-foreground">
+            <span :class="introspectData.session_exists ? 'text-green-500' : 'text-red-500'">
+              {{ introspectData.session_exists ? 'session online' : 'session offline' }}
+            </span>
+            <span v-if="introspectData.idle">idle</span>
+            <span v-if="introspectData.needs_approval" class="text-primary">awaiting approval: {{ introspectData.tool_name }}</span>
+            <span class="ml-auto">captured {{ new Date(introspectData.captured_at).toLocaleTimeString() }}</span>
+          </div>
+          <pre class="text-[11px] leading-snug text-foreground/80 bg-background rounded border border-border p-3 overflow-x-auto max-h-64 overflow-y-auto font-mono whitespace-pre-wrap">{{ introspectData.lines.join('\n') }}</pre>
         </div>
       </div>
 

--- a/frontend/src/components/AgentMessages.vue
+++ b/frontend/src/components/AgentMessages.vue
@@ -215,6 +215,20 @@ const enrichedMessages = computed((): MessageEntry[] => {
                 {{ entry.msg.sender }}
               </span>
 
+              <!-- Priority badge — directive / urgent only -->
+              <span
+                v-if="entry.msg.priority === 'urgent'"
+                class="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded mb-1 bg-red-500/15 text-red-500 border border-red-500/30"
+              >
+                urgent
+              </span>
+              <span
+                v-else-if="entry.msg.priority === 'directive'"
+                class="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded mb-1 bg-yellow-500/15 text-yellow-600 border border-yellow-500/30 dark:text-yellow-400"
+              >
+                directive
+              </span>
+
               <!-- Bubble -->
               <Tooltip>
                 <TooltipTrigger as-child>

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -416,6 +416,28 @@ const activeSections = computed(() => [
                         </div>
                         <div class="flex items-center gap-1.5 shrink-0">
                           <StatusBadge :status="agent.status" />
+                          <Tooltip v-if="agent.stale">
+                            <TooltipTrigger as-child>
+                              <Badge
+                                variant="outline"
+                                class="border-orange-500/50 text-orange-500 text-[10px] h-5 px-1.5"
+                              >
+                                Stale
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent>Agent has not posted an update recently</TooltipContent>
+                          </Tooltip>
+                          <Tooltip v-if="agent.inferred_status && agent.inferred_status !== 'working'">
+                            <TooltipTrigger as-child>
+                              <Badge
+                                variant="outline"
+                                class="border-muted-foreground/40 text-muted-foreground text-[10px] h-5 px-1.5 capitalize"
+                              >
+                                {{ agent.inferred_status.replace('_', ' ') }}
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent>Server-inferred status from tmux observation</TooltipContent>
+                          </Tooltip>
                           <Tooltip v-if="tmuxStatus?.[name]?.needs_approval">
                             <TooltipTrigger as-child>
                               <Badge

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -19,10 +19,13 @@ export interface AgentDocument {
   content: string
 }
 
+export type MessagePriority = 'info' | 'directive' | 'urgent'
+
 export interface AgentMessage {
   id: string
   message: string
   sender: string
+  priority?: MessagePriority
   timestamp: string
 }
 
@@ -83,6 +86,19 @@ export interface StatusSnapshot {
   inferred_status?: string
   stale?: boolean
   timestamp: string
+}
+
+// GET /spaces/{space}/agent/{name}/introspect response
+export interface IntrospectResponse {
+  agent: string
+  tmux_session?: string
+  session_exists: boolean
+  idle: boolean
+  needs_approval: boolean
+  tool_name?: string
+  prompt_text?: string
+  lines: string[]
+  captured_at: string
 }
 
 // GET /spaces/{space}/factory/interrupts response items


### PR DESCRIPTION
## Summary

Port of all features from `static/mission-control.html` that were missing in the Vue frontend, per CTO directive.

### Stale badge + inferred status
- Orange **Stale** badge on agent cards in SpaceOverview and AgentDetail when \`agent.stale\` is true
- Server-inferred status badge (\`session_missing\`, \`waiting_approval\`, \`idle\`) shown next to StatusBadge when \`inferred_status\` is set

### Message priority badges (AgentMessages)
- Added \`MessagePriority\` type: \`'info' | 'directive' | 'urgent'\`
- Added \`priority?\` field to \`AgentMessage\` interface  
- **urgent** → red badge above message bubble
- **directive** → yellow badge above message bubble

### Lifecycle controls (AgentDetail)
- **Spawn**, **Restart**, **Stop** buttons in agent header action bar
- Loading state per button; inline error display on failure
- Calls \`POST /spaces/{space}/agent/{name}/spawn|restart|stop\`

### Introspection panel (AgentDetail)
- **Inspect** button toggles live tmux pane capture panel
- Shows session online/offline, idle/approval state, capture timestamp
- Scrollable terminal output block (last 50 lines)
- Refresh button to re-capture on demand
- Calls \`GET /spaces/{space}/agent/{name}/introspect\`

### API + Types
- \`api.spawnAgent\`, \`stopAgent\`, \`restartAgent\`, \`introspectAgent\` in \`client.ts\`
- \`IntrospectResponse\` interface in \`types/index.ts\`

## Test plan
- [ ] Build passes: \`vue-tsc -b && vite build\` ✅
- [ ] Stale badge appears on agent cards for stale agents
- [ ] Inferred status badge shows when server-inferred
- [ ] Urgent/directive messages display colored priority badge
- [ ] Spawn/Stop/Restart buttons trigger lifecycle endpoints
- [ ] Inspect panel opens and shows tmux output

🤖 Generated with [Claude Code](https://claude.com/claude-code)