### PR TITLE
feat(ui): TASK-006+008 — user journey polish + boss identity UX

### DIFF
--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { AgentUpdate, TmuxAgentStatus, TmuxDisplayState, IntrospectResponse } from '@/types'
+import type { AgentUpdate, TmuxAgentStatus, TmuxDisplayState, IntrospectResponse, Task } from '@/types'
 import { TMUX_STATUS_DISPLAY, getTmuxDisplayState } from '@/types'
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted, onMounted } from 'vue'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/alert-dialog'
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Bell, Trash2, ShieldCheck, Terminal, ChevronRight, X, HelpCircle, AlertTriangle, MessageSquareReply, Play, Square, RotateCcw, Loader2, CheckCircle2, XCircle, Radio, MessageSquare } from 'lucide-vue-next'
+import { Bell, Trash2, ShieldCheck, Terminal, ChevronRight, X, HelpCircle, AlertTriangle, MessageSquareReply, Play, Square, RotateCcw, Loader2, CheckCircle2, XCircle, Radio, MessageSquare, ListTodo } from 'lucide-vue-next'
 import StatusBadge from './StatusBadge.vue'
 import AgentMessages from './AgentMessages.vue'
 import AgentAvatar from './AgentAvatar.vue'
@@ -297,6 +297,25 @@ onUnmounted(() => {
   stopLivePoll()
   if (toastTimer) clearTimeout(toastTimer)
 })
+
+// --------------- Task widget ---------------
+const agentTasks = ref<Task[]>([])
+const agentTasksLoading = ref(false)
+const taskWidgetOpen = ref(true)
+
+async function loadAgentTasks() {
+  agentTasksLoading.value = true
+  try {
+    agentTasks.value = await api.fetchTasks(props.spaceName, { assigned_to: props.agentName })
+  } catch {
+    agentTasks.value = []
+  } finally {
+    agentTasksLoading.value = false
+  }
+}
+
+onMounted(loadAgentTasks)
+watch(() => props.agentName, loadAgentTasks)
 </script>
 
 <template>
