### PR TITLE
feat(ui): UI unification — lifecycle polish, race fix, shared prLink

### DIFF
--- a/commands/boss.ignite.md
+++ b/commands/boss.ignite.md
@@ -53,6 +53,12 @@ curl -s "http://localhost:8899/spaces/Agent%20Boss%20Development/ignition/Protoc
 
 This registers your tmux session with the coordinator (**sticky** — no need to include in POST body) and returns your identity, peer agents, the full protocol, and a POST template.
 
+**Optional hierarchy registration:** append `?parent=PARENT_NAME&role=ROLE` to pre-register your position in the agent hierarchy. `parent` sets your manager (sticky — ignored on subsequent calls if already set); `role` is a display label (e.g. `Developer`, `Manager`, `SME`). Example:
+
+```bash
+curl -s "http://localhost:8899/spaces/SPACE_URL_ENCODED/ignition/AGENT_NAME?tmux_session=YOUR_TMUX_SESSION&parent=ManagerAgent&role=Developer"
+```
+
 ## Step 3: Read the blackboard
 
 ```bash

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vite

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -28,19 +28,11 @@ import AgentMessages from './AgentMessages.vue'
 import AgentAvatar from './AgentAvatar.vue'
 import { relativeTime, formatFullDate } from '@/composables/useTime'
 import { renderMarkdown, renderMarkdownInline, linkTaskRefs } from '@/lib/markdown'
+import { prLink } from '@/lib/utils'
 import { useRouter } from 'vue-router'
 import api from '@/api/client'
 
 const router = useRouter()
-
-function prLink(agent: { pr?: string; repo_url?: string }): string | null {
-  if (!agent.pr) return null
-  if (agent.pr.startsWith('http')) return agent.pr
-  if (!agent.repo_url) return null
-  const repoBase = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
-  const prNum = agent.pr.replace(/^#/, '')
-  return `${repoBase}/pull/${prNum}`
-}
 
 const props = defineProps<{
   agent: AgentUpdate
@@ -243,12 +235,22 @@ async function loadIntrospect() {
   if (introspectLoading.value) return
   introspectLoading.value = true
   introspectError.value = null
+  // Capture agent name at call time to detect stale responses after navigation
+  const capturedAgent = props.agentName
   try {
-    introspectData.value = await api.introspectAgent(props.spaceName, props.agentName)
+    const data = await api.introspectAgent(props.spaceName, capturedAgent)
+    // Discard response if user navigated to a different agent while request was in-flight
+    if (props.agentName === capturedAgent) {
+      introspectData.value = data
+    }
   } catch (e) {
-    introspectError.value = e instanceof Error ? e.message : String(e)
+    if (props.agentName === capturedAgent) {
+      introspectError.value = e instanceof Error ? e.message : String(e)
+    }
   } finally {
-    introspectLoading.value = false
+    if (props.agentName === capturedAgent) {
+      introspectLoading.value = false
+    }
   }
 }
 
@@ -409,115 +411,124 @@ watch(() => props.agentName, loadAgentTasks)
             </template>
           </div>
         </div>
-        <div class="flex items-center gap-2">
+        <!-- Action buttons: two rows for clarity -->
+        <div class="flex flex-col items-end gap-2 shrink-0">
+          <!-- Row 1: Primary actions -->
           <div class="flex items-center gap-1.5">
-            <span class="text-xs text-muted-foreground">Terminal:</span>
             <Tooltip>
               <TooltipTrigger as-child>
-                <Badge variant="outline" :class="tmuxLabelClass" role="status" :aria-label="`Terminal: ${tmuxDisplay.label}`">
-                  {{ tmuxDisplay.label }}
-                </Badge>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  class="h-8 px-3 text-xs gap-1.5"
+                  @click="router.push({ name: 'conversation', params: { space: spaceName, conversationAgent: agentName } })"
+                >
+                  <MessageSquare class="size-3.5" /> Conversations
+                </Button>
               </TooltipTrigger>
-              <TooltipContent>
-                Terminal: {{ tmuxDisplay.label }} — {{ tmuxDisplay.tooltip }}
-              </TooltipContent>
+              <TooltipContent>View conversation thread with {{ agentName }}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button variant="outline" size="sm" class="h-8 px-3 text-xs gap-1.5" @click="emit('broadcast')">
+                  <Bell class="size-3.5" /> Nudge
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Nudge this agent with the latest space state</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  class="h-8 px-3 text-xs gap-1.5 text-muted-foreground/60 hover:text-destructive"
+                  @click="deleteDialogOpen = true"
+                >
+                  <Trash2 class="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Remove this agent from the space</TooltipContent>
             </Tooltip>
           </div>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                variant="outline"
-                size="sm"
-                @click="router.push(`/${encodeURIComponent(spaceName)}/conversations/${encodeURIComponent(agentName)}`)"
-              >
-                <MessageSquare class="size-4" /> Conversations
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              View conversations with {{ agentName }}
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button variant="outline" size="sm" @click="emit('broadcast')">
-                <Bell class="size-4" /> Nudge
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Nudge this agent with the latest space state
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button variant="outline" size="sm" class="text-destructive hover:bg-destructive hover:text-destructive-foreground" @click="deleteDialogOpen = true">
-                <Trash2 class="size-4" /> Delete
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Remove this agent from the space
-            </TooltipContent>
-          </Tooltip>
 
-          <!-- Lifecycle buttons -->
-          <div class="flex items-center gap-1 border border-border rounded-md p-0.5 bg-muted/30">
+          <!-- Row 2: Session / lifecycle controls -->
+          <div class="flex items-center gap-2">
+            <!-- Terminal status -->
             <Tooltip>
               <TooltipTrigger as-child>
-                <Button
-                  variant="ghost" size="sm" class="h-7 px-2 text-xs gap-1"
-                  :disabled="lifecycleLoading !== null"
-                  @click="handleSpawn"
-                >
-                  <Loader2 v-if="lifecycleLoading === 'spawn'" class="size-3 animate-spin" />
-                  <Play v-else class="size-3" />
-                  Spawn
-                </Button>
+                <div class="flex items-center gap-1.5 cursor-default">
+                  <span class="text-[10px] text-muted-foreground uppercase tracking-wide font-medium">Session</span>
+                  <Badge variant="outline" :class="[tmuxLabelClass, 'text-[10px] h-5 px-1.5']" role="status" :aria-label="`Terminal: ${tmuxDisplay.label}`">
+                    {{ tmuxDisplay.label }}
+                  </Badge>
+                </div>
               </TooltipTrigger>
-              <TooltipContent>Create tmux session and launch agent</TooltipContent>
+              <TooltipContent>{{ tmuxDisplay.tooltip }}</TooltipContent>
             </Tooltip>
+
+            <!-- Lifecycle actions grouped -->
+            <div class="flex items-center rounded-md border border-border bg-muted/20 p-0.5 gap-0.5">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    variant="ghost" size="sm" class="h-7 px-2 text-xs gap-1"
+                    :disabled="lifecycleLoading !== null"
+                    @click="handleSpawn"
+                  >
+                    <Loader2 v-if="lifecycleLoading === 'spawn'" class="size-3 animate-spin" />
+                    <Play v-else class="size-3" />
+                    Spawn
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Create tmux session and launch agent</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    variant="ghost" size="sm" class="h-7 px-2 text-xs gap-1"
+                    :disabled="lifecycleLoading !== null"
+                    @click="handleRestart"
+                  >
+                    <Loader2 v-if="lifecycleLoading === 'restart'" class="size-3 animate-spin" />
+                    <RotateCcw v-else class="size-3" />
+                    Restart
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Kill existing session and spawn a new one</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    variant="ghost" size="sm"
+                    class="h-7 px-2 text-xs gap-1 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
+                    :disabled="lifecycleLoading !== null"
+                    @click="stopConfirmOpen = true"
+                  >
+                    <Loader2 v-if="lifecycleLoading === 'stop'" class="size-3 animate-spin" />
+                    <Square v-else class="size-3" />
+                    Stop
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Kill the agent's tmux session</TooltipContent>
+              </Tooltip>
+            </div>
+
+            <!-- Inspect toggle -->
             <Tooltip>
               <TooltipTrigger as-child>
                 <Button
-                  variant="ghost" size="sm" class="h-7 px-2 text-xs gap-1"
-                  :disabled="lifecycleLoading !== null"
-                  @click="handleRestart"
+                  size="sm"
+                  :variant="introspectOpen ? 'secondary' : 'outline'"
+                  class="h-7 px-2 text-xs gap-1"
+                  @click="toggleIntrospect"
                 >
-                  <Loader2 v-if="lifecycleLoading === 'restart'" class="size-3 animate-spin" />
-                  <RotateCcw v-else class="size-3" />
-                  Restart
+                  <Terminal class="size-3.5" />
+                  Inspect
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Kill existing session and spawn a new one</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger as-child>
-                <Button
-                  variant="ghost" size="sm"
-                  class="h-7 px-2 text-xs gap-1 text-destructive hover:text-destructive hover:bg-destructive/10"
-                  :disabled="lifecycleLoading !== null"
-                  @click="stopConfirmOpen = true"
-                >
-                  <Loader2 v-if="lifecycleLoading === 'stop'" class="size-3 animate-spin" />
-                  <Square v-else class="size-3" />
-                  Stop
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Kill the agent's tmux session</TooltipContent>
+              <TooltipContent>{{ introspectOpen ? 'Close' : 'Open' }} live tmux pane capture</TooltipContent>
             </Tooltip>
           </div>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                size="sm"
-                :variant="introspectOpen ? 'secondary' : 'outline'"
-                class="gap-1 text-xs"
-                @click="toggleIntrospect"
-              >
-                <Terminal class="size-3.5" />
-                Inspect
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Capture live tmux pane output</TooltipContent>
-          </Tooltip>
         </div>
       </div>
 

--- a/frontend/src/components/AgentProfileCard.vue
+++ b/frontend/src/components/AgentProfileCard.vue
@@ -8,6 +8,7 @@ import StatusBadge from './StatusBadge.vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { GitBranch, ExternalLink, Clock, ArrowUpRight, MessageSquare, Crown } from 'lucide-vue-next'
+import { prLink } from '@/lib/utils'
 
 const props = defineProps<{
   agentName: string
@@ -20,15 +21,6 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
-
-function prLink(agent: { pr?: string; repo_url?: string }): string | null {
-  if (!agent.pr) return null
-  if (agent.pr.startsWith('http')) return agent.pr
-  if (!agent.repo_url) return null
-  const repoBase = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
-  const prNum = agent.pr.replace(/^#/, '')
-  return `${repoBase}/pull/${prNum}`
-}
 
 const { relativeTime } = useTime()
 

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -13,6 +13,7 @@ import StatusBadge from './StatusBadge.vue'
 import NewTaskDialog from './NewTaskDialog.vue'
 import { MessageSquare, Search, X, GitBranch, ExternalLink, SendHorizontal, Plus } from 'lucide-vue-next'
 import { renderMarkdown, linkTaskRefs } from '@/lib/markdown'
+import { prLink } from '@/lib/utils'
 import type { Task } from '@/types'
 import { relativeTime } from '@/composables/useTime'
 import api from '@/api/client'
@@ -182,15 +183,6 @@ const router = useRouter()
 function goToAgentDetail(agentName: string) {
   slideoverAgentName.value = null
   router.push(`/${encodeURIComponent(props.space.name)}/${encodeURIComponent(agentName)}`)
-}
-
-function prLink(agent: { pr?: string; repo_url?: string }): string | null {
-  if (!agent.pr) return null
-  if (agent.pr.startsWith('http')) return agent.pr
-  if (!agent.repo_url) return null
-  const repoBase = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
-  const prNum = agent.pr.replace(/^#/, '')
-  return `${repoBase}/pull/${prNum}`
 }
 
 // ── New Message picker ──────────────────────────────────────────────

--- a/frontend/src/components/GanttTimeline.vue
+++ b/frontend/src/components/GanttTimeline.vue
@@ -239,6 +239,7 @@ onUnmounted(() => {
         <AgentProfileCard
           :agent-name="row.agent"
           :agent="agents?.[row.agent]"
+          :space-name="spaceName"
           @select-agent="emit('select-agent', $event)"
         >
           <button

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -49,6 +49,7 @@ import AgentAvatar from './AgentAvatar.vue'
 import AgentProfileCard from './AgentProfileCard.vue'
 import GanttTimeline from './GanttTimeline.vue'
 import HierarchyView from './HierarchyView.vue'
+import { prLink } from '@/lib/utils'
 
 const props = defineProps<{
   space: KnowledgeSpace
@@ -136,15 +137,6 @@ function refreshInbox() {
 }
 
 defineExpose({ switchToInbox, refreshInbox })
-
-function prLink(agent: { pr?: string; repo_url?: string }): string | null {
-  if (!agent.pr) return null
-  if (agent.pr.startsWith('http')) return agent.pr
-  if (!agent.repo_url) return null
-  const repoBase = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
-  const prNum = agent.pr.replace(/^#/, '')
-  return `${repoBase}/pull/${prNum}`
-}
 
 const sortedAgents = computed(() => {
   return Object.entries(props.space.agents).sort(([, a], [, b]) => {
@@ -787,14 +779,10 @@ const activeSections = computed(() => [
 
         <TabsContent value="hierarchy">
           <HierarchyView
-            v-if="hierarchy"
-            :tree="hierarchy"
+            :tree="hierarchy ?? { space: space.name, roots: [], nodes: {} }"
             :agents="space.agents"
             @select-agent="emit('select-agent', $event)"
           />
-          <div v-else class="flex flex-col items-center justify-center py-16 text-center">
-            <p class="text-sm text-muted-foreground">Loading hierarchy…</p>
-          </div>
         </TabsContent>
       </Tabs>
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,3 +5,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Build a full PR URL from agent.pr + agent.repo_url, or return null. */
+export function prLink(agent: { pr?: string; repo_url?: string }): string | null {
+  if (!agent.pr) return null
+  if (agent.pr.startsWith('http')) return agent.pr
+  if (!agent.repo_url) return null
+  const repoBase = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
+  const prNum = agent.pr.replace(/^#/, '')
+  return `${repoBase}/pull/${prNum}`
+}


### PR DESCRIPTION
## Summary

TASK-019 UI Unification — thorough audit and targeted fixes across the frontend.

**Bugs fixed:**
- **Introspect live-view race condition** (`AgentDetail`): when switching agents quickly, in-flight async `loadIntrospect()` responses would overwrite the new agent's data. Now captures agent name at call time and discards stale responses on navigation.
- **GanttTimeline hover card Message button always disabled**: `spaceName` prop was missing from `AgentProfileCard` in the timeline, so the Message button was always disabled. Fixed with a 1-line addition.
- **Hierarchy tab stuck on "Loading…"**: `SpaceOverview` showed "Loading hierarchy…" forever when there was no parent/child data. Now passes an empty tree to `HierarchyView` which renders its own informative empty state.

**UX improvements:**
- **Lifecycle controls refactored**: Agent detail header action buttons reorganised from a single crowded flat row into a clear 2-row layout: primary actions (Conversations, Nudge, Delete) on top; session controls (Terminal badge + Spawn/Restart/Stop group + Inspect) on bottom.
- **Conversations button uses named route**: uses `{ name: 'conversation', params: ... }` instead of raw URL string for consistency.

**Code quality:**
- **Extracted shared `prLink()` to `lib/utils.ts`**: function was copy-pasted in 4 files (`AgentDetail`, `SpaceOverview`, `AgentProfileCard`, `ConversationsView`). Now all import from one place.
- **`.vite/` added to `.gitignore`**: dev cache directory was untracked.

## Test plan
- [x] `vue-tsc -b && vite build` — clean, no type errors
- [x] `go build ./cmd/boss/` — clean
- [x] `go test -race ./internal/coordinator/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)