### PR TITLE
feat(tasks): notify agent on task comment (TASK-023)

### DIFF
--- a/internal/coordinator/handlers_task.go
+++ b/internal/coordinator/handlers_task.go
@@ -557,9 +557,70 @@ func (s *Server) handleTaskComment(w http.ResponseWriter, r *http.Request, space
 		s.broadcastSSE(spaceName, "", "task_updated", string(sseData))
 	}
 
+	// Notify the assigned agent about the new comment (if someone else commented).
+	if taskCopy.AssignedTo != "" && taskCopy.AssignedTo != caller {
+		go s.notifyTaskComment(spaceName, taskCopy.ID, taskCopy.Title, taskCopy.AssignedTo, caller, req.Body)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(taskCopy)
+}
+
+// notifyTaskComment delivers a coordinator message to the assigned agent when someone
+// comments on their task. Called in a goroutine after the lock is released.
+func (s *Server) notifyTaskComment(spaceName, taskID, taskTitle, assignedTo, commentBy, body string) {
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		return
+	}
+
+	preview := body
+	if len(preview) > 120 {
+		preview = preview[:117] + "..."
+	}
+
+	msg := AgentMessage{
+		ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
+		Sender:    commentBy,
+		Message:   fmt.Sprintf("[%s](/spaces/%s/tasks/%s) %q — new comment from %s: %s", taskID, spaceName, taskID, taskTitle, commentBy, preview),
+		Priority:  PriorityInfo,
+		Timestamp: time.Now().UTC(),
+	}
+
+	s.mu.Lock()
+	canonical := resolveAgentName(ks, assignedTo)
+	ag, exists := ks.Agents[canonical]
+	if !exists {
+		s.mu.Unlock()
+		return
+	}
+	ag.Messages = append(ag.Messages, msg)
+	notif := AgentNotification{
+		ID:        fmt.Sprintf("%s-%d", canonical, time.Now().UnixNano()),
+		Type:      NotifTypeTaskComment,
+		Title:     fmt.Sprintf("%s commented on %s", commentBy, taskID),
+		Body:      preview,
+		From:      commentBy,
+		TaskID:    taskID,
+		Timestamp: time.Now().UTC(),
+	}
+	ag.Notifications = append(ag.Notifications, notif)
+	pruneNotifications(ag)
+	ks.UpdatedAt = time.Now().UTC()
+	snap := ks.snapshot()
+	s.mu.Unlock()
+
+	s.saveSpace(snap)
+	s.journal.Append(spaceName, EventMessageSent, canonical, &msg)
+
+	sseData, _ := json.Marshal(map[string]interface{}{
+		"space":  spaceName,
+		"agent":  canonical,
+		"sender": commentBy,
+		"type":   string(NotifTypeTaskComment),
+	})
+	s.broadcastSSE(spaceName, canonical, "agent_notification", string(sseData))
 }
 
 // notifyTaskAssigned delivers a coordinator message to the assigned agent so they are

--- a/internal/coordinator/types.go
+++ b/internal/coordinator/types.go
@@ -132,8 +132,9 @@ type AgentDocument struct {
 type NotificationType string
 
 const (
-	NotifTypeMessage    NotificationType = "message"      // new message from another agent
-	NotifTypeTaskAssign NotificationType = "task_assigned" // task assigned to this agent
+	NotifTypeMessage     NotificationType = "message"         // new message from another agent
+	NotifTypeTaskAssign  NotificationType = "task_assigned"   // task assigned to this agent
+	NotifTypeTaskComment NotificationType = "task_commented"  // someone commented on agent's task
 )
 
 // AgentNotification is a typed notification surfaced to an agent explaining


### PR DESCRIPTION
## Summary

- **TASK-023**: Task comments were not surfaced to the assigned agent — making them effectively invisible unless the agent polled the task endpoint manually.

## Changes

- `types.go`: Added `NotifTypeTaskComment = "task_commented"` notification type
- `handlers_task.go`: Added `notifyTaskComment()` helper (parallel to existing `notifyTaskAssigned`); called from `handleTaskComment` when commenter ≠ assignee
  - Delivers an `AgentMessage` with task link + 120-char body preview to the assigned agent's inbox
  - Creates a typed `AgentNotification` (type: `task_commented`) so agents immediately know why they were notified
  - Broadcasts SSE `agent_notification` event for real-time frontend updates

## Test plan

- [x] \`go test -race -count=1 -parallel=4 -timeout 30s ./internal/coordinator/\` — all pass
- [x] \`go build ./cmd/boss/\` — clean
- [ ] Manual: assign task to AgentX, comment as boss — verify AgentX message inbox and notification badge update

🤖 Generated with [Claude Code](https://claude.com/claude-code)