### PR TITLE
feat(task-013): task improvements — subtasks, PR links, live kanban, event history

### DIFF
--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -70,14 +70,16 @@ const statusHeaderClass: Record<TaskStatus, string> = {
 
     <!-- Cards -->
     <div class="flex flex-col gap-2 p-2 flex-1 min-h-24 overflow-y-auto">
-      <TaskCard
-        v-for="task in tasks"
-        :key="task.id"
-        :task="task"
-        :dragging="draggingTaskId === task.id"
-        @click="emit('task-click', task)"
-        @dragstart="onDragStart"
-      />
+      <TransitionGroup name="kanban-card" tag="div" class="flex flex-col gap-2">
+        <TaskCard
+          v-for="task in tasks"
+          :key="task.id"
+          :task="task"
+          :dragging="draggingTaskId === task.id"
+          @click="emit('task-click', task)"
+          @dragstart="onDragStart"
+        />
+      </TransitionGroup>
       <div
         v-if="tasks.length === 0"
         class="flex-1 flex items-center justify-center text-[11px] text-muted-foreground py-6"
@@ -87,3 +89,21 @@ const statusHeaderClass: Record<TaskStatus, string> = {
     </div>
   </div>
 </template>
+
+<style scoped>
+.kanban-card-enter-active,
+.kanban-card-leave-active {
+  transition: all 0.25s ease;
+}
+.kanban-card-enter-from {
+  opacity: 0;
+  transform: translateY(-8px) scale(0.97);
+}
+.kanban-card-leave-to {
+  opacity: 0;
+  transform: translateY(8px) scale(0.97);
+}
+.kanban-card-move {
+  transition: transform 0.3s ease;
+}
+</style>

--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { Task, TaskStatus, KnowledgeSpace } from '@/types'
 import { TASK_STATUS_COLUMNS } from '@/types'
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { api } from '@/api/client'
+import { useSSE } from '@/composables/useSSE'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -141,9 +142,54 @@ function openTaskById(id: string) {
   }
 }
 
-// ── SSE integration (listen for task_updated events) ───────────────
-// The parent App.vue manages the SSE stream; we watch for space changes
-// and refresh. Full SSE integration would be wired through a composable.
+// ── SSE integration: auto-reload on task_updated events ────────────
+const sse = useSSE()
+let sseReloadTimer: ReturnType<typeof setTimeout> | null = null
+
+// Debounce SSE-triggered reloads to batch rapid bursts.
+function scheduleSSEReload() {
+  if (sseReloadTimer !== null) return
+  sseReloadTimer = setTimeout(async () => {
+    sseReloadTimer = null
+    const fresh = await api.fetchTasks(props.space.name).catch(() => null)
+    if (fresh === null) return
+    // Merge fresh data: update status in place so TransitionGroup animates moves.
+    for (const t of fresh) {
+      const idx = tasks.value.findIndex(x => x.id === t.id)
+      if (idx >= 0) {
+        Object.assign(tasks.value[idx] as object, t)
+      } else {
+        tasks.value.push(t)
+      }
+    }
+    // Remove tasks that are no longer present.
+    const freshIds = new Set(fresh.map(t => t.id))
+    tasks.value = tasks.value.filter(t => freshIds.has(t.id))
+    // Keep selected task in sync.
+    if (selectedTask.value) {
+      const updated = tasks.value.find(t => t.id === selectedTask.value!.id)
+      if (updated) selectedTask.value = updated
+    }
+  }, 300)
+}
+
+const unsubTaskUpdated = sse.on('task_updated', (data) => {
+  if (data.space !== props.space.name) return
+  if (data.deleted) {
+    tasks.value = tasks.value.filter(t => t.id !== data.id)
+    if (selectedTask.value?.id === data.id) {
+      selectedTask.value = null
+      panelOpen.value = false
+    }
+    return
+  }
+  scheduleSSEReload()
+})
+
+onUnmounted(() => {
+  unsubTaskUpdated()
+  if (sseReloadTimer !== null) clearTimeout(sseReloadTimer)
+})
 </script>
 
 <template>

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Separator } from '@/components/ui/separator'
 import AgentAvatar from './AgentAvatar.vue'
