### PR TITLE
feat(task-015): optional reason field on task move/assign

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -289,24 +289,24 @@ class ApiClient {
     )
   }
 
-  moveTask(space: string, id: string, status: TaskStatus, actor = 'boss'): Promise<Task> {
+  moveTask(space: string, id: string, status: TaskStatus, actor = 'boss', reason?: string): Promise<Task> {
     return this.request<Task>(
       `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}/move`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
-        body: JSON.stringify({ status }),
+        body: JSON.stringify(reason ? { status, reason } : { status }),
       },
     )
   }
 
-  assignTask(space: string, id: string, assignedTo: string, actor = 'boss'): Promise<Task> {
+  assignTask(space: string, id: string, assignedTo: string, actor = 'boss', reason?: string): Promise<Task> {
     return this.request<Task>(
       `/spaces/${encodeURIComponent(space)}/tasks/${encodeURIComponent(id)}/assign`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Agent-Name': actor },
-        body: JSON.stringify({ assigned_to: assignedTo }),
+        body: JSON.stringify(reason ? { assigned_to: assignedTo, reason } : { assigned_to: assignedTo }),
       },
     )
   }

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -47,12 +47,16 @@ const localTitle = ref('')
 const addingSubtask = ref(false)
 const newSubtaskTitle = ref('')
 const submittingSubtask = ref(false)
+const pendingStatus = ref<TaskStatus | null>(null)
+const pendingReason = ref('')
 
 watch(() => props.task, (t) => {
   if (t) localTitle.value = t.title
   editingTitle.value = false
   addingSubtask.value = false
   newSubtaskTitle.value = ''
+  pendingStatus.value = null
+  pendingReason.value = ''
 })
 
 const agentNames = computed(() => Object.keys(props.space.agents))
@@ -74,15 +78,30 @@ function buildPrUrl(pr: string): string | null {
   return null
 }
 