@@ -409,13 +428,13 @@ onUnmounted(() => {
               <Button
                 variant="outline"
                 size="sm"
-                @click="router.push(`/${encodeURIComponent(spaceName)}/conversations`)"
+                @click="router.push(`/${encodeURIComponent(spaceName)}/conversations/${encodeURIComponent(agentName)}`)"
               >
                 <MessageSquare class="size-4" /> Conversations
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              View all conversations in this space
+              View conversations with {{ agentName }}
             </TooltipContent>
           </Tooltip>
           <Tooltip>
@@ -718,7 +737,48 @@ onUnmounted(() => {
         </ol>
       </section>
 
-      <Separator v-if="hasItems && (hasSections || agent.next_steps)" class="opacity-50" />
+      <Separator v-if="hasItems" class="opacity-50" />
+
+      <!-- Task widget -->
+      <section aria-label="Assigned tasks">
+        <div class="flex items-center justify-between mb-2">
+          <div class="flex items-center gap-1.5">
+            <ListTodo class="size-3.5 text-muted-foreground" />
+            <h2 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Tasks</h2>
+            <span v-if="agentTasks.length > 0" class="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full">{{ agentTasks.length }}</span>
+          </div>
+          <button class="text-xs text-muted-foreground hover:text-foreground transition-colors" @click="taskWidgetOpen = !taskWidgetOpen">
+            {{ taskWidgetOpen ? '−' : '+' }}
+          </button>
+        </div>
+        <div v-if="taskWidgetOpen">
+          <div v-if="agentTasksLoading" class="text-xs text-muted-foreground">Loading…</div>
+          <div v-else-if="agentTasks.length === 0" class="text-xs text-muted-foreground italic">No tasks assigned to {{ agentName }}</div>
+          <ul v-else class="space-y-1">
+            <li v-for="task in agentTasks" :key="task.id">
+              <a
+                :href="`/${encodeURIComponent(spaceName)}/kanban#${task.id}`"
+                class="flex items-start gap-2 py-1.5 px-2 rounded hover:bg-muted/60 transition-colors text-xs"
+              >
+                <span class="font-mono text-muted-foreground shrink-0 mt-0.5">{{ task.id }}</span>
+                <span class="flex-1 min-w-0 leading-snug">{{ task.title }}</span>
+                <span
+                  class="shrink-0 rounded px-1 py-0.5 text-[10px] font-medium"
+                  :class="{
+                    'bg-blue-500/10 text-blue-600 dark:text-blue-400': task.status === 'in_progress',
+                    'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400': task.status === 'review',
+                    'bg-red-500/10 text-red-600 dark:text-red-400': task.status === 'blocked',
+                    'bg-green-500/10 text-green-600 dark:text-green-400': task.status === 'done',
+                    'bg-muted text-muted-foreground': task.status === 'backlog',
+                  }"
+                >{{ task.status }}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <Separator v-if="hasSections || agent.next_steps" class="opacity-50" />
 
       <!-- Sections -->
       <div v-if="hasSections" class="space-y-4">
@@ -812,6 +872,7 @@ onUnmounted(() => {
       </AlertDialog>
 
       <Separator v-if="hasSections && agent.next_steps" class="opacity-50" />
+
 
       <!-- Next Steps -->
       <section v-if="agent.next_steps" aria-label="Next steps">
@@ -928,7 +989,14 @@ onUnmounted(() => {
       <section class="mt-6" aria-label="Agent messages">
         <Separator class="mb-4" />
         <div class="flex items-center gap-2 mb-3">
-          <h2 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Messages</h2>
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <h2 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground cursor-default">
+                Boss ↔ {{ agentName }} Messages
+              </h2>
+            </TooltipTrigger>
+            <TooltipContent>Direct channel between you (boss) and {{ agentName }}. Messages sent here go directly to the agent's inbox.</TooltipContent>
+          </Tooltip>
           <Badge v-if="agent.messages?.length" variant="secondary" class="h-4 min-w-4 px-1 text-[10px] font-semibold tabular-nums">
             {{ agent.messages.length }}
           </Badge>

--- a/frontend/src/components/AgentProfileCard.vue
+++ b/frontend/src/components/AgentProfileCard.vue
@@ -7,7 +7,7 @@ import AgentAvatar from './AgentAvatar.vue'
 import StatusBadge from './StatusBadge.vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { GitBranch, ExternalLink, Clock, ArrowUpRight, MessageSquare } from 'lucide-vue-next'
+import { GitBranch, ExternalLink, Clock, ArrowUpRight, MessageSquare, Crown } from 'lucide-vue-next'
 
 const props = defineProps<{
   agentName: string
@@ -136,95 +136,114 @@ const summaryText = computed(() => {
         @mouseenter="onCardMouseEnter"
         @mouseleave="onCardMouseLeave"
       >
-        <!-- Header -->
-        <div class="p-4 pb-3 flex items-start gap-3">
-          <AgentAvatar :name="agentName" :size="40" class="shrink-0 mt-0.5" />
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-1.5 flex-wrap">
-              <span class="font-semibold text-sm leading-tight truncate">{{ agentName }}</span>
-              <StatusBadge v-if="agent" :status="agent.status" />
+        <!-- Boss special card -->
+        <template v-if="agentName === 'boss'">
+          <div class="p-4 pb-3 flex items-start gap-3">
+            <div class="shrink-0 mt-0.5 size-10 rounded-full bg-amber-500/15 border border-amber-500/30 flex items-center justify-center">
+              <Crown class="size-5 text-amber-500" />
             </div>
-            <div v-if="agent?.role" class="mt-0.5">
-              <Badge variant="outline" class="text-[10px] h-4 px-1 border-purple-500/40 text-purple-600 dark:text-purple-400">
-                {{ agent.role }}
-              </Badge>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <span class="font-semibold text-sm leading-tight">boss</span>
+                <Badge variant="outline" class="text-[10px] h-4 px-1 border-amber-500/40 text-amber-600 dark:text-amber-400">Human Operator</Badge>
+              </div>
+              <p class="text-xs text-muted-foreground mt-0.5">Project owner — gives orders, reviews PRs, manages the team</p>
             </div>
           </div>
-        </div>
+        </template>
 
-        <div v-if="agent" class="px-4 pb-3 space-y-2">
-          <!-- Summary -->
-          <p v-if="summaryText" class="text-xs text-muted-foreground leading-relaxed line-clamp-3">
-            {{ summaryText }}
-          </p>
-
-          <!-- Hierarchy: parent -->
-          <div v-if="agent.parent" class="flex items-center gap-1 text-[11px] text-muted-foreground">
-            <span class="opacity-60">Reports to</span>
-            <button
-              class="font-medium text-foreground hover:text-primary transition-colors hover:underline"
-              @click.stop="emit('select-agent', agent.parent!)"
-            >
-              {{ agent.parent }}
-            </button>
+        <!-- Regular agent card -->
+        <template v-else>
+          <!-- Header -->
+          <div class="p-4 pb-3 flex items-start gap-3">
+            <AgentAvatar :name="agentName" :size="40" class="shrink-0 mt-0.5" />
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <span class="font-semibold text-sm leading-tight truncate">{{ agentName }}</span>
+                <StatusBadge v-if="agent" :status="agent.status" />
+              </div>
+              <div v-if="agent?.role" class="mt-0.5">
+                <Badge variant="outline" class="text-[10px] h-4 px-1 border-purple-500/40 text-purple-600 dark:text-purple-400">
+                  {{ agent.role }}
+                </Badge>
+              </div>
+            </div>
           </div>
 
-          <!-- Meta row: branch + PR -->
-          <div class="flex items-center gap-2 flex-wrap">
-            <span
-              v-if="agent.branch"
-              class="inline-flex items-center gap-1 font-mono text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground"
-            >
-              <GitBranch class="size-2.5 shrink-0" />
-              {{ agent.branch }}
-            </span>
-            <a
-              v-if="agent.pr && prLink(agent)"
-              :href="prLink(agent)!"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-0.5 text-[10px] text-primary/70 hover:text-primary transition-colors"
-              @click.stop
-            >
-              <ExternalLink class="size-2.5" />
-              {{ agent.pr }}
-            </a>
+          <div v-if="agent" class="px-4 pb-3 space-y-2">
+            <!-- Summary -->
+            <p v-if="summaryText" class="text-xs text-muted-foreground leading-relaxed line-clamp-3">
+              {{ summaryText }}
+            </p>
+
+            <!-- Hierarchy: parent -->
+            <div v-if="agent.parent" class="flex items-center gap-1 text-[11px] text-muted-foreground">
+              <span class="opacity-60">Reports to</span>
+              <button
+                class="font-medium text-foreground hover:text-primary transition-colors hover:underline"
+                @click.stop="emit('select-agent', agent.parent!)"
+              >
+                {{ agent.parent }}
+              </button>
+            </div>
+
+            <!-- Meta row: branch + PR -->
+            <div class="flex items-center gap-2 flex-wrap">
+              <span
+                v-if="agent.branch"
+                class="inline-flex items-center gap-1 font-mono text-[10px] bg-muted px-1.5 py-0.5 rounded text-muted-foreground"
+              >
+                <GitBranch class="size-2.5 shrink-0" />
+                {{ agent.branch }}
+              </span>
+              <a
+                v-if="agent.pr && prLink(agent)"
+                :href="prLink(agent)!"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-0.5 text-[10px] text-primary/70 hover:text-primary transition-colors"
+                @click.stop
+              >
+                <ExternalLink class="size-2.5" />
+                {{ agent.pr }}
+              </a>
+            </div>
+
+            <!-- Last update -->
+            <div class="flex items-center gap-1 text-[10px] text-muted-foreground">
+              <Clock class="size-2.5 shrink-0" />
+              Updated {{ relativeTime(agent.updated_at) }}
+            </div>
           </div>
 
-          <!-- Last update -->
-          <div class="flex items-center gap-1 text-[10px] text-muted-foreground">
-            <Clock class="size-2.5 shrink-0" />
-            Updated {{ relativeTime(agent.updated_at) }}
+          <!-- No data fallback -->
+          <div v-else class="px-4 pb-3">
+            <p class="text-xs text-muted-foreground italic">No data available</p>
           </div>
-        </div>
 
-        <!-- No data fallback -->
-        <div v-else class="px-4 pb-3">
-          <p class="text-xs text-muted-foreground italic">No data available</p>
-        </div>
-
-        <!-- Footer: View Details + Message -->
-        <div class="border-t px-3 py-2 flex gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            class="flex-1 h-7 text-xs justify-start gap-1.5 text-primary hover:text-primary"
-            @click.stop="goToAgent"
-          >
-            <ArrowUpRight class="size-3" />
-            View details
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            class="h-7 text-xs gap-1.5"
-            :disabled="!spaceName"
-            @click.stop="goToConversations"
-          >
-            <MessageSquare class="size-3" />
-            Message
-          </Button>
-        </div>
+          <!-- Footer: View Details + Message -->
+          <div class="border-t px-3 py-2 flex gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              class="flex-1 h-7 text-xs justify-start gap-1.5 text-primary hover:text-primary"
+              @click.stop="goToAgent"
+            >
+              <ArrowUpRight class="size-3" />
+              View details
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="h-7 text-xs gap-1.5"
+              :disabled="!spaceName"
+              @click.stop="goToConversations"
+            >
+              <MessageSquare class="size-3" />
+              Message
+            </Button>
+          </div>
+        </template>
       </div>
     </Transition>
   </Teleport>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -48,7 +48,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard } from 'lucide-vue-next'
+import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard, MessageSquare, Crown } from 'lucide-vue-next'
 import AgentAvatar from './AgentAvatar.vue'
 
 const props = defineProps<{
@@ -242,6 +242,10 @@ function submitNewSpace() {
         <div class="h-6 w-1 rounded-full bg-primary" aria-hidden="true" />
         <h2 class="text-lg font-semibold tracking-tight">Agent Boss</h2>
       </div>
+      <div class="flex items-center gap-1.5 mt-1 text-xs text-amber-600 dark:text-amber-400">
+        <Crown class="size-3 shrink-0" aria-hidden="true" />
+        <span class="font-medium">You (Boss)</span>
+      </div>
     </SidebarHeader>
 
     <!-- overflow-y-auto enables independent scrolling within the fixed-height sidebar -->
@@ -331,7 +335,7 @@ function submitNewSpace() {
 
       <SidebarSeparator v-if="currentSpace" />
 
-      <!-- Space nav: Tasks board -->
+      <!-- Space nav: Tasks board + Conversations -->
       <SidebarGroup v-if="currentSpace">
         <SidebarGroupContent>
           <SidebarMenu>
@@ -342,6 +346,15 @@ function submitNewSpace() {
               >
                 <LayoutDashboard class="size-4" />
                 <span>Tasks</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                :data-active="false"
+                @click="router.push('/' + selectedSpace + '/conversations')"
+              >
+                <MessageSquare class="size-4" />
+                <span>Conversations</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import AgentAvatar from './AgentAvatar.vue'
 import AgentProfileCard from './AgentProfileCard.vue'
 import StatusBadge from './StatusBadge.vue'
+import NewTaskDialog from './NewTaskDialog.vue'
 import { MessageSquare, Search, X, GitBranch, ExternalLink, SendHorizontal, Plus } from 'lucide-vue-next'
 import { renderMarkdown, linkTaskRefs } from '@/lib/markdown'
 import type { Task } from '@/types'
@@ -263,6 +264,7 @@ function handleComposeKeydown(e: KeyboardEvent) {
 const agentTasks = ref<Task[]>([])
 const tasksLoading = ref(false)
 const showTaskPanel = ref(true)
+const newTaskDialogOpen = ref(false)
 
 watch(composeRecipient, async (agent) => {
   agentTasks.value = []
@@ -572,6 +574,11 @@ watch(composeRecipient, async (agent) => {
           </div>
         </ScrollArea>
 
+        <!-- Note shown when boss is not a participant (agent-to-agent thread) -->
+        <div v-if="selectedConversation && !composeRecipient" class="border-t p-3 shrink-0">
+          <p class="text-xs text-muted-foreground text-center italic">Compose is only available in boss ↔ agent threads</p>
+        </div>
+
         <!-- Inline compose box — only when boss is a participant -->
         <div v-if="composeRecipient" class="border-t p-3 shrink-0">
           <form class="flex items-end gap-2" @submit.prevent="sendInlineCompose">
@@ -621,11 +628,25 @@ watch(composeRecipient, async (agent) => {
       >
         <div class="flex items-center justify-between px-3 py-2 border-b shrink-0">
           <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Tasks</span>
-          <button
-            class="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            :aria-label="showTaskPanel ? 'Collapse tasks' : 'Expand tasks'"
-            @click="showTaskPanel = !showTaskPanel"
-          >{{ showTaskPanel ? '−' : '+' }}</button>
+          <div class="flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <button
+                  class="text-xs text-muted-foreground hover:text-primary transition-colors p-0.5"
+                  aria-label="Add task"
+                  @click="newTaskDialogOpen = true"
+                >
+                  <Plus class="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Add task for {{ composeRecipient }}</TooltipContent>
+            </Tooltip>
+            <button
+              class="text-xs text-muted-foreground hover:text-foreground transition-colors ml-1"
+              :aria-label="showTaskPanel ? 'Collapse tasks' : 'Expand tasks'"
+              @click="showTaskPanel = !showTaskPanel"
+            >{{ showTaskPanel ? '−' : '▸' }}</button>
+          </div>
         </div>
         <ScrollArea v-if="showTaskPanel" class="flex-1 min-h-0">
           <div v-if="tasksLoading" class="px-3 py-4 text-xs text-muted-foreground text-center">Loading…</div>
@@ -654,6 +675,15 @@ watch(composeRecipient, async (agent) => {
         </ScrollArea>
       </aside>
     </div>
+
+    <!-- New Task dialog (pre-filled with conversation partner) -->
+    <NewTaskDialog
+      v-if="composeRecipient"
+      v-model:open="newTaskDialogOpen"
+      :space="space"
+      :initial-assignee="composeRecipient"
+      @created="agentTasks = []"
+    />
 
     <!-- Agent detail slideover -->
     <Transition

--- a/frontend/src/components/NewTaskDialog.vue
+++ b/frontend/src/components/NewTaskDialog.vue
@@ -26,6 +26,7 @@ import AgentAvatar from './AgentAvatar.vue'
 const props = defineProps<{
   open: boolean
   space: KnowledgeSpace
+  initialAssignee?: string
 }>()
 
 const emit = defineEmits<{
@@ -36,14 +37,14 @@ const emit = defineEmits<{
 const title = ref('')
 const description = ref('')
 const priority = ref<TaskPriority>('medium')
-const assignedTo = ref('')
+const assignedTo = ref(props.initialAssignee ?? '')
 const submitting = ref(false)
 
 function reset() {
   title.value = ''
   description.value = ''
   priority.value = 'medium'
-  assignedTo.value = ''
+  assignedTo.value = props.initialAssignee ?? ''
 }
 
 async function submit() {

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { KnowledgeSpace, TmuxAgentStatus, HierarchyTree } from '@/types'
 import { ref, computed, nextTick, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { useTime } from '@/composables/useTime'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -102,13 +103,20 @@ function openMessageDialog(name: string) {
 function sendQuickMessage() {
   const text = messageText.value.trim()
   if (!text || !messageDialogAgent.value) return
-  emit('send-message-to-agent', messageDialogAgent.value, text)
+  const targetAgent = messageDialogAgent.value
+  emit('send-message-to-agent', targetAgent, text)
   messageDialogOpen.value = false
   messageDialogAgent.value = null
   messageText.value = ''
+  // Navigate to the conversation thread after sending
+  router.push({
+    name: 'conversation',
+    params: { space: props.space.name, conversationAgent: targetAgent },
+  })
 }
 
 const { relativeTime, formatFullDate, freshness } = useTime()
+const router = useRouter()
 
 function handleCardKeydown(e: KeyboardEvent, name: string) {
   const tag = (e.target as HTMLElement)?.tagName

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -7,6 +7,7 @@ import {
   TASK_STATUS_COLUMNS,
 } from '@/types'
 import { ref, watch, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { api } from '@/api/client'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
@@ -35,6 +36,7 @@ const emit = defineEmits<{
   'task-deleted': [id: string]
 }>()
 
+const router = useRouter()
 const commentText = ref('')
 const submittingComment = ref(false)
 const saving = ref(false)
@@ -207,12 +209,20 @@ async function deleteTask() {
             <!-- Assignee -->
             <div class="flex flex-col gap-1">
               <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Assignee</span>
+              <div class="flex items-center gap-1">
+                <button
+                  v-if="task.assigned_to"
+                  class="flex items-center gap-1 text-xs text-primary hover:underline"
+                  :title="`View ${task.assigned_to} details`"
+                  @click="router.push(`/${encodeURIComponent(space.name)}/${encodeURIComponent(task.assigned_to)}`)"
+                >
+                  <AgentAvatar :name="task.assigned_to" :size="14" />
+                  {{ task.assigned_to }}
+                </button>
               <DropdownMenu>
                 <DropdownMenuTrigger as-child>
                   <Button variant="outline" size="sm" class="h-7 gap-1 text-xs" :disabled="saving">
-                    <AgentAvatar v-if="task.assigned_to" :name="task.assigned_to" :size="14" />
-                    <span v-if="task.assigned_to">{{ task.assigned_to }}</span>
-                    <span v-else class="text-muted-foreground">Unassigned</span>
+                    <span v-if="!task.assigned_to" class="text-muted-foreground">Unassigned</span>
                     <ChevronDown class="size-3" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -231,6 +241,7 @@ async function deleteTask() {
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

Implements TASK-006 (Frontend User Journey Polish) and TASK-008 (Boss Identity UX) fixes.

### TASK-006: User Journey Fixes
- **AgentDetail conversations button** now routes to the agent-specific thread (`/{space}/conversations/{agentName}`) instead of the generic conversations page
- **AppSidebar**: Added Conversations nav item below Tasks for direct sidebar access
- **ConversationsView task widget**: Added `+` button in task panel header — opens NewTaskDialog pre-filled with the conversation partner as assignee (fixes the user story break where you can see tasks but can't add one)
- **NewTaskDialog**: Added `initialAssignee` prop for pre-filling the assignee field
- **AgentDetail task widget**: New collapsible section showing all tasks assigned to the agent (fetched on mount and agent change)
- **ConversationsView**: Added note explaining compose box is only available in boss↔agent threads

### TASK-008: Boss Identity UX Fixes
- **AgentDetail Messages header**: Renamed to "Boss ↔ {agentName} Messages" with tooltip explaining it's the direct boss channel
- **AgentProfileCard**: Special rendering for `boss` — crown icon, "Human Operator" badge, description; prevents null crash when boss card is triggered
- **AppSidebar**: Boss identity label (Crown icon + "You (Boss)") added to sidebar header
- **TaskDetailPanel**: Assignee name is now clickable, navigates to the agent detail page
- **SpaceOverview**: After quick-message send, automatically navigates to the conversation thread

## Test plan
- [ ] Build passes: `cd frontend && npm run build` ✅
- [ ] AgentDetail → Conversations button opens the agent-specific thread
- [ ] ConversationsView task `+` button opens NewTaskDialog pre-filled with agent
- [ ] AppSidebar shows Conversations nav item
- [ ] AgentDetail shows task widget with agent's tasks
- [ ] Hovering "boss" in any AgentProfileCard shows crown card, not crash
- [ ] AppSidebar header shows crown + "You (Boss)" identity indicator
- [ ] TaskDetailPanel assignee name is clickable link to agent detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)