### PR TITLE
feat(ui): Phase 3 — task widget, TASK-NNN auto-link, Kanban default view

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -231,7 +231,7 @@ async function loadTmuxStatus(space: string) {
 
 // ── Selection handlers (via router) ────────────────────────────────
 function handleSelectSpace(name: string) {
-  router.push('/' + name)
+  router.push('/' + name + '/kanban')
 }
 
 function handleSelectAgent(name: string) {
@@ -746,7 +746,7 @@ onMounted(async () => {
     sse.connect(selectedSpace.value)
   } else if (spaces.value.length > 0) {
     // No space in URL — redirect to first space
-    router.replace('/' + spaces.value[0]!.name)
+    router.replace('/' + spaces.value[0]!.name + '/kanban')
   } else {
     // No spaces at all — connect to global SSE to catch new spaces
     sse.connect()
@@ -815,8 +815,14 @@ onUnmounted(() => {
             <nav class="flex items-center gap-1" aria-label="Space views">
               <button
                 class="px-2.5 py-1 rounded text-xs font-medium transition-colors"
-                :class="showConversations ? 'text-muted-foreground hover:text-foreground hover:bg-muted' : 'bg-muted text-foreground'"
-                :aria-current="!showConversations ? 'page' : undefined"
+                :class="showKanban ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted'"
+                :aria-current="showKanban ? 'page' : undefined"
+                @click="router.push('/' + selectedSpace + '/kanban')"
+              >Kanban</button>
+              <button
+                class="px-2.5 py-1 rounded text-xs font-medium transition-colors"
+                :class="!showConversations && !showKanban ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted'"
+                :aria-current="!showConversations && !showKanban ? 'page' : undefined"
                 @click="router.push('/' + selectedSpace)"
               >Overview</button>
               <button

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -27,7 +27,7 @@ import StatusBadge from './StatusBadge.vue'
 import AgentMessages from './AgentMessages.vue'
 import AgentAvatar from './AgentAvatar.vue'
 import { relativeTime, formatFullDate } from '@/composables/useTime'
-import { renderMarkdown, renderMarkdownInline } from '@/lib/markdown'
+import { renderMarkdown, renderMarkdownInline, linkTaskRefs } from '@/lib/markdown'
 import { useRouter } from 'vue-router'
 import api from '@/api/client'
 
@@ -713,7 +713,7 @@ onUnmounted(() => {
         <ol class="space-y-1.5 font-text text-sm">
           <li v-for="(item, i) in agent.items" :key="i" class="flex items-start gap-2.5">
             <span class="shrink-0 mt-0.5 min-w-[1.25rem] text-right text-xs font-mono font-semibold text-muted-foreground/70 select-none">{{ i + 1 }}.</span>
-            <span class="leading-relaxed md-content-inline" v-html="renderMarkdownInline(item)" />
+            <span class="leading-relaxed md-content-inline" v-html="renderMarkdownInline(linkTaskRefs(item, spaceName))" />
           </li>
         </ol>
       </section>
@@ -727,7 +727,7 @@ onUnmounted(() => {
           <ol v-if="section.items?.length" class="space-y-1.5 font-text text-sm mb-2">
             <li v-for="(item, ii) in section.items" :key="ii" class="flex items-start gap-2.5">
               <span class="shrink-0 mt-0.5 min-w-[1.25rem] text-right text-xs font-mono font-semibold text-muted-foreground/70 select-none">{{ ii + 1 }}.</span>
-              <span class="leading-relaxed md-content-inline" v-html="renderMarkdownInline(item)" />
+              <span class="leading-relaxed md-content-inline" v-html="renderMarkdownInline(linkTaskRefs(item, spaceName))" />
             </li>
           </ol>
           <!-- Table -->

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -11,7 +11,8 @@ import AgentAvatar from './AgentAvatar.vue'
 import AgentProfileCard from './AgentProfileCard.vue'
 import StatusBadge from './StatusBadge.vue'
 import { MessageSquare, Search, X, GitBranch, ExternalLink, SendHorizontal, Plus } from 'lucide-vue-next'
-import { renderMarkdown } from '@/lib/markdown'
+import { renderMarkdown, linkTaskRefs } from '@/lib/markdown'
+import type { Task } from '@/types'
 import { relativeTime } from '@/composables/useTime'
 import api from '@/api/client'
 
@@ -257,6 +258,24 @@ function handleComposeKeydown(e: KeyboardEvent) {
     sendInlineCompose()
   }
 }
+
+// ── Task widget ──────────────────────────────────────────────────────
+const agentTasks = ref<Task[]>([])
+const tasksLoading = ref(false)
+const showTaskPanel = ref(true)
+
+watch(composeRecipient, async (agent) => {
+  agentTasks.value = []
+  if (!agent) return
+  tasksLoading.value = true
+  try {
+    agentTasks.value = await api.fetchTasks(props.space.name, { assigned_to: agent })
+  } catch {
+    agentTasks.value = []
+  } finally {
+    tasksLoading.value = false
+  }
+}, { immediate: true })
 </script>
 
 <template>
@@ -424,8 +443,10 @@ function handleComposeKeydown(e: KeyboardEvent) {
       </ScrollArea>
     </aside>
 
-    <!-- Right panel: thread view -->
-    <div class="flex-1 flex flex-col min-h-0 min-w-0">
+    <!-- Right panel: thread view + task widget -->
+    <div class="flex-1 flex flex-row min-h-0 min-w-0">
+      <!-- Thread column -->
+      <div class="flex-1 flex flex-col min-h-0 min-w-0">
       <template v-if="selectedConversation">
         <!-- Thread header -->
         <div class="flex items-center gap-3 px-4 py-3 border-b shrink-0">
@@ -543,7 +564,7 @@ function handleComposeKeydown(e: KeyboardEvent) {
                   </div>
                   <div
                     class="bg-muted rounded-lg px-3 py-2 text-sm break-words leading-relaxed md-content"
-                    v-html="renderMarkdown(msg.message)"
+                    v-html="renderMarkdown(linkTaskRefs(msg.message, space.name))"
                   />
                 </div>
               </div>
@@ -590,6 +611,48 @@ function handleComposeKeydown(e: KeyboardEvent) {
           <p class="text-xs mt-0.5">Choose a conversation from the list to view its thread</p>
         </div>
       </div>
+      </div><!-- end thread column -->
+
+      <!-- Task widget panel -->
+      <aside
+        v-if="composeRecipient"
+        class="w-60 shrink-0 border-l flex flex-col min-h-0"
+        aria-label="Agent tasks"
+      >
+        <div class="flex items-center justify-between px-3 py-2 border-b shrink-0">
+          <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Tasks</span>
+          <button
+            class="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            :aria-label="showTaskPanel ? 'Collapse tasks' : 'Expand tasks'"
+            @click="showTaskPanel = !showTaskPanel"
+          >{{ showTaskPanel ? '−' : '+' }}</button>
+        </div>
+        <ScrollArea v-if="showTaskPanel" class="flex-1 min-h-0">
+          <div v-if="tasksLoading" class="px-3 py-4 text-xs text-muted-foreground text-center">Loading…</div>
+          <div v-else-if="agentTasks.length === 0" class="px-3 py-4 text-xs text-muted-foreground text-center">No tasks assigned</div>
+          <ul v-else class="py-1">
+            <li v-for="task in agentTasks" :key="task.id">
+              <a
+                :href="`/${encodeURIComponent(space.name)}/kanban#${task.id}`"
+                class="flex items-start gap-2 px-3 py-2 hover:bg-muted/60 transition-colors text-xs"
+              >
+                <span class="font-mono text-muted-foreground shrink-0 mt-0.5">{{ task.id }}</span>
+                <span class="flex-1 min-w-0 leading-snug line-clamp-2">{{ task.title }}</span>
+                <span
+                  class="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium"
+                  :class="{
+                    'bg-blue-500/10 text-blue-600 dark:text-blue-400': task.status === 'in_progress',
+                    'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400': task.status === 'review',
+                    'bg-red-500/10 text-red-600 dark:text-red-400': task.status === 'blocked',
+                    'bg-green-500/10 text-green-600 dark:text-green-400': task.status === 'done',
+                    'bg-muted text-muted-foreground': task.status === 'backlog',
+                  }"
+                >{{ task.status }}</span>
+              </a>
+            </li>
+          </ul>
+        </ScrollArea>
+      </aside>
     </div>
 
     <!-- Agent detail slideover -->

--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -79,7 +79,15 @@ async function loadTasks() {
   }
 }
 
-onMounted(loadTasks)
+onMounted(async () => {
+  await loadTasks()
+  // Scroll to task anchor if URL hash is present (e.g. /kanban#TASK-001)
+  if (window.location.hash) {
+    const id = window.location.hash.slice(1)
+    const el = document.getElementById(id)
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+})
 watch(() => props.space.name, loadTasks)
 
 // ── Drag and drop ──────────────────────────────────────────────────

--- a/frontend/src/components/TaskCard.vue
+++ b/frontend/src/components/TaskCard.vue
@@ -33,6 +33,7 @@ function onDragStart(e: DragEvent) {
 
 <template>
   <div
+    :id="task.id"
     class="group bg-card border border-border rounded-lg p-3 cursor-pointer hover:border-primary/40 hover:shadow-sm transition-all select-none"
     :class="{ 'opacity-50 rotate-1 shadow-lg': dragging }"
     draggable="true"

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -11,6 +11,14 @@ const BLOCK_ALLOWED_TAGS = [
 const INLINE_ALLOWED_TAGS = ['strong', 'em', 'code', 'a', 'del', 's', 'br']
 const ALLOWED_ATTR = ['href', 'target', 'rel', 'class']
 
+export function linkTaskRefs(text: string, space: string): string {
+  if (!text) return text
+  return text.replace(/\bTASK-\d+\b/g, (match) => {
+    const encoded = encodeURIComponent(space)
+    return `[${match}](/${encoded}/kanban#${match})`
+  })
+}
+
 export function renderMarkdown(text: string): string {
   if (!text) return ''
   const html = marked.parse(text) as string


### PR DESCRIPTION
## Summary

- **Task widget in ConversationsView**: collapsible right sidebar shows tasks assigned to the selected agent, fetched from `/api/spaces/:space/tasks?agent=NAME`, with links to `/:space/kanban#TASK-NNN`
- **TASK-NNN auto-link**: `linkTaskRefs()` helper added to `src/lib/markdown.ts`; applied in AgentDetail items/section.items and ConversationsView message threads; TaskCard gets `:id="task.id"` for anchor nav; KanbanView scrolls to hash-targeted task on mount
- **Kanban as default view**: `handleSelectSpace` pushes `/:space/kanban`, onMounted redirect goes to `/kanban`; header nav updated to Kanban | Overview | Conversations

## Test plan

- [ ] Open a space — should land on Kanban view by default
- [ ] Navigate via header: Kanban, Overview, Conversations all reachable
- [ ] Open Conversations, select an agent with assigned tasks — task widget appears in right sidebar
- [ ] Click task in widget — navigates to Kanban board scrolled to that task
- [ ] Agent status items containing `TASK-001` style refs render as clickable links
- [ ] Direct link to `/:space/kanban#TASK-001` scrolls to correct task card
- [ ] Build: `cd frontend && npm run build` passes clean (2562 modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)