-async function moveTask(status: TaskStatus) {
-  if (!props.task) return
+function requestMoveTask(status: TaskStatus) {
+  if (!props.task || status === props.task.status) return
+  pendingStatus.value = status
+  pendingReason.value = ''
+}
+
+async function confirmMoveTask() {
+  if (!props.task || !pendingStatus.value) return
   saving.value = true
+  const status = pendingStatus.value
+  const reason = pendingReason.value.trim()
+  pendingStatus.value = null
+  pendingReason.value = ''
   try {
-    const updated = await api.moveTask(props.space.name, props.task.id, status)
+    const updated = await api.moveTask(props.space.name, props.task.id, status, 'boss', reason || undefined)
     emit('task-updated', updated)
   } finally {
     saving.value = false
   }
+}
+
+function cancelMoveTask() {
+  pendingStatus.value = null
+  pendingReason.value = ''
 }
 
 async function setPriority(priority: TaskPriority) {
@@ -198,8 +217,8 @@ async function submitSubtask() {
               <span class="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Status</span>
               <DropdownMenu>
                 <DropdownMenuTrigger as-child>
-                  <Button variant="outline" size="sm" class="h-7 gap-1 text-xs" :disabled="saving">
-                    {{ TASK_STATUS_LABELS[task.status] }}
+                  <Button variant="outline" size="sm" class="h-7 gap-1 text-xs" :disabled="saving || !!pendingStatus">
+                    {{ pendingStatus ? TASK_STATUS_LABELS[pendingStatus] : TASK_STATUS_LABELS[task.status] }}
                     <ChevronDown class="size-3" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -208,12 +227,30 @@ async function submitSubtask() {
                     v-for="s in TASK_STATUS_COLUMNS"
                     :key="s"
                     :class="{ 'font-semibold': s === task.status }"
-                    @click="moveTask(s)"
+                    @click="requestMoveTask(s)"
                   >
                     {{ TASK_STATUS_LABELS[s] }}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+              <!-- Inline reason input shown after selecting a new status -->
+              <div v-if="pendingStatus" class="flex flex-col gap-1.5 mt-1 p-2 bg-muted/40 rounded border border-border">
+                <span class="text-[10px] text-muted-foreground">
+                  Moving to <strong>{{ TASK_STATUS_LABELS[pendingStatus] }}</strong> — reason (optional):
+                </span>
+                <input
+                  v-model="pendingReason"
+                  placeholder="Why is this moving?"
+                  class="text-xs bg-background border border-border rounded px-2 py-1 outline-none focus:border-primary w-full"
+                  autofocus
+                  @keydown.enter="confirmMoveTask"
+                  @keydown.escape="cancelMoveTask"
+                />
+                <div class="flex gap-1.5">
+                  <Button size="sm" class="h-6 text-[10px] px-2" @click="confirmMoveTask">Confirm</Button>
+                  <Button size="sm" variant="ghost" class="h-6 text-[10px] px-2" @click="cancelMoveTask">Cancel</Button>
+                </div>
+              </div>
             </div>
 
             <!-- Priority -->

--- a/internal/coordinator/handlers_task.go
+++ b/internal/coordinator/handlers_task.go
@@ -367,6 +367,7 @@ func (s *Server) handleTaskMove(w http.ResponseWriter, r *http.Request, spaceNam
 
 	var req struct {
 		Status TaskStatus `json:"status"`
+		Reason string     `json:"reason"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
@@ -394,8 +395,11 @@ func (s *Server) handleTaskMove(w http.ResponseWriter, r *http.Request, spaceNam
 	task.Status = req.Status
 	now := time.Now().UTC()
 	task.UpdatedAt = now
-	appendTaskEvent(task, "moved", caller,
-		fmt.Sprintf("Moved from %s to %s by %s", fromStatus, req.Status, caller), now)
+	moveDetail := fmt.Sprintf("Moved from %s to %s by %s", fromStatus, req.Status, caller)
+	if req.Reason != "" {
+		moveDetail += ": " + req.Reason
+	}
+	appendTaskEvent(task, "moved", caller, moveDetail, now)
 	taskCopy := *task
 	snap := ks.snapshot()
 	s.mu.Unlock()
@@ -424,6 +428,7 @@ func (s *Server) handleTaskAssign(w http.ResponseWriter, r *http.Request, spaceN
 
 	var req struct {
 		AssignedTo string `json:"assigned_to"`
+		Reason     string `json:"reason"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
@@ -450,6 +455,9 @@ func (s *Server) handleTaskAssign(w http.ResponseWriter, r *http.Request, spaceN
 	detail := fmt.Sprintf("Assigned to %s by %s", req.AssignedTo, caller)
 	if req.AssignedTo == "" {
 		detail = fmt.Sprintf("Unassigned by %s", caller)
+	}
+	if req.Reason != "" {
+		detail += ": " + req.Reason
 	}
 	appendTaskEvent(task, "assigned", caller, detail, now)
 	taskCopy := *task


### PR DESCRIPTION
## Summary

- **TASK-016 (backend)**: Add optional `reason` string to `POST /tasks/:id/move` and `POST /tasks/:id/assign`. When provided, it is appended to the `TaskEvent` detail (e.g. `Moved from backlog to in_progress by AgentX: Fixed the bug`). Fully backward-compatible — reason defaults to empty.
- **TASK-017 (frontend)**: In `TaskDetailPanel` status dropdown, selecting a new status now shows a small inline reason input (`Why is this moving? (optional)`) with Confirm/Cancel before the API call is made. KanbanView drag-drop passes no reason (no popup). Reason automatically appears in the Activity log.
- `client.ts`: `moveTask()` and `assignTask()` accept an optional `reason` parameter.

## Test plan

- [x] `go test -race -count=1 -parallel=4 -timeout 30s ./internal/coordinator/` passes
- [x] `cd frontend && npm run build` passes
- [ ] Manual: open TaskDetailPanel, change status — confirm reason input appears, reason shows in Activity log
- [ ] Manual: drag task in KanbanView — no reason popup, move works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)