-import { GitBranch, ExternalLink, ChevronDown, Trash2, Send, ChevronsUpDown, ListTree } from 'lucide-vue-next'
+import { GitBranch, ExternalLink, ChevronDown, Trash2, Send, ChevronsUpDown, ListTree, Plus, Clock } from 'lucide-vue-next'
 import { relativeTime } from '@/composables/useTime'
 
 const props = defineProps<{
@@ -44,10 +44,15 @@ const submittingComment = ref(false)
 const saving = ref(false)
 const editingTitle = ref(false)
 const localTitle = ref('')
+const addingSubtask = ref(false)
+const newSubtaskTitle = ref('')
+const submittingSubtask = ref(false)
 
 watch(() => props.task, (t) => {
   if (t) localTitle.value = t.title
   editingTitle.value = false
+  addingSubtask.value = false
+  newSubtaskTitle.value = ''
 })
 
 const agentNames = computed(() => Object.keys(props.space.agents))
@@ -133,6 +138,21 @@ async function deleteTask() {
   await api.deleteTask(props.space.name, props.task.id)
   emit('task-deleted', props.task.id)
   emit('update:open', false)
+}
+
+async function submitSubtask() {
+  if (!props.task || !newSubtaskTitle.value.trim()) return
+  submittingSubtask.value = true
+  try {
+    await api.createSubtask(props.space.name, props.task.id, { title: newSubtaskTitle.value.trim() })
+    newSubtaskTitle.value = ''
+    addingSubtask.value = false
+    // Reload the parent task to get updated subtask list.
+    const updated = await api.fetchTask(props.space.name, props.task.id)
+    emit('task-updated', updated)
+  } finally {
+    submittingSubtask.value = false
+  }
 }
 </script>
 
@@ -315,12 +335,42 @@ async function deleteTask() {
           </div>
 
           <!-- Subtasks -->
-          <div v-if="task.subtasks && task.subtasks.length" class="flex flex-col gap-1.5">
-            <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-1">
-              <ListTree class="size-3" />
-              Subtasks ({{ task.subtasks.length }})
-            </span>
-            <div class="flex flex-col gap-1">
+          <div class="flex flex-col gap-1.5">
+            <div class="flex items-center justify-between">
+              <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-1">
+                <ListTree class="size-3" />
+                Subtasks ({{ task.subtasks?.length ?? 0 }})
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-5 px-1.5 text-[10px] gap-0.5"
+                @click="addingSubtask = !addingSubtask"
+              >
+                <Plus class="size-3" />
+                Add
+              </Button>
+            </div>
+            <!-- Add subtask inline form -->
+            <div v-if="addingSubtask" class="flex gap-2 mt-0.5">
+              <input
+                v-model="newSubtaskTitle"
+                placeholder="Subtask title…"
+                class="flex-1 text-sm bg-transparent border border-border rounded px-2 py-1 outline-none focus:border-primary"
+                autofocus
+                @keydown.enter="submitSubtask"
+                @keydown.escape="addingSubtask = false; newSubtaskTitle = ''"
+              />
+              <Button
+                size="sm"
+                class="h-7 text-xs shrink-0"
+                :disabled="!newSubtaskTitle.trim() || submittingSubtask"
+                @click="submitSubtask"
+              >
+                <Send class="size-3" />
+              </Button>
+            </div>
+            <div v-if="task.subtasks && task.subtasks.length" class="flex flex-col gap-1">
               <button
                 v-for="sub in subtaskItems"
                 :key="sub.id"
@@ -342,6 +392,7 @@ async function deleteTask() {
                 <span class="text-xs italic">loading…</span>
               </div>
             </div>
+            <div v-else-if="!addingSubtask" class="text-xs text-muted-foreground">No subtasks yet</div>
           </div>
 
           <Separator />
@@ -385,6 +436,28 @@ async function deleteTask() {
               >
                 <Send class="size-3.5" />
               </Button>
+            </div>
+          </div>
+
+          <!-- Event History -->
+          <div v-if="task.events && task.events.length" class="flex flex-col gap-2">
+            <Separator />
+            <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide flex items-center gap-1">
+              <Clock class="size-3" />
+              Activity
+            </span>
+            <div class="flex flex-col gap-1.5">
+              <div
+                v-for="event in [...(task.events ?? [])].reverse()"
+                :key="event.id"
+                class="flex items-start gap-2 text-xs"
+              >
+                <AgentAvatar :name="event.by" :size="16" class="shrink-0 mt-0.5" />
+                <div class="flex flex-col gap-0.5 min-w-0">
+                  <span class="text-foreground/80">{{ event.detail }}</span>
+                  <span class="text-[10px] text-muted-foreground">{{ relativeTime(event.created_at) }}</span>
+                </div>
+              </div>
             </div>
           </div>
 

--- a/frontend/src/composables/useSSE.ts
+++ b/frontend/src/composables/useSSE.ts
@@ -5,6 +5,7 @@ import type {
   SSEAgentMessage,
   SSETmuxLiveness,
   SSEBroadcastProgress,
+  SSETaskUpdated,
 } from '@/types'
 
 // All SSE event types emitted by the Go backend
@@ -16,6 +17,7 @@ export type SSEEventType =
   | 'tmux_liveness'
   | 'broadcast_complete'
   | 'broadcast_progress'
+  | 'task_updated'
 
 export type SSEEventMap = {
   agent_updated: SSEAgentUpdated
@@ -25,6 +27,7 @@ export type SSEEventMap = {
   tmux_liveness: SSETmuxLiveness[]
   broadcast_complete: unknown
   broadcast_progress: SSEBroadcastProgress
+  task_updated: SSETaskUpdated
 }
 
 type SSECallback<T extends SSEEventType> = (data: SSEEventMap[T]) => void
@@ -37,17 +40,17 @@ interface SSECallbackEntry {
 const INITIAL_RETRY_MS = 1000
 const MAX_RETRY_MS = 30000
 
+// Module-level singleton — all callers share one EventSource connection.
+const connected: Ref<boolean> = ref(false)
+const error: Ref<string | null> = ref(null)
+let eventSource: EventSource | null = null
+let retryMs = INITIAL_RETRY_MS
+let retryTimer: ReturnType<typeof setTimeout> | null = null
+let currentSpace: string | undefined
+let intentionalClose = false
+const callbacks: SSECallbackEntry[] = []
+
 export function useSSE() {
-  const connected: Ref<boolean> = ref(false)
-  const error: Ref<string | null> = ref(null)
-
-  let eventSource: EventSource | null = null
-  let retryMs = INITIAL_RETRY_MS
-  let retryTimer: ReturnType<typeof setTimeout> | null = null
-  let currentSpace: string | undefined
-  let intentionalClose = false
-
-  const callbacks: SSECallbackEntry[] = []
 
   function on<T extends SSEEventType>(type: T, cb: SSECallback<T>): () => void {
     const entry: SSECallbackEntry = {
@@ -98,6 +101,7 @@ export function useSSE() {
       'tmux_liveness',
       'broadcast_complete',
       'broadcast_progress',
+      'task_updated',
     ]
 
     for (const type of eventTypes) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -166,6 +166,14 @@ export interface TaskComment {
   created_at: string
 }
 
+export interface TaskEvent {
+  id: string
+  type: string   // "created" | "moved" | "assigned" | "commented" | "updated"
+  by: string
+  detail: string
+  created_at: string
+}
+
 export interface Task {
   id: string
   space: string
@@ -184,6 +192,7 @@ export interface Task {
   updated_at: string
   due_at?: string
   comments?: TaskComment[]
+  events?: TaskEvent[]
 }
 
 export const TASK_STATUS_COLUMNS: TaskStatus[] = ['backlog', 'in_progress', 'review', 'blocked', 'done']
@@ -221,6 +230,15 @@ export interface SSEAgentUpdated {
 export interface SSEAgentRemoved {
   space: string
   agent: string
+}
+
+export interface SSETaskUpdated {
+  id: string
+  space: string
+  status?: string
+  title?: string
+  assigned_to?: string
+  deleted?: boolean
 }
 
 export interface SSEAgentMessage {

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -159,6 +159,19 @@ func (s *Server) handleSpaceAgent(w http.ResponseWriter, r *http.Request, spaceN
 		if parentChanged {
 			rebuildChildren(ks)
 		}
+		// Auto-link PR: when an agent posts with a pr field, set linked_pr on all
+		// tasks assigned to that agent that don't already have a linked_pr.
+		if update.PR != "" && ks.Tasks != nil {
+			now := time.Now().UTC()
+			for _, task := range ks.Tasks {
+				if strings.EqualFold(task.AssignedTo, canonical) && task.LinkedPR == "" {
+					task.LinkedPR = update.PR
+					task.UpdatedAt = now
+					appendTaskEvent(task, "updated", canonical,
+						fmt.Sprintf("PR linked: %s", update.PR), now)
+				}
+			}
+		}
 		if err := s.saveSpace(ks); err != nil {
 			s.mu.Unlock()
 			writeJSONError(w, fmt.Sprintf("save: %v", err), http.StatusInternalServerError)

--- a/internal/coordinator/handlers_task.go
+++ b/internal/coordinator/handlers_task.go
@@ -9,6 +9,17 @@ import (
 	"time"
 )
 
+// appendTaskEvent adds a TaskEvent to a task's event log (called under s.mu.Lock).
+func appendTaskEvent(task *Task, eventType, by, detail string, now time.Time) {
+	task.Events = append(task.Events, TaskEvent{
+		ID:        fmt.Sprintf("%d", now.UnixNano()),
+		Type:      eventType,
+		By:        by,
+		Detail:    detail,
+		CreatedAt: now,
+	})
+}
+
 func (s *Server) handleSpaceTasks(w http.ResponseWriter, r *http.Request, spaceName, rest string) {
 	if rest == "" {
 		// Collection: POST (create) or GET (list)
@@ -117,6 +128,7 @@ func (s *Server) handleTaskCreate(w http.ResponseWriter, r *http.Request, spaceN
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
+	appendTaskEvent(task, "created", caller, fmt.Sprintf("Task created by %s", caller), now)
 	if ks.Tasks == nil {
 		ks.Tasks = make(map[string]*Task)
 	}
@@ -380,7 +392,10 @@ func (s *Server) handleTaskMove(w http.ResponseWriter, r *http.Request, spaceNam
 	}
 	fromStatus := task.Status
 	task.Status = req.Status
-	task.UpdatedAt = time.Now().UTC()
+	now := time.Now().UTC()
+	task.UpdatedAt = now
+	appendTaskEvent(task, "moved", caller,
+		fmt.Sprintf("Moved from %s to %s by %s", fromStatus, req.Status, caller), now)
 	taskCopy := *task
 	snap := ks.snapshot()
 	s.mu.Unlock()
@@ -430,7 +445,13 @@ func (s *Server) handleTaskAssign(w http.ResponseWriter, r *http.Request, spaceN
 	}
 	fromAgent := task.AssignedTo
 	task.AssignedTo = req.AssignedTo
-	task.UpdatedAt = time.Now().UTC()
+	now := time.Now().UTC()
+	task.UpdatedAt = now
+	detail := fmt.Sprintf("Assigned to %s by %s", req.AssignedTo, caller)
+	if req.AssignedTo == "" {
+		detail = fmt.Sprintf("Unassigned by %s", caller)
+	}
+	appendTaskEvent(task, "assigned", caller, detail, now)
 	taskCopy := *task
 	snap := ks.snapshot()
 	s.mu.Unlock()
@@ -496,6 +517,8 @@ func (s *Server) handleTaskComment(w http.ResponseWriter, r *http.Request, space
 	}
 	task.Comments = append(task.Comments, comment)
 	task.UpdatedAt = now
+	appendTaskEvent(task, "commented", caller,
+		fmt.Sprintf("Comment added by %s", caller), now)
 	taskCopy := *task
 	snap := ks.snapshot()
 	s.mu.Unlock()
@@ -654,6 +677,8 @@ func (s *Server) handleTaskCreateSubtask(w http.ResponseWriter, r *http.Request,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
+	appendTaskEvent(task, "created", caller,
+		fmt.Sprintf("Subtask created under %s by %s", parentID, caller), now)
 	if ks.Tasks == nil {
 		ks.Tasks = make(map[string]*Task)
 	}

--- a/internal/coordinator/types.go
+++ b/internal/coordinator/types.go
@@ -232,6 +232,7 @@ type Task struct {
 
 	// Activity
 	Comments []TaskComment `json:"comments,omitempty"`
+	Events   []TaskEvent   `json:"events,omitempty"`
 }
 
 // TaskComment is a human or agent note on a task.
@@ -239,6 +240,15 @@ type TaskComment struct {
 	ID        string    `json:"id"`
 	Author    string    `json:"author"`
 	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// TaskEvent records a point-in-time change to a task for display in the event history.
+type TaskEvent struct {
+	ID        string    `json:"id"`
+	Type      string    `json:"type"`   // "created", "moved", "assigned", "commented", "updated"
+	By        string    `json:"by"`     // agent name who caused the event
+	Detail    string    `json:"detail"` // human-readable description
 	CreatedAt time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
## Summary

- **First-class subtasks**: Inline "Add subtask" button always visible in TaskDetailPanel (no task needed); keyboard-driven (Enter to submit, Esc to cancel)
- **PR auto-linking**: When an agent posts with `pr` field, `linked_pr` is automatically set on all tasks assigned to that agent that don't yet have a PR link
- **Kanban live auto-update**: Wired SSE `task_updated` events to trigger a debounced (300ms) task reload in KanbanView — board updates without manual refresh
- **Kanban card animations**: TransitionGroup on KanbanColumn cards with slide+fade for entry/exit and smooth move transitions
- **Task event history**: Backend records `TaskEvent` entries on create/move/assign/comment; TaskDetailPanel shows chronological "Activity" log with agent avatar, detail text, and relative timestamp

## Changes

- `internal/coordinator/types.go`: Added `TaskEvent` struct + `Events []TaskEvent` to `Task`
- `internal/coordinator/handlers_task.go`: `appendTaskEvent` helper; events recorded in create/move/assign/comment/subtask handlers
- `internal/coordinator/handlers_agent.go`: Auto-link PR to assigned tasks when agent posts with `pr` field
- `frontend/src/composables/useSSE.ts`: Converted to module-level singleton; added `task_updated` event type
- `frontend/src/types/index.ts`: Added `TaskEvent`, `SSETaskUpdated` types; `events` field on `Task`
- `frontend/src/components/KanbanView.vue`: SSE wiring for live reload + debounced merge
- `frontend/src/components/KanbanColumn.vue`: TransitionGroup animations for card movement
- `frontend/src/components/TaskDetailPanel.vue`: Inline subtask creation + Activity event log

## Test plan

- [x] `go test -race -count=1 -parallel=4 -timeout 30s ./internal/coordinator/` — all pass
- [x] `npm run build` — clean TypeScript + Vite build
- [ ] Manual: Create task, move it, assign it, add comment — verify Activity section shows all events
- [ ] Manual: Agent posts with `pr` field — verify `linked_pr` auto-populated on assigned tasks
- [ ] Manual: Open Kanban while agent moves a task — verify board updates live without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)