### PR TITLE
fix(ui): UX audit v2 — scroll fixes + UX improvements

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -86,7 +86,7 @@ const conversationAgent = computed(() => {
 })
 
 const showConversations = computed(() =>
-  selectedAgent.value === 'conversations' || !!conversationAgent.value,
+  route.name === 'conversations' || route.name === 'conversation' || selectedAgent.value === 'conversations',
 )
 
 const showKanban = computed(() => route.name === 'kanban')
@@ -803,7 +803,15 @@ onUnmounted(() => {
               >
                 {{ selectedSpace }}
               </button>
-              <template v-if="selectedAgent && !showConversations">
+              <template v-if="showKanban">
+                <span class="text-muted-foreground">/</span>
+                <span class="text-foreground font-medium" aria-current="page">Kanban</span>
+              </template>
+              <template v-else-if="showConversations">
+                <span class="text-muted-foreground">/</span>
+                <span class="text-foreground font-medium" aria-current="page">Conversations</span>
+              </template>
+              <template v-else-if="selectedAgent">
                 <span class="text-muted-foreground">/</span>
                 <span class="text-foreground font-medium" aria-current="page">{{ selectedAgent }}</span>
               </template>
@@ -909,7 +917,7 @@ onUnmounted(() => {
         </div>
 
         <!-- Main content -->
-        <main class="flex-1 min-h-0 overflow-hidden" aria-label="Dashboard content">
+        <main class="flex-1 min-h-0 overflow-hidden flex flex-col" aria-label="Dashboard content">
           <!-- Initial load state -->
           <div v-if="loading" class="flex flex-col items-center justify-center h-full text-muted-foreground font-text gap-3">
             <div class="h-8 w-8 animate-spin rounded-full border-2 border-muted-foreground border-t-primary" role="status">

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -300,7 +300,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <ScrollArea class="h-full">
+  <ScrollArea class="flex-1 min-h-0">
     <div class="p-6 space-y-6 max-w-4xl border-t-[3px]" :class="statusAccentClass">
       <!-- Header -->
       <div class="flex items-start justify-between gap-4 flex-wrap">

--- a/frontend/src/components/AgentProfileCard.vue
+++ b/frontend/src/components/AgentProfileCard.vue
@@ -58,7 +58,7 @@ function computePosition() {
   if (left < 8) left = 8
 
   // If card would go off the bottom, flip above
-  const estimatedCardH = 200
+  const estimatedCardH = 320
   if (top + estimatedCardH > viewportH - 8) {
     top = rect.top - estimatedCardH - 8
     if (top < 8) top = 8

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -52,7 +52,7 @@ const statusHeaderClass: Record<TaskStatus, string> = {
 
 <template>
   <div
-    class="flex flex-col w-64 shrink-0 rounded-lg bg-muted/40 border border-border transition-colors"
+    class="flex flex-col w-64 shrink-0 rounded-lg bg-muted/40 border border-border transition-colors max-h-full"
     :class="{ 'border-primary bg-primary/5': isDragOver }"
     @dragover="onDragOver"
     @dragleave="onDragLeave"

--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -88,7 +88,11 @@ onMounted(async () => {
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }
 })
-watch(() => props.space.name, loadTasks)
+watch(() => props.space.name, () => {
+  filterAssignee.value = ''
+  filterLabel.value = ''
+  loadTasks()
+})
 
 // ── Drag and drop ──────────────────────────────────────────────────
 async function onTaskDrop(taskId: string, newStatus: TaskStatus) {
@@ -212,7 +216,7 @@ function onTaskCreated() {
     <!-- Board -->
     <div
       v-else
-      class="flex gap-3 p-4 overflow-x-auto flex-1"
+      class="flex gap-3 p-4 overflow-x-auto overflow-y-hidden flex-1"
       @dragend="draggingTaskId = null"
     >
       <KanbanColumn

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -278,7 +278,7 @@ const activeSections = computed(() => [
 </script>
 
 <template>
-  <ScrollArea class="h-full">
+  <ScrollArea class="flex-1 min-h-0">
     <div class="p-6 space-y-6 max-w-7xl">
       <!-- Header -->
       <div class="flex items-center justify-between">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -24,6 +24,11 @@ const router = createRouter({
       component: Empty,
     },
     {
+      path: '/:space/conversations',
+      name: 'conversations',
+      component: Empty,
+    },
+    {
       path: '/:space/conversations/:conversationAgent',
       name: 'conversation',
       component: Empty,


### PR DESCRIPTION
## Summary

### Scroll Fixes (priority)
- **App.vue `<main>`**: added `flex flex-col` — fixes h-full resolution for all child views
- **SpaceOverview + AgentDetail ScrollArea**: `h-full` → `flex-1 min-h-0` — scroll works in flex context
- **KanbanView board**: added `overflow-y-hidden` — prevents double scrollbar
- **KanbanColumn root**: added `max-h-full` — columns respect container height

### UX Improvements
- **AgentProfileCard**: `estimatedCardH` 200 → 320 — hover card no longer truncated
- **App.vue breadcrumb**: shows current view label (Kanban / Conversations / agent name)
- **Router**: explicit `/:space/conversations` named route added; `showConversations` detects both `conversations` and `conversation` named routes
- **KanbanView**: resets `filterAssignee` + `filterLabel` when space changes

## Test plan

- [ ] Open any space — scroll works in SpaceOverview agent list
- [ ] Open AgentDetail — content scrolls within panel, no overflow
- [ ] Open KanbanView — columns scroll independently, board does not double-scroll
- [ ] Hover over agent card — full card visible (not truncated at bottom)
- [ ] Navigate to Kanban — breadcrumb shows "Kanban"
- [ ] Navigate to Conversations — breadcrumb shows "Conversations"
- [ ] Switch spaces while in KanbanView — filters reset correctly
- [ ] Direct URL `/:space/conversations` loads ConversationsView
- [ ] Build: `cd frontend && npm run build` passes clean (2562 modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)