### PR TITLE
feat(hierarchy): TASK-009 — parent propagation via spawn and ignition

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -571,25 +571,56 @@ func (s *Server) handleIgnition(w http.ResponseWriter, r *http.Request, spaceNam
 	}
 
 	tmuxSession := r.URL.Query().Get("tmux_session")
+	parentParam := r.URL.Query().Get("parent")
+	roleParam := r.URL.Query().Get("role")
 
-	if tmuxSession != "" {
+	if tmuxSession != "" || parentParam != "" || roleParam != "" {
 		s.mu.Lock()
 		ks := s.getOrCreateSpaceLocked(spaceName)
 		canonical := resolveAgentName(ks, agentName)
-		if existing, ok := ks.Agents[canonical]; ok {
-			existing.TmuxSession = tmuxSession
-		} else {
-			ks.Agents[canonical] = &AgentUpdate{
-				Status:      StatusIdle,
-				Summary:     canonical + ": awaiting ignition",
-				TmuxSession: tmuxSession,
-				UpdatedAt:   time.Now().UTC(),
+
+		// Validate parent param before making any changes.
+		if parentParam != "" {
+			if strings.EqualFold(parentParam, agentName) || strings.EqualFold(parentParam, canonical) {
+				s.mu.Unlock()
+				writeJSONError(w, "self-parent not allowed", http.StatusBadRequest)
+				return
 			}
+			if hasCycle(ks, canonical, parentParam) {
+				s.mu.Unlock()
+				writeJSONError(w, "parent would create a cycle", http.StatusBadRequest)
+				return
+			}
+		}
+
+		var agentRecord *AgentUpdate
+		if existing, ok := ks.Agents[canonical]; ok {
+			agentRecord = existing
+		} else {
+			agentRecord = &AgentUpdate{
+				Status:    StatusIdle,
+				Summary:   canonical + ": awaiting ignition",
+				UpdatedAt: time.Now().UTC(),
+			}
+			ks.Agents[canonical] = agentRecord
+		}
+		if tmuxSession != "" {
+			agentRecord.TmuxSession = tmuxSession
+		}
+		// Set Parent and Role only if not already set (sticky).
+		if parentParam != "" && agentRecord.Parent == "" {
+			agentRecord.Parent = resolveAgentName(ks, parentParam)
+			rebuildChildren(ks)
+		}
+		if roleParam != "" && agentRecord.Role == "" {
+			agentRecord.Role = roleParam
 		}
 		ks.UpdatedAt = time.Now().UTC()
 		s.saveSpace(ks)
 		s.mu.Unlock()
-		s.logEvent(fmt.Sprintf("[%s/%s] tmux session registered via ignition: %s", spaceName, agentName, tmuxSession))
+		if tmuxSession != "" {
+			s.logEvent(fmt.Sprintf("[%s/%s] tmux session registered via ignition: %s", spaceName, agentName, tmuxSession))
+		}
 	}
 
 	s.mu.RLock()
@@ -733,6 +764,12 @@ func (s *Server) handleIgnition(w http.ResponseWriter, r *http.Request, spaceNam
 	b.WriteString("    \"status\": \"active\",\n")
 	b.WriteString(fmt.Sprintf("    \"summary\": \"%s: working on ...\",\n", agentName))
 	b.WriteString("    \"branch\": \"feat/...\",\n")
+	if hasExisting && existing.Parent != "" {
+		b.WriteString(fmt.Sprintf("    \"parent\": \"%s\",\n", existing.Parent))
+		if existing.Role != "" {
+			b.WriteString(fmt.Sprintf("    \"role\": \"%s\",\n", existing.Role))
+		}
+	}
 	b.WriteString("    \"items\": [\"...\"]\n")
 	b.WriteString("  }'\n")
 	b.WriteString("```\n")

--- a/internal/coordinator/hierarchy_test.go
+++ b/internal/coordinator/hierarchy_test.go
@@ -1,0 +1,413 @@
+package coordinator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// postSpawn posts to /spaces/{space}/agent/{agent}/spawn with given headers and body.
+func postSpawn(t *testing.T, base, space, agentName string, body map[string]interface{}, spawnerName string) *http.Response {
+	t.Helper()
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequest(http.MethodPost,
+		base+"/spaces/"+space+"/agent/"+agentName+"/spawn",
+		bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("new spawn request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if spawnerName != "" {
+		req.Header.Set("X-Agent-Name", spawnerName)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST spawn: %v", err)
+	}
+	return resp
+}
+
+// killTmuxSession cleans up a tmux session if it exists.
+func killTmuxSession(session string) {
+	exec.Command("tmux", "kill-session", "-t", session).Run() //nolint:errcheck
+}
+
+// tmuxServerRunning returns true if a tmux server is reachable.
+func tmuxServerRunning() bool {
+	err := exec.Command("tmux", "list-sessions").Run()
+	return err == nil
+}
+
+// requireTmux skips the test if tmux is unavailable or no server is running.
+func requireTmux(t *testing.T) {
+	t.Helper()
+	if !tmuxAvailable() {
+		t.Skip("tmux binary not found")
+	}
+	if !tmuxServerRunning() {
+		t.Skip("no tmux server running")
+	}
+}
+
+// TestSpawnSetsParentFromSpawner verifies that when an agent spawns a child via
+// POST /agent/{child}/spawn with X-Agent-Name: {spawner}, the child's Parent is
+// set to the canonical spawner name.
+func TestSpawnSetsParentFromSpawner(t *testing.T) {
+	requireTmux(t)
+
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestSpawnParent"
+
+	// Register the spawner agent first.
+	postJSON(t, base+"/spaces/"+space+"/agent/Manager", map[string]interface{}{
+		"status":  "active",
+		"summary": "Manager: active",
+	})
+
+	session := fmt.Sprintf("test-spawn-parent-%s", srv.Port()[1:])
+	defer killTmuxSession(session)
+
+	resp := postSpawn(t, base, space, "Worker", map[string]interface{}{
+		"tmux_session": session,
+		"command":      "sleep 30",
+	}, "Manager")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("spawn: expected 202, got %d: %s", resp.StatusCode, body)
+	}
+
+	srv.mu.RLock()
+	ks := srv.spaces[space]
+	workerCanonical := resolveAgentName(ks, "Worker")
+	worker := ks.Agents[workerCanonical]
+	srv.mu.RUnlock()
+
+	if worker == nil {
+		t.Fatal("Worker agent record not found after spawn")
+	}
+	if worker.Parent == "" {
+		t.Error("expected Worker.Parent to be set to manager's canonical name")
+	}
+	// Parent must not equal the agent itself.
+	if strings.EqualFold(worker.Parent, workerCanonical) {
+		t.Errorf("Worker.Parent must not be the agent itself, got %q", worker.Parent)
+	}
+}
+
+// TestSpawnNoSpawnerNoParent verifies that spawning without X-Agent-Name does not
+// set a parent on the spawned agent.
+func TestSpawnNoSpawnerNoParent(t *testing.T) {
+	requireTmux(t)
+
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestSpawnNoParent"
+
+	session := fmt.Sprintf("test-spawn-no-parent-%s", srv.Port()[1:])
+	defer killTmuxSession(session)
+
+	// Spawn without X-Agent-Name header (spawnerName = "").
+	resp := postSpawn(t, base, space, "Orphan", map[string]interface{}{
+		"tmux_session": session,
+		"command":      "sleep 30",
+	}, "")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("spawn: expected 202, got %d: %s", resp.StatusCode, body)
+	}
+
+	srv.mu.RLock()
+	ks := srv.spaces[space]
+	orphanCanonical := resolveAgentName(ks, "Orphan")
+	orphan := ks.Agents[orphanCanonical]
+	srv.mu.RUnlock()
+
+	if orphan == nil {
+		t.Fatal("Orphan agent record not found after spawn")
+	}
+	if orphan.Parent != "" {
+		t.Errorf("expected Orphan.Parent to be empty, got %q", orphan.Parent)
+	}
+}
+
+// TestSpawnSelfSpawnNoParent verifies that when X-Agent-Name equals the spawned
+// agent's name, Parent is NOT set (no self-parent).
+func TestSpawnSelfSpawnNoParent(t *testing.T) {
+	requireTmux(t)
+
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestSpawnSelf"
+
+	session := fmt.Sprintf("test-spawn-self-%s", srv.Port()[1:])
+	defer killTmuxSession(session)
+
+	// X-Agent-Name == agentName → self-spawn, no parent should be set.
+	resp := postSpawn(t, base, space, "Solo", map[string]interface{}{
+		"tmux_session": session,
+		"command":      "sleep 30",
+	}, "Solo")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("spawn: expected 202, got %d: %s", resp.StatusCode, body)
+	}
+
+	srv.mu.RLock()
+	ks := srv.spaces[space]
+	canonical := resolveAgentName(ks, "Solo")
+	solo := ks.Agents[canonical]
+	srv.mu.RUnlock()
+
+	if solo == nil {
+		t.Fatal("Solo agent not found after spawn")
+	}
+	if solo.Parent != "" {
+		t.Errorf("expected Solo.Parent to be empty (self-spawn), got %q", solo.Parent)
+	}
+}
+
+// TestIgnitionWithParentParam verifies that GET /ignition?tmux_session=X&parent=Y&role=Z
+// sets the agent's Parent and Role fields.
+func TestIgnitionWithParentParam(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestIgnitionParent"
+
+	// Register the parent agent first.
+	postJSON(t, base+"/spaces/"+space+"/agent/Boss", map[string]interface{}{
+		"status":  "active",
+		"summary": "Boss: active",
+	})
+
+	// Call ignition with ?parent=Boss&role=Worker.
+	url := base + "/spaces/" + space + "/ignition/Worker?tmux_session=fake-session&parent=Boss&role=Developer"
+	code, body := getBody(t, url)
+	if code != http.StatusOK {
+		t.Fatalf("ignition: expected 200, got %d: %s", code, body)
+	}
+
+	srv.mu.RLock()
+	ks := srv.spaces[space]
+	canonical := resolveAgentName(ks, "Worker")
+	worker := ks.Agents[canonical]
+	srv.mu.RUnlock()
+
+	if worker == nil {
+		t.Fatal("Worker not found after ignition")
+	}
+	if worker.Parent == "" {
+		t.Error("expected Worker.Parent to be set after ignition with ?parent=Boss")
+	}
+	if worker.Role == "" {
+		t.Error("expected Worker.Role to be set after ignition with ?role=Developer")
+	}
+}
+
+// TestIgnitionParentStickyNotOverwritten verifies that calling ignition with
+// ?parent=NewParent does not overwrite an already-set Parent.
+func TestIgnitionParentStickyNotOverwritten(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestIgnitionSticky"
+
+	// Register parent agents.
+	for _, name := range []string{"OriginalParent", "NewParent", "Child"} {
+		postJSON(t, base+"/spaces/"+space+"/agent/"+name, map[string]interface{}{
+			"status":  "active",
+			"summary": name + ": active",
+		})
+	}
+
+	// Set Child's parent to OriginalParent via ignition.
+	url1 := base + "/spaces/" + space + "/ignition/Child?tmux_session=s1&parent=OriginalParent"
+	code, body := getBody(t, url1)
+	if code != http.StatusOK {
+		t.Fatalf("ignition 1: expected 200, got %d: %s", code, body)
+	}
+
+	// Try to overwrite parent to NewParent via second ignition call.
+	url2 := base + "/spaces/" + space + "/ignition/Child?tmux_session=s2&parent=NewParent"
+	code, body = getBody(t, url2)
+	if code != http.StatusOK {
+		t.Fatalf("ignition 2: expected 200, got %d: %s", code, body)
+	}
+
+	srv.mu.RLock()
+	ks := srv.spaces[space]
+	canonical := resolveAgentName(ks, "Child")
+	child := ks.Agents[canonical]
+	srv.mu.RUnlock()
+
+	if child == nil {
+		t.Fatal("Child not found")
+	}
+	// Parent must remain OriginalParent (sticky).
+	originalCanonical := resolveAgentName(ks, "OriginalParent")
+	if child.Parent != originalCanonical {
+		t.Errorf("expected sticky Parent=%q, got %q", originalCanonical, child.Parent)
+	}
+}
+
+// TestIgnitionSelfParentRejected verifies that calling ignition with ?parent equal
+// to the agent's own name returns 400.
+func TestIgnitionSelfParentRejected(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestIgnitionSelfParent"
+
+	url := base + "/spaces/" + space + "/ignition/Agent1?tmux_session=s1&parent=Agent1"
+	code, body := getBody(t, url)
+	if code != http.StatusBadRequest {
+		t.Errorf("expected 400 for self-parent, got %d: %s", code, body)
+	}
+}
+
+// TestIgnitionParentCycleRejected verifies that calling ignition with ?parent that
+// would create a cycle returns 400.
+func TestIgnitionParentCycleRejected(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestIgnitionCycle"
+
+	// Register Alpha and Beta.
+	postJSON(t, base+"/spaces/"+space+"/agent/Alpha", map[string]interface{}{
+		"status":  "active",
+		"summary": "Alpha: active",
+	})
+	postJSON(t, base+"/spaces/"+space+"/agent/Beta", map[string]interface{}{
+		"status":  "active",
+		"summary": "Beta: active",
+	})
+
+	// Set Alpha's parent = Beta via ignition (no cycle yet).
+	url1 := base + "/spaces/" + space + "/ignition/Alpha?tmux_session=s1&parent=Beta"
+	code, body := getBody(t, url1)
+	if code != http.StatusOK {
+		t.Fatalf("first ignition: expected 200, got %d: %s", code, body)
+	}
+
+	// Now try to set Beta's parent = Alpha → creates cycle Alpha→Beta→Alpha.
+	url2 := base + "/spaces/" + space + "/ignition/Beta?tmux_session=s2&parent=Alpha"
+	code, body = getBody(t, url2)
+	if code != http.StatusBadRequest {
+		t.Errorf("expected 400 for cycle-creating parent, got %d: %s", code, body)
+	}
+}
+
+// TestIgnitionPostTemplateIncludesParent verifies that when an agent has a Parent set,
+// the ignition response's POST template JSON includes the parent and role fields.
+func TestIgnitionPostTemplateIncludesParent(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestIgnitionTemplate"
+
+	// Register parent agent.
+	postJSON(t, base+"/spaces/"+space+"/agent/Boss", map[string]interface{}{
+		"status":  "active",
+		"summary": "Boss: active",
+	})
+
+	// Ignite Worker with parent=Boss and role=Developer.
+	url := base + "/spaces/" + space + "/ignition/Worker?tmux_session=s1&parent=Boss&role=Developer"
+	code, body := getBody(t, url)
+	if code != http.StatusOK {
+		t.Fatalf("ignition: expected 200, got %d: %s", code, body)
+	}
+
+	// The POST template section must include "parent" field.
+	if !strings.Contains(body, `"parent"`) {
+		t.Errorf("ignition response missing \"parent\" field in POST template; body snippet: %s",
+			truncate(body, 500))
+	}
+	// The POST template must include "role" field.
+	if !strings.Contains(body, `"role"`) {
+		t.Errorf("ignition response missing \"role\" field in POST template; body snippet: %s",
+			truncate(body, 500))
+	}
+}
+
+// TestSpawnParentPropagatedToIgnition verifies the end-to-end: after spawn sets
+// Parent (via X-Agent-Name), a subsequent ignition call reflects that parent
+// in the "Your Last State" section.
+func TestSpawnParentPropagatedToIgnition(t *testing.T) {
+	requireTmux(t)
+
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "TestSpawnToIgnition"
+
+	// Register spawner.
+	postJSON(t, base+"/spaces/"+space+"/agent/Spawner", map[string]interface{}{
+		"status":  "active",
+		"summary": "Spawner: active",
+	})
+
+	session := fmt.Sprintf("test-spawn-ignition-%s", srv.Port()[1:])
+	defer killTmuxSession(session)
+
+	// Spawn Child with X-Agent-Name: Spawner.
+	resp := postSpawn(t, base, space, "Child", map[string]interface{}{
+		"tmux_session": session,
+		"command":      "sleep 30",
+	}, "Spawner")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("spawn: expected 202, got %d: %s", resp.StatusCode, body)
+	}
+
+	// Verify parent was set on agent.
+	srv.mu.RLock()
+	ks := srv.spaces[space]
+	childCanonical := resolveAgentName(ks, "Child")
+	child := ks.Agents[childCanonical]
+	srv.mu.RUnlock()
+
+	if child == nil {
+		t.Fatal("Child agent not found after spawn")
+	}
+	if child.Parent == "" {
+		t.Fatal("Child.Parent not set after spawn — cannot verify ignition propagation")
+	}
+
+	// Now call ignition for Child and verify parent appears in the response.
+	ignitionURL := base + "/spaces/" + space + "/ignition/Child"
+	code, body := getBody(t, ignitionURL)
+	if code != http.StatusOK {
+		t.Fatalf("ignition: expected 200, got %d: %s", code, body)
+	}
+	if !strings.Contains(body, child.Parent) {
+		t.Errorf("ignition response does not mention parent %q; got: %s",
+			child.Parent, truncate(body, 300))
+	}
+}
+
+// truncate returns at most n characters of s for safe error messages.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -148,6 +148,15 @@ func (s *Server) handleAgentSpawn(w http.ResponseWriter, r *http.Request, spaceN
 		ks.Agents[agentName] = agent
 	}
 	agent.TmuxSession = sessionName
