### PR TITLE
feat(tasks): Phase 1 task management backend

### DIFF
--- a/internal/coordinator/journal.go
+++ b/internal/coordinator/journal.go
@@ -23,6 +23,14 @@ const (
 	EventContractsUpdated  SpaceEventType = "contracts_updated"
 	EventArchiveUpdated    SpaceEventType = "archive_updated"
 	EventSnapshot          SpaceEventType = "snapshot"
+
+	// Task events
+	EventTaskCreated   SpaceEventType = "task_created"
+	EventTaskUpdated   SpaceEventType = "task_updated"
+	EventTaskDeleted   SpaceEventType = "task_deleted"
+	EventTaskCommented SpaceEventType = "task_commented"
+	EventTaskMoved     SpaceEventType = "task_moved"
+	EventTaskAssigned  SpaceEventType = "task_assigned"
 )
 
 // SpaceEvent is a single append-only entry in the event journal.
@@ -283,6 +291,80 @@ func (j *EventJournal) ReplayInto(space string) (*KnowledgeSpace, error) {
 			}
 			if err := json.Unmarshal(ev.Payload, &payload); err == nil {
 				ks.Archive = payload.Content
+			}
+
+		case EventTaskCreated, EventTaskUpdated:
+			var task Task
+			if err := json.Unmarshal(ev.Payload, &task); err != nil {
+				continue
+			}
+			if ks.Tasks == nil {
+				ks.Tasks = make(map[string]*Task)
+			}
+			ks.Tasks[task.ID] = &task
+			if task.ID > fmt.Sprintf("TASK-%03d", ks.NextTaskSeq) {
+				// parse and update counter
+				var seq int
+				fmt.Sscanf(task.ID, "TASK-%d", &seq)
+				if seq >= ks.NextTaskSeq {
+					ks.NextTaskSeq = seq + 1
+				}
+			}
+
+		case EventTaskDeleted:
+			var payload struct {
+				ID string `json:"id"`
+			}
+			if err := json.Unmarshal(ev.Payload, &payload); err == nil && payload.ID != "" {
+				delete(ks.Tasks, payload.ID)
+			}
+
+		case EventTaskCommented:
+			var payload struct {
+				TaskID  string      `json:"task_id"`
+				Comment TaskComment `json:"comment"`
+			}
+			if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+				continue
+			}
+			if ks.Tasks == nil {
+				continue
+			}
+			if task, ok := ks.Tasks[payload.TaskID]; ok {
+				task.Comments = append(task.Comments, payload.Comment)
+				task.UpdatedAt = ev.Timestamp
+			}
+
+		case EventTaskMoved:
+			var payload struct {
+				ID     string     `json:"id"`
+				Status TaskStatus `json:"status"`
+			}
+			if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+				continue
+			}
+			if ks.Tasks == nil {
+				continue
+			}
+			if task, ok := ks.Tasks[payload.ID]; ok {
+				task.Status = payload.Status
+				task.UpdatedAt = ev.Timestamp
+			}
+
+		case EventTaskAssigned:
+			var payload struct {
+				ID         string `json:"id"`
+				AssignedTo string `json:"assigned_to"`
+			}
+			if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+				continue
+			}
+			if ks.Tasks == nil {
+				continue
+			}
+			if task, ok := ks.Tasks[payload.ID]; ok {
+				task.AssignedTo = payload.AssignedTo
+				task.UpdatedAt = ev.Timestamp
 			}
 		}
 	}

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -584,6 +585,12 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 		} else {
 			http.NotFound(w, r)
 		}
+	case "tasks":
+		rest := ""
+		if len(parts) >= 3 {
+			rest = strings.TrimRight(strings.Join(parts[2:], "/"), "/")
+		}
+		s.handleSpaceTasks(w, r, spaceName, rest)
 	case "hierarchy":
 		s.handleSpaceHierarchy(w, r, spaceName)
 	case "history":
