### PR TITLE
feat(ui): Phase 2 Kanban task management frontend

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,6 +24,7 @@ import SpaceOverview from '@/components/SpaceOverview.vue'
 import AgentDetail from '@/components/AgentDetail.vue'
 import EventLog from '@/components/EventLog.vue'
 import ConversationsView from '@/components/ConversationsView.vue'
+import KanbanView from '@/components/KanbanView.vue'
 import { Keyboard } from 'lucide-vue-next'
 import { useTheme } from '@/composables/useTheme'
 
@@ -88,8 +89,10 @@ const showConversations = computed(() =>
   selectedAgent.value === 'conversations' || !!conversationAgent.value,
 )
 
+const showKanban = computed(() => route.name === 'kanban')
+
 const selectedAgentData = computed<AgentUpdate | null>(() => {
-  if (!currentSpace.value || !selectedAgent.value || showConversations.value) return null
+  if (!currentSpace.value || !selectedAgent.value || showConversations.value || showKanban.value) return null
   return currentSpace.value.agents[selectedAgent.value] ?? null
 })
 
@@ -916,6 +919,12 @@ onUnmounted(() => {
             </div>
             <p class="text-sm">Loading {{ selectedSpace }}…</p>
           </div>
+
+          <!-- Kanban board -->
+          <KanbanView
+            v-else-if="showKanban && currentSpace"
+            :space="currentSpace"
+          />
 
           <!-- Conversations view -->
           <ConversationsView

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,6 +8,9 @@ import type {
   StatusSnapshot,
   IntrospectResponse,
   HierarchyTree,
+  Task,
+  TaskStatus,
+  TaskPriority,
 } from '@/types'
 
 class ApiClient {
@@ -228,6 +231,93 @@ class ApiClient {
   introspectAgent(space: string, agent: string): Promise<IntrospectResponse> {
     return this.request(
       `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/introspect`,
+    )
+  }
+
+  // --------------- Tasks ---------------
+
+  fetchTasks(space: string, filters?: { status?: TaskStatus; assigned_to?: string; label?: string }): Promise<Task[]> {
+    const params = new URLSearchParams()
+    if (filters?.status) params.set('status', filters.status)
+    if (filters?.assigned_to) params.set('assigned_to', filters.assigned_to)
+    if (filters?.label) params.set('label', filters.label)
+    const qs = params.toString()
+    return this.request<Task[]>(
+      `/spaces/${encodeURIComponent(space)}/tasks${qs ? '?' + qs : ''}`,
+    )
+  }
+
+  createTask(space: string, task: {
+    title: string
+    description?: string
+    priority?: TaskPriority
+    assigned_to?: string
+    labels?: string[]
+  }, actor = 'boss'): Promise<Task> {
+    return this.request<Task>(
+      `/spaces/${encodeURIComponent(space)}/tasks`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
+        body: JSON.stringify(task),
+      },
+    )
+  }
+
+  fetchTask(space: string, id: string): Promise<Task> {
+    return this.request<Task>(
+      `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}`,
+    )
+  }
+
+  updateTask(space: string, id: string, patch: Partial<Pick<Task, 'title' | 'description' | 'priority' | 'assigned_to' | 'labels' | 'linked_branch' | 'linked_pr' | 'due_at'>>, actor = 'boss'): Promise<Task> {
+    return this.request<Task>(
+      `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
+        body: JSON.stringify(patch),
+      },
+    )
+  }
+
+  deleteTask(space: string, id: string, actor = 'boss'): Promise<void> {
+    return this.requestVoid(
+      `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}`,
+      { method: 'DELETE', headers: { 'X-Agent-Name': actor } },
+    )
+  }
+
+  moveTask(space: string, id: string, status: TaskStatus, actor = 'boss'): Promise<Task> {
+    return this.request<Task>(
+      `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}/move`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
+        body: JSON.stringify({ status }),
+      },
+    )
+  }
+
+  assignTask(space: string, id: string, assignedTo: string, actor = 'boss'): Promise<Task> {
+    return this.request<Task>(
+      `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}/assign`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
+        body: JSON.stringify({ assigned_to: assignedTo }),
+      },
+    )
+  }
+
+  addTaskComment(space: string, id: string, body: string, actor = 'boss'): Promise<Task> {
+    return this.request<Task>(
+      `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}/comment`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
+        body: JSON.stringify({ body }),
+      },
     )
   }
 }

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -48,7 +48,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus } from 'lucide-vue-next'
+import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard } from 'lucide-vue-next'
 import AgentAvatar from './AgentAvatar.vue'
 
 const props = defineProps<{
@@ -324,6 +324,25 @@ function submitNewSpace() {
               <div class="px-2 py-3 text-sm text-muted-foreground font-text">
                 No spaces yet — agents will create spaces when they register
               </div>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+
+      <SidebarSeparator v-if="currentSpace" />
+
+      <!-- Space nav: Tasks board -->
+      <SidebarGroup v-if="currentSpace">
+        <SidebarGroupContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                :data-active="false"
+                @click="router.push('/' + selectedSpace + '/kanban')"
+              >
+                <LayoutDashboard class="size-4" />
+                <span>Tasks</span>
+              </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarGroupContent>

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -555,7 +555,7 @@ function handleComposeKeydown(e: KeyboardEvent) {
         <div v-if="composeRecipient" class="border-t p-3 shrink-0">
           <form class="flex items-end gap-2" @submit.prevent="sendInlineCompose">
             <Textarea
-              ref="composeRef"
+              :ref="(el) => { composeRef = el as HTMLTextAreaElement | null }"
               v-model="inlineMessage"
               :placeholder="`Message ${composeRecipient}… (Enter to send, Shift+Enter for newline)`"
               class="flex-1 min-h-[38px] max-h-40 resize-none text-sm"

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { Task, TaskStatus } from '@/types'
+import { TASK_STATUS_LABELS } from '@/types'
+import { ref } from 'vue'
+import TaskCard from './TaskCard.vue'
+
+const props = defineProps<{
+  status: TaskStatus
+  tasks: Task[]
+  draggingTaskId?: string | null
+}>()
+
+const emit = defineEmits<{
+  'task-click': [task: Task]
+  'task-drop': [taskId: string, newStatus: TaskStatus]
+  'task-drag-start': [task: Task]
+}>()
+
+const isDragOver = ref(false)
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = true
+}
+
+function onDragLeave() {
+  isDragOver.value = false
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault()
+  isDragOver.value = false
+  const taskId = e.dataTransfer?.getData('text/plain')
+  if (taskId) {
+    emit('task-drop', taskId, props.status)
+  }
+}
+
+function onDragStart(e: DragEvent, task: Task) {
+  e.dataTransfer?.setData('text/plain', task.id)
+  emit('task-drag-start', task)
+}
+
+const statusHeaderClass: Record<TaskStatus, string> = {
+  backlog: 'text-muted-foreground',
+  in_progress: 'text-blue-600 dark:text-blue-400',
+  review: 'text-purple-600 dark:text-purple-400',
+  blocked: 'text-red-600 dark:text-red-400',
+  done: 'text-teal-600 dark:text-teal-400',
+}
+</script>
+
+<template>
+  <div
+    class="flex flex-col w-64 shrink-0 rounded-lg bg-muted/40 border border-border transition-colors"
+    :class="{ 'border-primary bg-primary/5': isDragOver }"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
+    <!-- Column header -->
+    <div class="flex items-center justify-between px-3 py-2.5 border-b border-border">
+      <span :class="['text-xs font-semibold uppercase tracking-wide', statusHeaderClass[status]]">
+        {{ TASK_STATUS_LABELS[status] }}
+      </span>
+      <span class="text-[10px] font-mono text-muted-foreground bg-muted rounded-full px-1.5 py-0.5 min-w-5 text-center">
+        {{ tasks.length }}
+      </span>
+    </div>
+
+    <!-- Cards -->
+    <div class="flex flex-col gap-2 p-2 flex-1 min-h-24 overflow-y-auto">
+      <TaskCard
+        v-for="task in tasks"
+        :key="task.id"
+        :task="task"
+        :dragging="draggingTaskId === task.id"
+        @click="emit('task-click', task)"
+        @dragstart="onDragStart"
+      />
+      <div
+        v-if="tasks.length === 0"
+        class="flex-1 flex items-center justify-center text-[11px] text-muted-foreground py-6"
+      >
+        No tasks
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -1,0 +1,240 @@
+<script setup lang="ts">
+import type { Task, TaskStatus, KnowledgeSpace } from '@/types'
+import { TASK_STATUS_COLUMNS } from '@/types'
+import { ref, computed, onMounted, watch } from 'vue'
+import { api } from '@/api/client'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { ChevronDown, Plus, RefreshCw } from 'lucide-vue-next'
+import KanbanColumn from './KanbanColumn.vue'
+import TaskDetailPanel from './TaskDetailPanel.vue'
+import NewTaskDialog from './NewTaskDialog.vue'
+
+const props = defineProps<{
+  space: KnowledgeSpace
+}>()
+
+// ── State ──────────────────────────────────────────────────────────
+const tasks = ref<Task[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const draggingTaskId = ref<string | null>(null)
+
+// ── Filters ────────────────────────────────────────────────────────
+const filterAssignee = ref('')
+const filterLabel = ref('')
+
+// ── Panel / Dialog ─────────────────────────────────────────────────
+const selectedTask = ref<Task | null>(null)
+const panelOpen = ref(false)
+const newTaskOpen = ref(false)
+
+// ── Computed: tasks grouped by column ─────────────────────────────
+const allLabels = computed(() => {
+  const s = new Set<string>()
+  for (const t of tasks.value) {
+    for (const l of t.labels ?? []) s.add(l)
+  }
+  return [...s].sort()
+})
+
+const filteredTasks = computed(() => {
+  return tasks.value.filter(t => {
+    if (filterAssignee.value && t.assigned_to !== filterAssignee.value) return false
+    if (filterLabel.value && !t.labels?.includes(filterLabel.value)) return false
+    return true
+  })
+})
+
+const tasksByStatus = computed(() => {
+  const groups: Record<TaskStatus, Task[]> = {
+    backlog: [], in_progress: [], review: [], blocked: [], done: [],
+  }
+  for (const t of filteredTasks.value) {
+    groups[t.status]?.push(t)
+  }
+  return groups
+})
+
+// ── Data loading ───────────────────────────────────────────────────
+async function loadTasks() {
+  loading.value = true
+  error.value = null
+  try {
+    tasks.value = await api.fetchTasks(props.space.name)
+  } catch (e) {
+    // Backend may not have tasks yet — treat as empty
+    if (e instanceof Error && e.message.includes('404')) {
+      tasks.value = []
+    } else {
+      error.value = e instanceof Error ? e.message : String(e)
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadTasks)
+watch(() => props.space.name, loadTasks)
+
+// ── Drag and drop ──────────────────────────────────────────────────
+async function onTaskDrop(taskId: string, newStatus: TaskStatus) {
+  draggingTaskId.value = null
+  const task = tasks.value.find(t => t.id === taskId)
+  if (!task || task.status === newStatus) return
+
+  // Optimistic update
+  const oldStatus = task.status
+  task.status = newStatus
+  try {
+    const updated = await api.moveTask(props.space.name, taskId, newStatus)
+    Object.assign(task, updated)
+  } catch {
+    // Revert on error
+    task.status = oldStatus
+  }
+}
+
+// ── Task detail panel ──────────────────────────────────────────────
+function openTask(task: Task) {
+  selectedTask.value = task
+  panelOpen.value = true
+}
+
+function onTaskUpdated(updated: Task) {
+  const idx = tasks.value.findIndex(t => t.id === updated.id)
+  if (idx >= 0) tasks.value[idx] = updated
+  selectedTask.value = updated
+}
+
+function onTaskDeleted(id: string) {
+  tasks.value = tasks.value.filter(t => t.id !== id)
+  selectedTask.value = null
+}
+
+function onTaskCreated() {
+  loadTasks()
+}
+
+// ── SSE integration (listen for task_updated events) ───────────────
+// The parent App.vue manages the SSE stream; we watch for space changes
+// and refresh. Full SSE integration would be wired through a composable.
+</script>
+
+<template>
+  <div class="flex flex-col h-full overflow-hidden">
+    <!-- Toolbar -->
+    <div class="flex items-center gap-3 px-6 py-3 border-b border-border shrink-0">
+      <h2 class="text-sm font-semibold">Kanban Board</h2>
+      <span class="text-xs text-muted-foreground">{{ filteredTasks.length }} task{{ filteredTasks.length !== 1 ? 's' : '' }}</span>
+
+      <div class="flex items-center gap-2 ml-auto">
+        <!-- Filter by assignee -->
+        <DropdownMenu>
+          <DropdownMenuTrigger as-child>
+            <Button variant="outline" size="sm" class="h-7 text-xs gap-1">
+              {{ filterAssignee || 'All agents' }}
+              <ChevronDown class="size-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem :class="{ 'font-semibold': !filterAssignee }" @click="filterAssignee = ''">
+              All agents
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              v-for="agent in Object.keys(space.agents)"
+              :key="agent"
+              :class="{ 'font-semibold': filterAssignee === agent }"
+              @click="filterAssignee = agent"
+            >
+              {{ agent }}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <!-- Filter by label -->
+        <DropdownMenu v-if="allLabels.length > 0">
+          <DropdownMenuTrigger as-child>
+            <Button variant="outline" size="sm" class="h-7 text-xs gap-1">
+              {{ filterLabel || 'All labels' }}
+              <ChevronDown class="size-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem :class="{ 'font-semibold': !filterLabel }" @click="filterLabel = ''">
+              All labels
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              v-for="label in allLabels"
+              :key="label"
+              :class="{ 'font-semibold': filterLabel === label }"
+              @click="filterLabel = label"
+            >
+              {{ label }}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <Button variant="ghost" size="sm" class="h-7 w-7 p-0" :disabled="loading" @click="loadTasks">
+          <RefreshCw :class="['size-3.5', loading && 'animate-spin']" />
+        </Button>
+
+        <Button size="sm" class="h-7 text-xs gap-1" @click="newTaskOpen = true">
+          <Plus class="size-3.5" />
+          New Task
+        </Button>
+      </div>
+    </div>
+
+    <!-- Error state -->
+    <div v-if="error" class="px-6 py-3 bg-destructive/10 text-destructive text-sm border-b border-border">
+      {{ error }}
+    </div>
+
+    <!-- Loading skeleton -->
+    <div v-if="loading && tasks.length === 0" class="flex items-center justify-center flex-1 text-muted-foreground text-sm">
+      Loading tasks…
+    </div>
+
+    <!-- Board -->
+    <div
+      v-else
+      class="flex gap-3 p-4 overflow-x-auto flex-1"
+      @dragend="draggingTaskId = null"
+    >
+      <KanbanColumn
+        v-for="status in TASK_STATUS_COLUMNS"
+        :key="status"
+        :status="status"
+        :tasks="tasksByStatus[status]"
+        :dragging-task-id="draggingTaskId"
+        @task-click="openTask"
+        @task-drop="onTaskDrop"
+        @task-drag-start="t => draggingTaskId = t.id"
+      />
+    </div>
+
+    <!-- Task detail sheet -->
+    <TaskDetailPanel
+      :task="selectedTask"
+      :space="space"
+      :open="panelOpen"
+      @update:open="panelOpen = $event"
+      @task-updated="onTaskUpdated"
+      @task-deleted="onTaskDeleted"
+    />
+
+    <!-- New task dialog -->
+    <NewTaskDialog
+      :open="newTaskOpen"
+      :space="space"
+      @update:open="newTaskOpen = $event"
+      @created="onTaskCreated"
+    />
+  </div>
+</template>

--- a/frontend/src/components/NewTaskDialog.vue
+++ b/frontend/src/components/NewTaskDialog.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import type { KnowledgeSpace, TaskPriority } from '@/types'
+import { TASK_PRIORITY_LABELS } from '@/types'
+import { ref } from 'vue'
+import { api } from '@/api/client'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { ChevronDown } from 'lucide-vue-next'
+import AgentAvatar from './AgentAvatar.vue'
+
+const props = defineProps<{
+  open: boolean
+  space: KnowledgeSpace
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  created: []
+}>()
+
+const title = ref('')
+const description = ref('')
+const priority = ref<TaskPriority>('medium')
+const assignedTo = ref('')
+const submitting = ref(false)
+
+function reset() {
+  title.value = ''
+  description.value = ''
+  priority.value = 'medium'
+  assignedTo.value = ''
+}
+
+async function submit() {
+  if (!title.value.trim()) return
+  submitting.value = true
+  try {
+    await api.createTask(props.space.name, {
+      title: title.value.trim(),
+      description: description.value.trim() || undefined,
+      priority: priority.value,
+      assigned_to: assignedTo.value || undefined,
+    })
+    reset()
+    emit('created')
+    emit('update:open', false)
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="emit('update:open', $event)">
+    <DialogContent class="sm:max-w-[480px]">
+      <DialogHeader>
+        <DialogTitle>New Task</DialogTitle>
+        <DialogDescription>Create a task in {{ space.name }}</DialogDescription>
+      </DialogHeader>
+
+      <form class="flex flex-col gap-4 py-2" @submit.prevent="submit">
+        <!-- Title -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Title *</label>
+          <Input
+            v-model="title"
+            placeholder="Task title"
+            autofocus
+            class="text-sm"
+          />
+        </div>
+
+        <!-- Description -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Description</label>
+          <Textarea
+            v-model="description"
+            placeholder="Optional description (markdown supported)"
+            class="text-sm min-h-[80px] resize-none"
+          />
+        </div>
+
+        <!-- Priority + Assignee row -->
+        <div class="flex gap-3">
+          <!-- Priority -->
+          <div class="flex flex-col gap-1.5 flex-1">
+            <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Priority</label>
+            <DropdownMenu>
+              <DropdownMenuTrigger as-child>
+                <Button variant="outline" size="sm" class="w-full justify-between text-xs h-8">
+                  {{ TASK_PRIORITY_LABELS[priority] }}
+                  <ChevronDown class="size-3 ml-1" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  v-for="(label, p) in TASK_PRIORITY_LABELS"
+                  :key="p"
+                  :class="{ 'font-semibold': p === priority }"
+                  @click="priority = p as TaskPriority"
+                >
+                  {{ label }}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <!-- Assignee -->
+          <div class="flex flex-col gap-1.5 flex-1">
+            <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Assign To</label>
+            <DropdownMenu>
+              <DropdownMenuTrigger as-child>
+                <Button variant="outline" size="sm" class="w-full justify-between text-xs h-8 gap-1">
+                  <span v-if="assignedTo" class="flex items-center gap-1.5 truncate">
+                    <AgentAvatar :name="assignedTo" :size="14" />
+                    {{ assignedTo }}
+                  </span>
+                  <span v-else class="text-muted-foreground">Unassigned</span>
+                  <ChevronDown class="size-3 ml-1 shrink-0" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem @click="assignedTo = ''">
+                  <span class="text-muted-foreground">Unassigned</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  v-for="agent in Object.keys(space.agents)"
+                  :key="agent"
+                  @click="assignedTo = agent"
+                >
+                  <AgentAvatar :name="agent" :size="14" class="mr-2" />
+                  {{ agent }}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" @click="emit('update:open', false)">Cancel</Button>
+          <Button type="submit" :disabled="!title.trim() || submitting">
+            {{ submitting ? 'Creating…' : 'Create Task' }}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { Task } from '@/types'
+import { TASK_PRIORITY_LABELS, TASK_PRIORITY_COLOR } from '@/types'
+import { computed } from 'vue'
+import { Badge } from '@/components/ui/badge'
+import AgentAvatar from './AgentAvatar.vue'
+import { MessageSquare, GitBranch } from 'lucide-vue-next'
+
+const props = defineProps<{
+  task: Task
+  dragging?: boolean
+}>()
+
+const emit = defineEmits<{
+  click: [task: Task]
+  dragstart: [event: DragEvent, task: Task]
+}>()
+
+const priorityClass = computed(() =>
+  props.task.priority ? TASK_PRIORITY_COLOR[props.task.priority] : '',
+)
+
+const priorityLabel = computed(() =>
+  props.task.priority ? TASK_PRIORITY_LABELS[props.task.priority] : '',
+)
+
+const commentCount = computed(() => props.task.comments?.length ?? 0)
+
+function onDragStart(e: DragEvent) {
+  emit('dragstart', e, props.task)
+}
+</script>
+
+<template>
+  <div
+    class="group bg-card border border-border rounded-lg p-3 cursor-pointer hover:border-primary/40 hover:shadow-sm transition-all select-none"
+    :class="{ 'opacity-50 rotate-1 shadow-lg': dragging }"
+    draggable="true"
+    @click="emit('click', task)"
+    @dragstart="onDragStart"
+  >
+    <!-- ID + Priority row -->
+    <div class="flex items-center justify-between gap-2 mb-1.5">
+      <span class="text-[10px] font-mono text-muted-foreground">{{ task.id }}</span>
+      <Badge v-if="task.priority" :class="['text-[10px] px-1.5 py-0 h-4', priorityClass]">
+        {{ priorityLabel }}
+      </Badge>
+    </div>
+
+    <!-- Title -->
+    <p class="text-sm font-medium leading-snug line-clamp-2 mb-2">{{ task.title }}</p>
+
+    <!-- Labels -->
+    <div v-if="task.labels && task.labels.length" class="flex flex-wrap gap-1 mb-2">
+      <Badge
+        v-for="label in task.labels.slice(0, 3)"
+        :key="label"
+        variant="outline"
+        class="text-[10px] px-1.5 py-0 h-4"
+      >
+        {{ label }}
+      </Badge>
+      <Badge v-if="task.labels.length > 3" variant="outline" class="text-[10px] px-1.5 py-0 h-4">
+        +{{ task.labels.length - 3 }}
+      </Badge>
+    </div>
+
+    <!-- Footer: assignee + branch + comments -->
+    <div class="flex items-center gap-2 mt-1">
+      <AgentAvatar v-if="task.assigned_to" :name="task.assigned_to" :size="16" class="shrink-0" />
+      <span v-if="task.assigned_to" class="text-[10px] text-muted-foreground truncate flex-1">
+        {{ task.assigned_to }}
+      </span>
+      <div v-else class="flex-1" />
+
+      <div class="flex items-center gap-2 text-muted-foreground shrink-0">
+        <span v-if="task.linked_branch" class="flex items-center gap-0.5 text-[10px]">
+          <GitBranch class="size-3" />
+        </span>
+        <span v-if="commentCount > 0" class="flex items-center gap-0.5 text-[10px]">
+          <MessageSquare class="size-3" />
+          {{ commentCount }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -1,0 +1,330 @@
+<script setup lang="ts">
+import type { Task, TaskStatus, TaskPriority, KnowledgeSpace } from '@/types'
+import {
+  TASK_STATUS_LABELS,
+  TASK_PRIORITY_LABELS,
+  TASK_PRIORITY_COLOR,
+  TASK_STATUS_COLUMNS,
+} from '@/types'
+import { ref, watch, computed } from 'vue'
+import { api } from '@/api/client'
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Separator } from '@/components/ui/separator'
+import AgentAvatar from './AgentAvatar.vue'
+import { GitBranch, ExternalLink, ChevronDown, Trash2, Send } from 'lucide-vue-next'
+import { relativeTime } from '@/composables/useTime'
+
+const props = defineProps<{
+  task: Task | null
+  space: KnowledgeSpace
+  open: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'task-updated': [task: Task]
+  'task-deleted': [id: string]
+}>()
+
+const commentText = ref('')
+const submittingComment = ref(false)
+const saving = ref(false)
+const editingTitle = ref(false)
+const localTitle = ref('')
+
+watch(() => props.task, (t) => {
+  if (t) localTitle.value = t.title
+  editingTitle.value = false
+})
+
+const agentNames = computed(() => Object.keys(props.space.agents))
+
+function buildPrUrl(pr: string): string | null {
+  if (pr.startsWith('http')) return pr
+  return null
+}
+
+async function moveTask(status: TaskStatus) {
+  if (!props.task) return
+  saving.value = true
+  try {
+    const updated = await api.moveTask(props.space.name, props.task.id, status)
+    emit('task-updated', updated)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function setPriority(priority: TaskPriority) {
+  if (!props.task) return
+  saving.value = true
+  try {
+    const updated = await api.updateTask(props.space.name, props.task.id, { priority })
+    emit('task-updated', updated)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function assignTask(agent: string) {
+  if (!props.task) return
+  saving.value = true
+  try {
+    const updated = await api.assignTask(props.space.name, props.task.id, agent)
+    emit('task-updated', updated)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function saveTitle() {
+  if (!props.task || !localTitle.value.trim()) return
+  editingTitle.value = false
+  if (localTitle.value.trim() === props.task.title) return
+  saving.value = true
+  try {
+    const updated = await api.updateTask(props.space.name, props.task.id, { title: localTitle.value.trim() })
+    emit('task-updated', updated)
+  } finally {
+    saving.value = false
+  }
+}
+
+async function submitComment() {
+  if (!props.task || !commentText.value.trim()) return
+  submittingComment.value = true
+  try {
+    const updated = await api.addTaskComment(props.space.name, props.task.id, commentText.value.trim())
+    commentText.value = ''
+    emit('task-updated', updated)
+  } finally {
+    submittingComment.value = false
+  }
+}
+
+async function deleteTask() {
+  if (!props.task) return
+  if (!confirm(`Delete task ${props.task.id}?`)) return
+  await api.deleteTask(props.space.name, props.task.id)
+  emit('task-deleted', props.task.id)
+  emit('update:open', false)
+}
+</script>
+
+<template>
+  <Sheet :open="open" @update:open="emit('update:open', $event)">
+    <SheetContent class="w-[480px] sm:w-[540px] overflow-y-auto flex flex-col gap-0 p-0">
+      <div v-if="task" class="flex flex-col h-full">
+        <!-- Header -->
+        <SheetHeader class="px-6 pt-6 pb-4 border-b border-border">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex-1 min-w-0">
+              <span class="text-[11px] font-mono text-muted-foreground">{{ task.id }}</span>
+              <!-- Editable title -->
+              <input
+                v-if="editingTitle"
+                v-model="localTitle"
+                class="w-full text-base font-semibold bg-transparent border-b border-primary outline-none py-0.5 mt-0.5"
+                autofocus
+                @blur="saveTitle"
+                @keydown.enter="saveTitle"
+                @keydown.escape="editingTitle = false"
+              />
+              <SheetTitle
+                v-else
+                class="text-base font-semibold leading-snug cursor-text mt-0.5"
+                @click="editingTitle = true"
+              >
+                {{ task.title }}
+              </SheetTitle>
+            </div>
+            <Button variant="ghost" size="sm" class="text-destructive hover:text-destructive shrink-0" @click="deleteTask">
+              <Trash2 class="size-4" />
+            </Button>
+          </div>
+        </SheetHeader>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-5">
+          <!-- Status + Priority row -->
+          <div class="flex flex-wrap gap-3">
+            <!-- Status -->
+            <div class="flex flex-col gap-1">
+              <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Status</span>
+              <DropdownMenu>
+                <DropdownMenuTrigger as-child>
+                  <Button variant="outline" size="sm" class="h-7 gap-1 text-xs" :disabled="saving">
+                    {{ TASK_STATUS_LABELS[task.status] }}
+                    <ChevronDown class="size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    v-for="s in TASK_STATUS_COLUMNS"
+                    :key="s"
+                    :class="{ 'font-semibold': s === task.status }"
+                    @click="moveTask(s)"
+                  >
+                    {{ TASK_STATUS_LABELS[s] }}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+
+            <!-- Priority -->
+            <div class="flex flex-col gap-1">
+              <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Priority</span>
+              <DropdownMenu>
+                <DropdownMenuTrigger as-child>
+                  <Button variant="outline" size="sm" class="h-7 gap-1 text-xs" :disabled="saving">
+                    <span v-if="task.priority">{{ TASK_PRIORITY_LABELS[task.priority] }}</span>
+                    <span v-else class="text-muted-foreground">None</span>
+                    <ChevronDown class="size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem
+                    v-for="(label, p) in TASK_PRIORITY_LABELS"
+                    :key="p"
+                    :class="{ 'font-semibold': p === task.priority }"
+                    @click="setPriority(p as TaskPriority)"
+                  >
+                    <Badge :class="['text-[10px] mr-2', TASK_PRIORITY_COLOR[p as TaskPriority]]">{{ label }}</Badge>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+
+            <!-- Assignee -->
+            <div class="flex flex-col gap-1">
+              <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Assignee</span>
+              <DropdownMenu>
+                <DropdownMenuTrigger as-child>
+                  <Button variant="outline" size="sm" class="h-7 gap-1 text-xs" :disabled="saving">
+                    <AgentAvatar v-if="task.assigned_to" :name="task.assigned_to" :size="14" />
+                    <span v-if="task.assigned_to">{{ task.assigned_to }}</span>
+                    <span v-else class="text-muted-foreground">Unassigned</span>
+                    <ChevronDown class="size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem @click="assignTask('')">
+                    <span class="text-muted-foreground">Unassigned</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    v-for="agent in agentNames"
+                    :key="agent"
+                    :class="{ 'font-semibold': agent === task.assigned_to }"
+                    @click="assignTask(agent)"
+                  >
+                    <AgentAvatar :name="agent" :size="14" class="mr-2" />
+                    {{ agent }}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </div>
+
+          <Separator />
+
+          <!-- Description -->
+          <div v-if="task.description" class="flex flex-col gap-1.5">
+            <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Description</span>
+            <p class="text-sm text-foreground/80 whitespace-pre-wrap">{{ task.description }}</p>
+          </div>
+
+          <!-- Labels -->
+          <div v-if="task.labels && task.labels.length" class="flex flex-col gap-1.5">
+            <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Labels</span>
+            <div class="flex flex-wrap gap-1.5">
+              <Badge v-for="label in task.labels" :key="label" variant="outline" class="text-xs">
+                {{ label }}
+              </Badge>
+            </div>
+          </div>
+
+          <!-- Links -->
+          <div v-if="task.linked_branch || task.linked_pr" class="flex flex-col gap-1.5">
+            <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Links</span>
+            <div class="flex flex-col gap-1">
+              <div v-if="task.linked_branch" class="flex items-center gap-1.5 text-sm">
+                <GitBranch class="size-3.5 text-muted-foreground" />
+                <code class="text-xs bg-muted px-1.5 py-0.5 rounded">{{ task.linked_branch }}</code>
+              </div>
+              <a
+                v-if="task.linked_pr"
+                :href="buildPrUrl(task.linked_pr) ?? '#'"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="flex items-center gap-1.5 text-sm text-primary hover:underline"
+              >
+                <ExternalLink class="size-3.5" />
+                {{ task.linked_pr }}
+              </a>
+            </div>
+          </div>
+
+          <Separator />
+
+          <!-- Comments -->
+          <div class="flex flex-col gap-3">
+            <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
+              Comments ({{ task.comments?.length ?? 0 }})
+            </span>
+            <div v-if="task.comments && task.comments.length" class="flex flex-col gap-3">
+              <div
+                v-for="comment in task.comments"
+                :key="comment.id"
+                class="flex gap-2.5"
+              >
+                <AgentAvatar :name="comment.author" :size="22" class="shrink-0 mt-0.5" />
+                <div class="flex flex-col gap-0.5 min-w-0">
+                  <div class="flex items-baseline gap-2">
+                    <span class="text-xs font-medium">{{ comment.author }}</span>
+                    <span class="text-[10px] text-muted-foreground">{{ relativeTime(comment.created_at) }}</span>
+                  </div>
+                  <p class="text-sm text-foreground/80 whitespace-pre-wrap">{{ comment.body }}</p>
+                </div>
+              </div>
+            </div>
+            <div v-else class="text-xs text-muted-foreground">No comments yet</div>
+
+            <!-- Add comment -->
+            <div class="flex gap-2 mt-1">
+              <Textarea
+                v-model="commentText"
+                placeholder="Add a comment…"
+                class="text-sm min-h-[60px] resize-none flex-1"
+                @keydown.ctrl.enter="submitComment"
+              />
+              <Button
+                size="sm"
+                :disabled="!commentText.trim() || submittingComment"
+                class="self-end shrink-0"
+                @click="submitComment"
+              >
+                <Send class="size-3.5" />
+              </Button>
+            </div>
+          </div>
+
+          <!-- Metadata footer -->
+          <Separator />
+          <div class="text-[10px] text-muted-foreground flex flex-col gap-0.5 pb-2">
+            <div>Created by <span class="font-medium">{{ task.created_by }}</span> · {{ relativeTime(task.created_at) }}</div>
+            <div>Updated {{ relativeTime(task.updated_at) }}</div>
+          </div>
+        </div>
+      </div>
+    </SheetContent>
+  </Sheet>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -19,6 +19,11 @@ const router = createRouter({
       component: Empty,
     },
     {
+      path: '/:space/kanban',
+      name: 'kanban',
+      component: Empty,
+    },
+    {
       path: '/:space/conversations/:conversationAgent',
       name: 'conversation',
       component: Empty,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -154,6 +154,62 @@ export interface InterruptMetrics {
   avg_wait_seconds: number
 }
 
+// ── Task Management ────────────────────────────────────────────────
+
+export type TaskStatus = 'backlog' | 'in_progress' | 'review' | 'done' | 'blocked'
+export type TaskPriority = 'low' | 'medium' | 'high' | 'urgent'
+
+export interface TaskComment {
+  id: string
+  author: string
+  body: string
+  created_at: string
+}
+
+export interface Task {
+  id: string
+  space: string
+  title: string
+  description?: string
+  status: TaskStatus
+  priority?: TaskPriority
+  assigned_to?: string
+  created_by: string
+  labels?: string[]
+  parent_task?: string
+  subtasks?: string[]
+  linked_branch?: string
+  linked_pr?: string
+  created_at: string
+  updated_at: string
+  due_at?: string
+  comments?: TaskComment[]
+}
+
+export const TASK_STATUS_COLUMNS: TaskStatus[] = ['backlog', 'in_progress', 'review', 'blocked', 'done']
+
+export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  backlog: 'Backlog',
+  in_progress: 'In Progress',
+  review: 'Review',
+  done: 'Done',
+  blocked: 'Blocked',
+}
+
+export const TASK_PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  urgent: 'Urgent',
+}
+
+export const TASK_PRIORITY_COLOR: Record<TaskPriority, string> = {
+  low: 'bg-muted text-muted-foreground',
+  medium: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  high: 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300',
+  urgent: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+}
+
 // SSE event data shapes
 export interface SSEAgentUpdated {
   space: string


### PR DESCRIPTION
## Summary

Implements Phase 2 of the task management system (frontend Kanban board), as specified in `docs/task-system-design.md`.

**New components:**
- `KanbanView.vue` — main board with filter toolbar (by assignee, label), refresh, and New Task button
- `KanbanColumn.vue` — per-status column with native HTML5 drag-and-drop; optimistic card moves on drop
- `TaskCard.vue` — compact card: ID, title, priority badge, labels, assignee avatar, branch/comment indicators
- `TaskDetailPanel.vue` — Sheet side panel: editable title, status/priority/assignee dropdowns, comments thread, delete
- `NewTaskDialog.vue` — create dialog: title, description, priority, assignee

**Modified files:**
- `types/index.ts` — Task, TaskStatus, TaskPriority types + display constants
- `api/client.ts` — full task API surface (fetchTasks, createTask, updateTask, moveTask, assignTask, addTaskComment, deleteTask)
- `router/index.ts` — `/:space/kanban` route
- `AppSidebar.vue` — Tasks nav item with LayoutDashboard icon
- `App.vue` — KanbanView import + showKanban computed + board render

**Graceful degradation:** if the backend task endpoints return 404 (backend Phase 1 not yet deployed), KanbanView shows an empty board rather than an error state.

## Test plan

- [ ] Navigate to `/:space/kanban` — board renders with 5 columns (Backlog, In Progress, Review, Blocked, Done)
- [ ] Click "+ New Task" → dialog opens, create a task → card appears in Backlog
- [ ] Drag card between columns → optimistic move, API call fires
- [ ] Click a card → TaskDetailPanel opens; edit status, priority, assignee via dropdowns
- [ ] Add a comment in TaskDetailPanel
- [ ] Filter by assignee and label in toolbar
- [ ] Tasks nav item in sidebar navigates to board

🤖 Generated with [Claude Code](https://claude.com/claude-code)