+
+	// Set Parent from the spawner's identity (X-Agent-Name header), if not already set.
+	// Guard: skip if spawner == agentName to prevent self-parenting.
+	spawnerName := r.Header.Get("X-Agent-Name")
+	if spawnerName != "" && !strings.EqualFold(spawnerName, agentName) && agent.Parent == "" {
+		agent.Parent = resolveAgentName(ks, spawnerName)
+		rebuildChildren(ks)
+	}
+
 	if err := s.saveSpace(ks); err != nil {
 		s.mu.Unlock()
 		s.logEvent(fmt.Sprintf("[%s/%s] spawn: save failed: %v", spaceName, agentName, err))


### PR DESCRIPTION
## Summary

Implements TASK-009 three-part hierarchy reliability fix:

- **Part A (lifecycle.go)**: `handleAgentSpawn` reads `X-Agent-Name` header as the spawner; sets `agent.Parent = spawner` (canonical) if not already set; guards against self-parenting; calls `rebuildChildren` inside `mu.Lock` before `saveSpace`.

- **Part B (server.go)**: `handleIgnition` reads `?parent=` and `?role=` query params; validates self-parent (→ 400) and cycle detection (→ 400); sets `Parent`/`Role` with sticky semantics (no overwrite); calls `rebuildChildren`; POST template includes `parent`/`role` fields when agent has a parent set.

- **Part C (commands/boss.ignite.md)**: Documents the optional `?parent=PARENT_NAME&role=ROLE` params in Step 2.

## Test plan

9 new tests in `hierarchy_test.go`:

- [ ] `TestSpawnSetsParentFromSpawner` — spawn sets Parent from X-Agent-Name header
- [ ] `TestSpawnNoSpawnerNoParent` — spawn without header leaves Parent empty
- [ ] `TestSpawnSelfSpawnNoParent` — X-Agent-Name == agentName → no self-parent
- [ ] `TestIgnitionWithParentParam` — ?parent= and ?role= set agent fields
- [ ] `TestIgnitionParentStickyNotOverwritten` — existing parent not overwritten
- [ ] `TestIgnitionSelfParentRejected` — self-parent → 400
- [ ] `TestIgnitionParentCycleRejected` — cycle-creating parent → 400
- [ ] `TestIgnitionPostTemplateIncludesParent` — template includes parent/role when set
- [ ] `TestSpawnParentPropagatedToIgnition` — spawn parent shows in ignition response

All 9 pass. Full suite green (race detector enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)