@@ -2319,4 +2326,483 @@ func (s *Server) serveHTMLFile(w http.ResponseWriter, r *http.Request, filename 
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write(content)
+}
+
+// handleSpaceTasks handles all /spaces/{space}/tasks[/{id}[/{action}]] endpoints.
+// rest is the portion of the path after "tasks/": "", "{id}", "{id}/move", "{id}/assign", "{id}/comment".
+func (s *Server) handleSpaceTasks(w http.ResponseWriter, r *http.Request, spaceName, rest string) {
+	if rest == "" {
+		// Collection: POST (create) or GET (list)
+		switch r.Method {
+		case http.MethodPost:
+			s.handleTaskCreate(w, r, spaceName)
+		case http.MethodGet:
+			s.handleTaskList(w, r, spaceName)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
+	// Split rest into taskID and optional action.
+	slashIdx := strings.Index(rest, "/")
+	var taskID, action string
+	if slashIdx < 0 {
+		taskID = rest
+		action = ""
+	} else {
+		taskID = rest[:slashIdx]
+		action = rest[slashIdx+1:]
+	}
+
+	if action == "" {
+		// /tasks/{id}: GET, PUT, DELETE
+		switch r.Method {
+		case http.MethodGet:
+			s.handleTaskGet(w, r, spaceName, taskID)
+		case http.MethodPut:
+			s.handleTaskUpdate(w, r, spaceName, taskID)
+		case http.MethodDelete:
+			s.handleTaskDelete(w, r, spaceName, taskID)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	switch action {
+	case "move":
+		s.handleTaskMove(w, r, spaceName, taskID)
+	case "assign":
+		s.handleTaskAssign(w, r, spaceName, taskID)
+	case "comment":
+		s.handleTaskComment(w, r, spaceName, taskID)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request, spaceName string) {
+	caller := r.Header.Get("X-Agent-Name")
+	if caller == "" {
+		writeJSONError(w, "missing X-Agent-Name header", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Title        string       `json:"title"`
+		Description  string       `json:"description"`
+		Priority     TaskPriority `json:"priority"`
+		AssignedTo   string       `json:"assigned_to"`
+		Labels       []string     `json:"labels"`
+		ParentTask   string       `json:"parent_task"`
+		LinkedBranch string       `json:"linked_branch"`
+		LinkedPR     string       `json:"linked_pr"`
+		DueAt        *time.Time   `json:"due_at"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Title) == "" {
+		writeJSONError(w, "title is required", http.StatusBadRequest)
+		return
+	}
+
+	ks := s.getOrCreateSpace(spaceName)
+
+	s.mu.Lock()
+	ks.NextTaskSeq++
+	id := fmt.Sprintf("TASK-%03d", ks.NextTaskSeq)
+	now := time.Now().UTC()
+	task := &Task{
+		ID:           id,
+		Space:        spaceName,
+		Title:        strings.TrimSpace(req.Title),
+		Description:  req.Description,
+		Status:       TaskStatusBacklog,
+		Priority:     req.Priority,
+		AssignedTo:   req.AssignedTo,
+		CreatedBy:    caller,
+		Labels:       req.Labels,
+		ParentTask:   req.ParentTask,
+		LinkedBranch: req.LinkedBranch,
+		LinkedPR:     req.LinkedPR,
+		DueAt:        req.DueAt,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if ks.Tasks == nil {
+		ks.Tasks = make(map[string]*Task)
+	}
+	ks.Tasks[id] = task
+	ks.UpdatedAt = now
+	taskCopy := *task
+	s.mu.Unlock()
+
+	s.journal.Append(spaceName, EventTaskCreated, "", taskCopy)
+	s.saveSpace(ks)
+
+	// Broadcast SSE
+	if sseData, err := json.Marshal(map[string]any{
+		"id": taskCopy.ID, "space": spaceName, "status": taskCopy.Status,
+		"title": taskCopy.Title, "assigned_to": taskCopy.AssignedTo,
+	}); err == nil {
+		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(taskCopy)
+}
+
+func (s *Server) handleTaskList(w http.ResponseWriter, r *http.Request, spaceName string) {
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"tasks": []any{}, "total": 0})
+		return
+	}
+
+	filterStatus := r.URL.Query().Get("status")
+	filterAssigned := r.URL.Query().Get("assigned_to")
+	filterLabel := r.URL.Query().Get("label")
+	filterPriority := r.URL.Query().Get("priority")
+
+	s.mu.RLock()
+	tasks := make([]*Task, 0, len(ks.Tasks))
+	for _, t := range ks.Tasks {
+		if filterStatus != "" && string(t.Status) != filterStatus {
+			continue
+		}
+		if filterAssigned != "" && !strings.EqualFold(t.AssignedTo, filterAssigned) {
+			continue
+		}
+		if filterPriority != "" && string(t.Priority) != filterPriority {
+			continue
+		}
+		if filterLabel != "" {
+			found := false
+			for _, l := range t.Labels {
+				if l == filterLabel {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+		cp := *t
+		tasks = append(tasks, &cp)
+	}
+	s.mu.RUnlock()
+
+	// Stable sort by ID
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].ID < tasks[j].ID })
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"tasks": tasks, "total": len(tasks)})
+}
+
+func (s *Server) handleTaskGet(w http.ResponseWriter, r *http.Request, spaceName, taskID string) {
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, "space not found", http.StatusNotFound)
+		return
+	}
+	s.mu.RLock()
+	task, ok := ks.Tasks[taskID]
+	var cp Task
+	if ok {
+		cp = *task
+	}
+	s.mu.RUnlock()
+	if !ok {
+		writeJSONError(w, fmt.Sprintf("task %q not found", taskID), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(cp)
+}
+
+func (s *Server) handleTaskUpdate(w http.ResponseWriter, r *http.Request, spaceName, taskID string) {
+	caller := r.Header.Get("X-Agent-Name")
+	if caller == "" {
+		writeJSONError(w, "missing X-Agent-Name header", http.StatusBadRequest)
+		return
+	}
+
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, "space not found", http.StatusNotFound)
+		return
+	}
+
+	var req struct {
+		Title        *string      `json:"title"`
+		Description  *string      `json:"description"`
+		Status       *TaskStatus  `json:"status"`
+		Priority     *TaskPriority `json:"priority"`
+		AssignedTo   *string      `json:"assigned_to"`
+		Labels       []string     `json:"labels"`
+		LinkedBranch *string      `json:"linked_branch"`
+		LinkedPR     *string      `json:"linked_pr"`
+		DueAt        *time.Time   `json:"due_at"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	task, exists := ks.Tasks[taskID]
+	if !exists {
+		s.mu.Unlock()
+		writeJSONError(w, fmt.Sprintf("task %q not found", taskID), http.StatusNotFound)
+		return
+	}
+	now := time.Now().UTC()
+	if req.Title != nil {
+		task.Title = strings.TrimSpace(*req.Title)
+	}
+	if req.Description != nil {
+		task.Description = *req.Description
+	}
+	if req.Status != nil {
+		if !req.Status.Valid() {
+			s.mu.Unlock()
+			writeJSONError(w, fmt.Sprintf("invalid status %q", *req.Status), http.StatusBadRequest)
+			return
+		}
+		task.Status = *req.Status
+	}
+	if req.Priority != nil {
+		task.Priority = *req.Priority
+	}
+	if req.AssignedTo != nil {
+		task.AssignedTo = *req.AssignedTo
+	}
+	if req.Labels != nil {
+		task.Labels = req.Labels
+	}
+	if req.LinkedBranch != nil {
+		task.LinkedBranch = *req.LinkedBranch
+	}
+	if req.LinkedPR != nil {
+		task.LinkedPR = *req.LinkedPR
+	}
+	if req.DueAt != nil {
+		task.DueAt = req.DueAt
+	}
+	task.UpdatedAt = now
+	taskCopy := *task
+	s.mu.Unlock()
+
+	s.journal.Append(spaceName, EventTaskUpdated, "", taskCopy)
+	s.saveSpace(ks)
+
+	if sseData, err := json.Marshal(map[string]any{
+		"id": taskCopy.ID, "space": spaceName, "status": taskCopy.Status,
+		"title": taskCopy.Title, "assigned_to": taskCopy.AssignedTo,
+	}); err == nil {
+		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(taskCopy)
+}
+
+func (s *Server) handleTaskDelete(w http.ResponseWriter, r *http.Request, spaceName, taskID string) {
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, "space not found", http.StatusNotFound)
+		return
+	}
+	s.mu.Lock()
+	_, exists := ks.Tasks[taskID]
+	if !exists {
+		s.mu.Unlock()
+		writeJSONError(w, fmt.Sprintf("task %q not found", taskID), http.StatusNotFound)
+		return
+	}
+	delete(ks.Tasks, taskID)
+	ks.UpdatedAt = time.Now().UTC()
+	s.mu.Unlock()
+
+	s.journal.Append(spaceName, EventTaskDeleted, "", map[string]string{"id": taskID})
+	s.saveSpace(ks)
+
+	if sseData, err := json.Marshal(map[string]any{"id": taskID, "space": spaceName, "deleted": true}); err == nil {
+		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleTaskMove(w http.ResponseWriter, r *http.Request, spaceName, taskID string) {
+	caller := r.Header.Get("X-Agent-Name")
+	if caller == "" {
+		writeJSONError(w, "missing X-Agent-Name header", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Status TaskStatus `json:"status"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	if !req.Status.Valid() {
+		writeJSONError(w, fmt.Sprintf("invalid status %q", req.Status), http.StatusBadRequest)
+		return
+	}
+
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, "space not found", http.StatusNotFound)
+		return
+	}
+
+	s.mu.Lock()
+	task, exists := ks.Tasks[taskID]
+	if !exists {
+		s.mu.Unlock()
+		writeJSONError(w, fmt.Sprintf("task %q not found", taskID), http.StatusNotFound)
+		return
+	}
+	fromStatus := task.Status
+	task.Status = req.Status
+	task.UpdatedAt = time.Now().UTC()
+	taskCopy := *task
+	s.mu.Unlock()
+
+	s.journal.Append(spaceName, EventTaskMoved, "", map[string]string{
+		"id": taskID, "from_status": string(fromStatus), "status": string(req.Status), "by": caller,
+	})
+	s.saveSpace(ks)
+
+	if sseData, err := json.Marshal(map[string]any{
+		"id": taskID, "space": spaceName, "status": taskCopy.Status, "assigned_to": taskCopy.AssignedTo,
+	}); err == nil {
+		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(taskCopy)
+}
+
+func (s *Server) handleTaskAssign(w http.ResponseWriter, r *http.Request, spaceName, taskID string) {
+	caller := r.Header.Get("X-Agent-Name")
+	if caller == "" {
+		writeJSONError(w, "missing X-Agent-Name header", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		AssignedTo string `json:"assigned_to"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, "space not found", http.StatusNotFound)
+		return
+	}
+
+	s.mu.Lock()
+	task, exists := ks.Tasks[taskID]
+	if !exists {
+		s.mu.Unlock()
+		writeJSONError(w, fmt.Sprintf("task %q not found", taskID), http.StatusNotFound)
+		return
+	}
+	fromAgent := task.AssignedTo
+	task.AssignedTo = req.AssignedTo
+	task.UpdatedAt = time.Now().UTC()
+	taskCopy := *task
+	s.mu.Unlock()
+
+	s.journal.Append(spaceName, EventTaskAssigned, "", map[string]string{
+		"id": taskID, "from_agent": fromAgent, "assigned_to": req.AssignedTo, "by": caller,
+	})
+	s.saveSpace(ks)
+
+	if sseData, err := json.Marshal(map[string]any{
+		"id": taskID, "space": spaceName, "status": taskCopy.Status, "assigned_to": taskCopy.AssignedTo,
+	}); err == nil {
+		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(taskCopy)
+}
+
+func (s *Server) handleTaskComment(w http.ResponseWriter, r *http.Request, spaceName, taskID string) {
+	caller := r.Header.Get("X-Agent-Name")
+	if caller == "" {
+		writeJSONError(w, "missing X-Agent-Name header", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Body string `json:"body"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Body) == "" {
+		writeJSONError(w, "body is required", http.StatusBadRequest)
+		return
+	}
+
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, "space not found", http.StatusNotFound)
+		return
+	}
+
+	s.mu.Lock()
+	task, exists := ks.Tasks[taskID]
+	if !exists {
+		s.mu.Unlock()
+		writeJSONError(w, fmt.Sprintf("task %q not found", taskID), http.StatusNotFound)
+		return
+	}
+	now := time.Now().UTC()
+	comment := TaskComment{
+		ID:        fmt.Sprintf("%d", now.UnixNano()),
+		Author:    caller,
+		Body:      req.Body,
+		CreatedAt: now,
+	}
+	task.Comments = append(task.Comments, comment)
+	task.UpdatedAt = now
+	taskCopy := *task
+	s.mu.Unlock()
+
+	s.journal.Append(spaceName, EventTaskCommented, "", map[string]any{
+		"task_id": taskID, "comment": comment,
+	})
+	s.saveSpace(ks)
+
+	if sseData, err := json.Marshal(map[string]any{
+		"id": taskID, "space": spaceName, "status": taskCopy.Status,
+	}); err == nil {
+		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(taskCopy)
 }

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -2074,3 +2074,588 @@ func TestChildrenNotClientSettable(t *testing.T) {
 	}
 }
 
+// ---- Task Management Tests ----
+
+func taskURL(base, space, rest string) string {
+	if rest == "" {
+		return base + "/spaces/" + space + "/tasks"
+	}
+	return base + "/spaces/" + space + "/tasks/" + rest
+}
+
+func postTaskJSON(t *testing.T, url string, payload any, agentName string) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Agent-Name", agentName)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	return resp
+}
+
+func putTaskJSON(t *testing.T, url string, payload any, agentName string) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Agent-Name", agentName)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT %s: %v", url, err)
+	}
+	return resp
+}
+
+func deleteReq(t *testing.T, url, agentName string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if agentName != "" {
+		req.Header.Set("X-Agent-Name", agentName)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+	return resp
+}
+
+func TestTaskCreate(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	resp := postTaskJSON(t, taskURL(base, "myspace", ""), map[string]any{
+		"title":       "Fix SSE reconnect",
+		"priority":    "high",
+		"assigned_to": "DevAgent",
+		"labels":      []string{"backend"},
+	}, "ManagerAgent")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+
+	var task Task
+	json.NewDecoder(resp.Body).Decode(&task)
+
+	if task.ID != "TASK-001" {
+		t.Errorf("expected TASK-001, got %q", task.ID)
+	}
+	if task.Status != TaskStatusBacklog {
+		t.Errorf("expected backlog status, got %q", task.Status)
+	}
+	if task.CreatedBy != "ManagerAgent" {
+		t.Errorf("created_by = %q, want ManagerAgent", task.CreatedBy)
+	}
+	if task.Priority != "high" {
+		t.Errorf("priority = %q, want high", task.Priority)
+	}
+	if task.AssignedTo != "DevAgent" {
+		t.Errorf("assigned_to = %q, want DevAgent", task.AssignedTo)
+	}
+}
+
+func TestTaskCreateMissingTitle(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	resp := postTaskJSON(t, taskURL(base, "myspace", ""), map[string]any{
+		"priority": "high",
+	}, "ManagerAgent")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestTaskCreateMissingAgentName(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	data, _ := json.Marshal(map[string]any{"title": "Some task"})
+	req, _ := http.NewRequest(http.MethodPost, taskURL(base, "myspace", ""), strings.NewReader(string(data)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestTaskListEmpty(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	code, body := getBody(t, taskURL(base, "emptyspace", ""))
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	var result struct {
+		Tasks []Task `json:"tasks"`
+		Total int    `json:"total"`
+	}
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 0 {
+		t.Errorf("expected 0 tasks, got %d", result.Total)
+	}
+}
+
+func TestTaskListWithTasks(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "listspace"
+
+	// Create 3 tasks
+	for i, title := range []string{"Task A", "Task B", "Task C"} {
+		resp := postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": title, "priority": "low"}, "Creator")
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create task %d: got %d", i, resp.StatusCode)
+		}
+	}
+
+	code, body := getBody(t, taskURL(base, space, ""))
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	var result struct {
+		Tasks []Task `json:"tasks"`
+		Total int    `json:"total"`
+	}
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 3 {
+		t.Errorf("expected 3 tasks, got %d", result.Total)
+	}
+}
+
+func TestTaskListFilterByStatus(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "filterspace"
+
+	// Create task then move it
+	resp := postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Movable"}, "Mgr")
+	resp.Body.Close()
+	postTaskJSON(t, taskURL(base, space, "TASK-001/move"), map[string]any{"status": "in_progress"}, "Mgr").Body.Close()
+
+	// Filter by in_progress
+	code, body := getBody(t, taskURL(base, space, "")+"?status=in_progress")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	var result struct {
+		Tasks []Task `json:"tasks"`
+		Total int    `json:"total"`
+	}
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 1 || result.Tasks[0].Status != TaskStatusInProgress {
+		t.Errorf("expected 1 in_progress task, got %+v", result)
+	}
+
+	// Filter by backlog — should be 0 now
+	code, body = getBody(t, taskURL(base, space, "")+"?status=backlog")
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 0 {
+		t.Errorf("expected 0 backlog tasks, got %d", result.Total)
+	}
+}
+
+func TestTaskListFilterByAssignee(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "assignspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "For Alice", "assigned_to": "Alice"}, "Mgr").Body.Close()
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "For Bob", "assigned_to": "Bob"}, "Mgr").Body.Close()
+
+	code, body := getBody(t, taskURL(base, space, "")+"?assigned_to=Alice")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	var result struct {
+		Tasks []Task `json:"tasks"`
+		Total int    `json:"total"`
+	}
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 1 || result.Tasks[0].AssignedTo != "Alice" {
+		t.Errorf("expected 1 Alice task, got %+v", result)
+	}
+}
+
+func TestTaskListFilterByLabel(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "labelspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Backend task", "labels": []string{"backend", "api"}}, "Mgr").Body.Close()
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Frontend task", "labels": []string{"frontend"}}, "Mgr").Body.Close()
+
+	code, body := getBody(t, taskURL(base, space, "")+"?label=backend")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	var result struct {
+		Tasks []Task `json:"tasks"`
+		Total int    `json:"total"`
+	}
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 1 {
+		t.Errorf("expected 1 backend task, got %d", result.Total)
+	}
+}
+
+func TestTaskListFilterByPriority(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "priospace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Urgent one", "priority": "urgent"}, "Mgr").Body.Close()
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Low one", "priority": "low"}, "Mgr").Body.Close()
+
+	code, body := getBody(t, taskURL(base, space, "")+"?priority=urgent")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	var result struct {
+		Tasks []Task `json:"tasks"`
+		Total int    `json:"total"`
+	}
+	json.Unmarshal([]byte(body), &result)
+	if result.Total != 1 || result.Tasks[0].Priority != "urgent" {
+		t.Errorf("expected 1 urgent task, got %+v", result)
+	}
+}
+
+func TestTaskGet(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "getspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Gettable task"}, "Mgr").Body.Close()
+
+	code, body := getBody(t, taskURL(base, space, "TASK-001"))
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", code, body)
+	}
+	var task Task
+	json.Unmarshal([]byte(body), &task)
+	if task.ID != "TASK-001" {
+		t.Errorf("expected TASK-001, got %q", task.ID)
+	}
+	if task.Title != "Gettable task" {
+		t.Errorf("expected 'Gettable task', got %q", task.Title)
+	}
+}
+
+func TestTaskGetNotFound(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	code, _ := getBody(t, taskURL(base, "myspace", "TASK-999"))
+	if code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", code)
+	}
+}
+
+func TestTaskUpdate(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "updatespace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Original title"}, "Mgr").Body.Close()
+
+	newTitle := "Updated title"
+	resp := putTaskJSON(t, taskURL(base, space, "TASK-001"), map[string]any{
+		"title":    newTitle,
+		"priority": "high",
+	}, "Mgr")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var task Task
+	json.NewDecoder(resp.Body).Decode(&task)
+	if task.Title != newTitle {
+		t.Errorf("title = %q, want %q", task.Title, newTitle)
+	}
+	if task.Priority != "high" {
+		t.Errorf("priority = %q, want high", task.Priority)
+	}
+}
+
+func TestTaskDelete(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "delspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "To delete"}, "Mgr").Body.Close()
+
+	resp := deleteReq(t, taskURL(base, space, "TASK-001"), "Mgr")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", resp.StatusCode)
+	}
+
+	// Verify gone
+	code, _ := getBody(t, taskURL(base, space, "TASK-001"))
+	if code != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", code)
+	}
+}
+
+func TestTaskMove(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "movespace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Movable"}, "Mgr").Body.Close()
+
+	resp := postTaskJSON(t, taskURL(base, space, "TASK-001/move"), map[string]any{"status": "in_progress"}, "DevAgent")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var task Task
+	json.NewDecoder(resp.Body).Decode(&task)
+	if task.Status != TaskStatusInProgress {
+		t.Errorf("status = %q, want in_progress", task.Status)
+	}
+}
+
+func TestTaskMoveInvalidStatus(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "movevalspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Task"}, "Mgr").Body.Close()
+
+	resp := postTaskJSON(t, taskURL(base, space, "TASK-001/move"), map[string]any{"status": "nonexistent"}, "DevAgent")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestTaskAssign(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "assigntestspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Assignable"}, "Mgr").Body.Close()
+
+	resp := postTaskJSON(t, taskURL(base, space, "TASK-001/assign"), map[string]any{"assigned_to": "WorkerBot"}, "Mgr")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var task Task
+	json.NewDecoder(resp.Body).Decode(&task)
+	if task.AssignedTo != "WorkerBot" {
+		t.Errorf("assigned_to = %q, want WorkerBot", task.AssignedTo)
+	}
+}
+
+func TestTaskComment(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "commentspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Commentable"}, "Mgr").Body.Close()
+
+	resp := postTaskJSON(t, taskURL(base, space, "TASK-001/comment"), map[string]any{"body": "Started investigation."}, "DevAgent")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.StatusCode)
+	}
+	var task Task
+	json.NewDecoder(resp.Body).Decode(&task)
+	if len(task.Comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(task.Comments))
+	}
+	if task.Comments[0].Author != "DevAgent" {
+		t.Errorf("comment author = %q, want DevAgent", task.Comments[0].Author)
+	}
+	if task.Comments[0].Body != "Started investigation." {
+		t.Errorf("comment body = %q", task.Comments[0].Body)
+	}
+}
+
+func TestTaskCommentEmptyBody(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "commentvalspace"
+
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Task"}, "Mgr").Body.Close()
+
+	resp := postTaskJSON(t, taskURL(base, space, "TASK-001/comment"), map[string]any{"body": "  "}, "DevAgent")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty comment, got %d", resp.StatusCode)
+	}
+}
+
+func TestTaskSSEBroadcast(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "ssespace"
+
+	// Subscribe to SSE before creating the task
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, base+"/spaces/"+space+"/events", nil)
+	sseResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("SSE connect: %v", err)
+	}
+	defer sseResp.Body.Close()
+
+	// Create a task — should trigger SSE task_updated event
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "SSE test task"}, "Mgr").Body.Close()
+
+	// Read SSE stream until we see task_updated or timeout
+	buf := make([]byte, 4096)
+	sseResp.Body.Read(buf)
+	got := string(buf)
+	if !strings.Contains(got, "task_updated") {
+		t.Errorf("expected task_updated SSE event, got: %q", got)
+	}
+}
+
+func TestTaskJournalReplay(t *testing.T) {
+	dataDir := t.TempDir()
+	space := "replayspace"
+
+	// First server: create tasks and mutate them
+	srv1 := NewServer(":0", dataDir)
+	if err := srv1.Start(); err != nil {
+		t.Fatalf("start srv1: %v", err)
+	}
+	base1 := serverBaseURL(srv1)
+
+	postTaskJSON(t, taskURL(base1, space, ""), map[string]any{"title": "Replay task", "priority": "high"}, "Mgr").Body.Close()
+	postTaskJSON(t, taskURL(base1, space, "TASK-001/move"), map[string]any{"status": "in_progress"}, "Mgr").Body.Close()
+	postTaskJSON(t, taskURL(base1, space, "TASK-001/assign"), map[string]any{"assigned_to": "Worker"}, "Mgr").Body.Close()
+	postTaskJSON(t, taskURL(base1, space, "TASK-001/comment"), map[string]any{"body": "Working on it."}, "Worker").Body.Close()
+	srv1.Stop()
+
+	// Second server: replay from journal
+	srv2 := NewServer(":0", dataDir)
+	if err := srv2.Start(); err != nil {
+		t.Fatalf("start srv2: %v", err)
+	}
+	defer srv2.Stop()
+	base2 := serverBaseURL(srv2)
+
+	code, body := getBody(t, taskURL(base2, space, "TASK-001"))
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 after replay, got %d; body: %s", code, body)
+	}
+	var task Task
+	json.Unmarshal([]byte(body), &task)
+	if task.Status != TaskStatusInProgress {
+		t.Errorf("replayed status = %q, want in_progress", task.Status)
+	}
+	if task.AssignedTo != "Worker" {
+		t.Errorf("replayed assigned_to = %q, want Worker", task.AssignedTo)
+	}
+	if len(task.Comments) != 1 {
+		t.Errorf("replayed comments = %d, want 1", len(task.Comments))
+	}
+}
+
+func TestTaskSequentialIDs(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "idspace"
+
+	var ids []string
+	for i := 0; i < 5; i++ {
+		resp := postTaskJSON(t, taskURL(base, space, ""), map[string]any{"title": "Task"}, "Mgr")
+		var task Task
+		json.NewDecoder(resp.Body).Decode(&task)
+		resp.Body.Close()
+		ids = append(ids, task.ID)
+	}
+
+	expected := []string{"TASK-001", "TASK-002", "TASK-003", "TASK-004", "TASK-005"}
+	for i, id := range ids {
+		if id != expected[i] {
+			t.Errorf("task[%d] ID = %q, want %q", i, id, expected[i])
+		}
+	}
+}
+
+func TestTaskUpdateNotFound(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	resp := putTaskJSON(t, taskURL(base, "myspace", "TASK-999"), map[string]any{"title": "Ghost"}, "Mgr")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestTaskDeleteNotFound(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	resp := deleteReq(t, taskURL(base, "myspace", "TASK-999"), "Mgr")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+

--- a/internal/coordinator/types.go
+++ b/internal/coordinator/types.go
@@ -134,9 +134,79 @@ type Table struct {
 	Rows    [][]string `json:"rows"`
 }
 
+// TaskStatus is the Kanban column a task occupies.
+type TaskStatus string
+
+const (
+	TaskStatusBacklog    TaskStatus = "backlog"
+	TaskStatusInProgress TaskStatus = "in_progress"
+	TaskStatusReview     TaskStatus = "review"
+	TaskStatusDone       TaskStatus = "done"
+	TaskStatusBlocked    TaskStatus = "blocked"
+)
+
+func (ts TaskStatus) Valid() bool {
+	switch ts {
+	case TaskStatusBacklog, TaskStatusInProgress, TaskStatusReview, TaskStatusDone, TaskStatusBlocked:
+		return true
+	}
+	return false
+}
+
+// TaskPriority controls visual ordering and filtering on the board.
+type TaskPriority string
+
+const (
+	TaskPriorityLow    TaskPriority = "low"
+	TaskPriorityMedium TaskPriority = "medium"
+	TaskPriorityHigh   TaskPriority = "high"
+	TaskPriorityUrgent TaskPriority = "urgent"
+)
+
+// Task is the canonical unit of tracked work within a KnowledgeSpace.
+type Task struct {
+	ID          string       `json:"id"`
+	Space       string       `json:"space"`
+	Title       string       `json:"title"`
+	Description string       `json:"description,omitempty"`
+	Status      TaskStatus   `json:"status"`
+	Priority    TaskPriority `json:"priority,omitempty"`
+
+	// Assignment
+	AssignedTo string `json:"assigned_to,omitempty"`
+	CreatedBy  string `json:"created_by"`
+
+	// Relationships
+	Labels     []string `json:"labels,omitempty"`
+	ParentTask string   `json:"parent_task,omitempty"`
+	Subtasks   []string `json:"subtasks,omitempty"`
+
+	// Cross-system links
+	LinkedBranch string `json:"linked_branch,omitempty"`
+	LinkedPR     string `json:"linked_pr,omitempty"`
+
+	// Timestamps
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	DueAt     *time.Time `json:"due_at,omitempty"`
+
+	// Activity
+	Comments []TaskComment `json:"comments,omitempty"`
+}
+
+// TaskComment is a human or agent note on a task.
+type TaskComment struct {
+	ID        string    `json:"id"`
+	Author    string    `json:"author"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 type KnowledgeSpace struct {
 	Name            string                  `json:"name"`
 	Agents          map[string]*AgentUpdate `json:"agents"`
+	Tasks           map[string]*Task        `json:"tasks,omitempty"`
+	NextTaskSeq     int                     `json:"next_task_seq,omitempty"`
 	SharedContracts string                  `json:"shared_contracts,omitempty"`
 	Archive         string                  `json:"archive,omitempty"`
 	CreatedAt       time.Time               `json:"created_at"`
@@ -148,6 +218,7 @@ func NewKnowledgeSpace(name string) *KnowledgeSpace {
 	return &KnowledgeSpace{
 		Name:      name,
 		Agents:    make(map[string]*AgentUpdate),
+		Tasks:     make(map[string]*Task),
 		CreatedAt: now,
 		UpdatedAt: now,
 	}


### PR DESCRIPTION
## Summary

- Implements Phase 1 of the task system from `docs/task-system-design.md`
- Adds `Task`, `TaskComment`, `TaskStatus`, `TaskPriority` types to `types.go`; extends `KnowledgeSpace` with `Tasks map[string]*Task` and `NextTaskSeq int`
- Adds 6 new journal event types (`task_created/updated/deleted/commented/moved/assigned`) with full `ReplayInto` replay support in `journal.go`
- Implements `handleSpaceTasks` in `server.go` covering all 8 API endpoints; broadcasts `task_updated` SSE events on every mutation
- 23 new tests in `server_test.go`: create/list/move/assign/comment, all filter params, SSE broadcast, journal replay, sequential IDs, all error cases

## Test plan

- [x] `go test -race ./internal/coordinator/` — all tests pass (existing + 23 new)
- [x] `go build -o /tmp/boss ./cmd/boss/` — binary builds clean
- [x] No new blocking compiler errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)