### PR TITLE
feat(frontend): parity audit — fix PR links and add space archive UI (TASK-033, TASK-034)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -384,6 +384,22 @@ async function handleDeleteSpace(spaceName: string) {
   }
 }
 
+async function handleArchiveSpace(spaceName: string) {
+  const isArchived = !!currentSpace.value?.archive
+  try {
+    await api.archiveSpace(spaceName, isArchived ? '' : undefined)
+    showStatus(isArchived ? `Unarchived space "${spaceName}"` : `Archived space "${spaceName}"`)
+    await loadSpaces()
+    // Reload current space to reflect archive field change
+    if (selectedSpace.value === spaceName) {
+      currentSpace.value = await api.fetchSpace(spaceName)
+    }
+  } catch (err) {
+    console.error('Archive space failed:', err)
+    showError(`Failed to ${isArchived ? 'unarchive' : 'archive'} space "${spaceName}".`)
+  }
+}
+
 async function handleCreateSpace(spaceName: string) {
   try {
     await api.createSpace(spaceName)
@@ -780,6 +796,7 @@ onUnmounted(() => {
         @broadcast="handleBroadcastSpace"
         @delete-space="handleDeleteSpace"
         @create-space="handleCreateSpace"
+        @archive-space="handleArchiveSpace"
       />
       <SidebarInset class="flex flex-col h-dvh">
         <!-- Header -->
@@ -980,6 +997,7 @@ onUnmounted(() => {
             @broadcast-agent="handleBroadcastSingleAgent"
             @send-message-to-agent="handleSendMessageToAgent"
             @delete-space="handleDeleteSpace(selectedSpace)"
+            @archive-space="handleArchiveSpace(selectedSpace)"
             @clear-done-agents="handleClearDoneAgents"
           />
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -62,6 +62,34 @@ class ApiClient {
     })
   }
 
+  archiveSpace(space: string, body?: string): Promise<void> {
+    return this.requestVoid(`/spaces/${encodeURIComponent(space)}/archive`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: body !== undefined ? body : `Archived at ${new Date().toISOString()}`,
+    })
+  }
+
+  fetchAgentMessages(space: string, agent: string, since?: string): Promise<{ agent: string; cursor: string; messages: import('@/types').AgentMessage[] }> {
+    const url = since
+      ? `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/messages?since=${encodeURIComponent(since)}`
+      : `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/messages`
+    return this.request(url)
+  }
+
+  ackMessage(space: string, agent: string, messageId: string, agentName: string): Promise<void> {
+    return this.requestVoid(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/message/${encodeURIComponent(messageId)}/ack`,
+      { method: 'POST', headers: { 'X-Agent-Name': agentName } },
+    )
+  }
+
+  fetchAgentHistory(space: string, agent: string): Promise<import('@/types').StatusSnapshot[]> {
+    return this.request(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/history`,
+    )
+  }
+
   // --------------- Agents ---------------
 
   fetchAgent(space: string, agent: string): Promise<AgentUpdate> {
@@ -109,13 +137,16 @@ class ApiClient {
 
   // --------------- History ---------------
 
-  fetchHistory(space: string, sinceMs?: number): Promise<StatusSnapshot[]> {
-    let path = `/spaces/${encodeURIComponent(space)}/history`
+  fetchHistory(space: string, sinceMs?: number, agent?: string): Promise<StatusSnapshot[]> {
+    const params = new URLSearchParams()
     if (sinceMs !== undefined) {
-      const since = new Date(Date.now() - sinceMs).toISOString()
-      path += `?since=${encodeURIComponent(since)}`
+      params.set('since', new Date(Date.now() - sinceMs).toISOString())
     }
-    return this.request<StatusSnapshot[]>(path)
+    if (agent) params.set('agent', agent)
+    const qs = params.toString()
+    return this.request<StatusSnapshot[]>(
+      `/spaces/${encodeURIComponent(space)}/history${qs ? '?' + qs : ''}`,
+    )
   }
 
   // --------------- Events ---------------

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -4,6 +4,7 @@ import { STATUS_DISPLAY } from '@/types'
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { relativeTime } from '@/composables/useTime'
+import { prLink } from '@/lib/utils'
 import {
   Sidebar,
   SidebarContent,
@@ -48,7 +49,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard, MessageSquare, Crown } from 'lucide-vue-next'
+import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard, MessageSquare, Crown, Archive } from 'lucide-vue-next'
 import AgentAvatar from './AgentAvatar.vue'
 
 const props = defineProps<{
@@ -65,6 +66,7 @@ const emit = defineEmits<{
   broadcast: []
   'delete-space': [name: string]
   'create-space': [name: string]
+  'archive-space': [name: string]
 }>()
 
 const router = useRouter()
@@ -315,6 +317,13 @@ function submitNewSpace() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent side="right" align="start">
                   <DropdownMenuItem
+                    class="cursor-pointer"
+                    @click="emit('archive-space', space.name)"
+                  >
+                    <Archive class="size-4 mr-2" aria-hidden="true" />
+                    Archive space
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
                     class="text-destructive focus:text-destructive focus:bg-destructive/10 cursor-pointer"
                     @click="requestDeleteSpace(space.name)"
                   >
@@ -426,14 +435,18 @@ function submitNewSpace() {
                           </TooltipContent>
                         </Tooltip>
                         <a
-                          v-if="agent.pr"
-                          :href="agent.pr"
+                          v-if="agent.pr && prLink(agent)"
+                          :href="prLink(agent)!"
                           target="_blank"
                           rel="noopener noreferrer"
                           class="text-[10px] text-primary hover:underline shrink-0"
-                          :title="agent.pr"
+                          :title="prLink(agent)!"
                           @click.stop
-                        >PR</a>
+                        >{{ agent.pr }}</a>
+                        <span
+                          v-else-if="agent.pr"
+                          class="text-[10px] text-muted-foreground shrink-0"
+                        >{{ agent.pr }}</span>
                       </div>
                     </div>
                   </SidebarMenuButton>
@@ -519,14 +532,18 @@ function submitNewSpace() {
                               </TooltipContent>
                             </Tooltip>
                             <a
-                              v-if="agent.pr"
-                              :href="agent.pr"
+                              v-if="agent.pr && prLink(agent)"
+                              :href="prLink(agent)!"
                               target="_blank"
                               rel="noopener noreferrer"
                               class="text-[10px] text-primary hover:underline shrink-0"
-                              :title="agent.pr"
+                              :title="prLink(agent)!"
                               @click.stop
-                            >PR</a>
+                            >{{ agent.pr }}</a>
+                            <span
+                              v-else-if="agent.pr"
+                              class="text-[10px] text-muted-foreground shrink-0"
+                            >{{ agent.pr }}</span>
                           </div>
                         </div>
                       </SidebarMenuButton>

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -32,6 +32,7 @@ import {
   Radio,
   Bell,
   Trash2,
+  Archive,
   MessageSquare,
   SendHorizontal,
   HelpCircle,
@@ -65,6 +66,7 @@ const emit = defineEmits<{
   'broadcast-agent': [name: string]
   'send-message-to-agent': [agentName: string, text: string]
   'delete-space': []
+  'archive-space': []
   'clear-done-agents': [names: string[]]
 }>()
 
@@ -280,6 +282,16 @@ const activeSections = computed(() => [
 <template>
   <ScrollArea class="flex-1 min-h-0">
     <div class="p-6 space-y-6 max-w-7xl">
+      <!-- Archived banner -->
+      <div
+        v-if="space.archive"
+        class="flex items-center gap-2 px-3 py-2 rounded-md bg-muted border border-border text-sm text-muted-foreground mb-2"
+        role="status"
+      >
+        <Archive class="size-4 shrink-0" aria-hidden="true" />
+        <span>This space is archived. <span class="font-mono text-xs">{{ space.archive }}</span></span>
+      </div>
+
       <!-- Header -->
       <div class="flex items-center justify-between">
         <div>
@@ -319,6 +331,22 @@ const activeSections = computed(() => [
             </TooltipTrigger>
             <TooltipContent>
               Remove all {{ doneIdleAgents.length }} done or idle agent{{ doneIdleAgents.length !== 1 ? 's' : '' }} from this space
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="outline"
+                size="sm"
+                :class="space.archive ? 'text-muted-foreground' : ''"
+                @click="emit('archive-space')"
+              >
+                <Archive class="size-4" />
+                {{ space.archive ? 'Unarchive' : 'Archive Space' }}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {{ space.archive ? 'Remove archived status from this space' : 'Mark this space as archived' }}
             </TooltipContent>
           </Tooltip>
           <Tooltip>

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -75,6 +75,23 @@ const subtaskItems = computed(() => {
 
 function buildPrUrl(pr: string): string | null {
   if (pr.startsWith('http')) return pr
+  // Try to build URL from the assigned agent's repo_url
+  if (props.task?.assigned_to) {
+    const agent = props.space.agents[props.task.assigned_to]
+    if (agent?.repo_url) {
+      const base = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
+      const num = pr.replace(/^#/, '')
+      return `${base}/pull/${num}`
+    }
+  }
+  // Fall back to any agent in the space that has a repo_url
+  for (const agent of Object.values(props.space.agents)) {
+    if (agent.repo_url) {
+      const base = agent.repo_url.replace(/\.git$/, '').replace(/\/$/, '')
+      const num = pr.replace(/^#/, '')
+      return `${base}/pull/${num}`
+    }
+  }
   return null
 }
 
@@ -380,8 +397,8 @@ async function setDueDate(value: string) {
                 <code class="text-xs bg-muted px-1.5 py-0.5 rounded">{{ task.linked_branch }}</code>
               </div>
               <a
-                v-if="task.linked_pr"
-                :href="buildPrUrl(task.linked_pr) ?? '#'"
+                v-if="task.linked_pr && buildPrUrl(task.linked_pr)"
+                :href="buildPrUrl(task.linked_pr)!"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="flex items-center gap-1.5 text-sm text-primary hover:underline"
@@ -389,6 +406,13 @@ async function setDueDate(value: string) {
                 <ExternalLink class="size-3.5" />
                 {{ task.linked_pr }}
               </a>
+              <span
+                v-else-if="task.linked_pr"
+                class="flex items-center gap-1.5 text-sm text-muted-foreground"
+              >
+                <ExternalLink class="size-3.5" />
+                {{ task.linked_pr }}
+              </span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

Closes TASK-033 (Frontend Parity with API) and TASK-034 (Fix PR Links).

### TASK-034 — Fix PR Links (Medium)

- **AppSidebar.vue**: The two agent PR link blocks used `:href="agent.pr"` directly, making `#42` a page anchor (`#42`) instead of a real URL. Now uses `prLink(agent)` from utils (same as other components). Falls back to plain text when no `repo_url` is available. Shows PR number as link text instead of generic "PR".
- **TaskDetailPanel.vue**: `buildPrUrl()` previously only resolved full `http://...` URLs. Now attempts to construct the full URL from the assigned agent's `repo_url`, then falls back to any agent in the space. Falls back to plain text if no repo context is available.

### TASK-033 — Frontend Parity with API (Urgent)

API coverage audit — gaps found and addressed:

| Endpoint | Gap | Fix |
|----------|-----|-----|
| `POST /spaces/{space}/archive` | No UI | Added Archive/Unarchive button in SpaceOverview + sidebar context menu |
| `GET /spaces/{space}/agent/{agent}/messages` | No API client method | Added `fetchAgentMessages()` with cursor support |
| `POST /spaces/{space}/agent/{agent}/message/{id}/ack` | No API client method | Added `ackMessage()` |
| `GET /spaces/{space}/agent/{agent}/history` | No API client method | Added `fetchAgentHistory()` |
| `GET /spaces/{space}/history?agent=` | Filter param ignored | Updated `fetchHistory()` to pass `?agent=` when provided |

**Space archive UX:**
- Sidebar context menu: Archive space option added alongside Delete
- SpaceOverview header: Archive/Unarchive toggle button; shows archived banner with timestamp when space is archived
- Toggling: sending empty body clears the archive field (unarchives)

## Test plan

- [x] `go test -race ./internal/coordinator/` passes (no backend changes)
- [x] `npm run build` in `frontend/` passes with zero TypeScript errors
- [ ] Verify PR links in AppSidebar show as proper `github.com/.../pull/N` links
- [ ] Verify Archive button appears in space context menu and SpaceOverview
- [ ] Verify archived banner shows when space is archived
- [ ] Verify Unarchive clears the banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)