### PR TITLE
feat(frontend): improve read indicators + Conversations unread badge (TASK-035 follow-up)

### DIFF
--- a/frontend/src/components/AgentMessages.vue
+++ b/frontend/src/components/AgentMessages.vue
@@ -263,28 +263,31 @@ const enrichedMessages = computed((): MessageEntry[] => {
                 </TooltipContent>
               </Tooltip>
 
-              <!-- Timestamp + delivered (last message in group only) -->
+              <!-- Timestamp + read/delivered status (last message in group only) -->
               <div
                 v-if="entry.isLastInGroup"
-                :class="[
-                  'flex items-center gap-1 mt-1 px-1',
-                  entry.isBoss ? 'flex-row' : 'flex-row',
-                ]"
+                class="flex items-center gap-1.5 mt-1 px-1"
               >
                 <time :datetime="entry.msg.timestamp" class="text-xs text-muted-foreground">
                   {{ formatTime(entry.msg.timestamp) }}
                 </time>
+                <!-- Read receipt: double-check in blue when read, single grey when delivered -->
                 <span
                   v-if="entry.isBoss && entry.msg.read"
-                  class="flex items-center gap-0.5 text-xs text-muted-foreground"
+                  class="flex items-center gap-0 text-xs font-medium text-primary"
+                  title="Read by agent"
                 >
-                  <Check class="size-3" />Read
+                  <Check class="size-3.5 -mr-1" />
+                  <Check class="size-3.5" />
+                  <span class="ml-1">Read</span>
                 </span>
                 <span
                   v-else-if="entry.isBoss"
                   class="flex items-center gap-0.5 text-xs text-muted-foreground"
+                  title="Delivered to agent"
                 >
-                  <Check class="size-3" />Delivered
+                  <Check class="size-3.5" />
+                  <span>Delivered</span>
                 </span>
               </div>
             </div>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -223,6 +223,24 @@ function statusLabel(status: string): string {
   return display ? display.label : status
 }
 
+// Count unread messages directed at the boss across all boss↔agent conversations.
+// Messages in any agent's inbox where sender is an agent (not boss) and recipient is boss,
+// plus any messages in the 'boss' agent's own inbox that are unread.
+const bossUnreadCount = computed(() => {
+  if (!props.currentSpace) return 0
+  let count = 0
+  // Messages in the 'boss' pseudo-agent inbox (agents sending TO boss)
+  const bossAgent = props.currentSpace.agents['boss']
+  if (bossAgent?.messages) {
+    for (const msg of bossAgent.messages) {
+      if (!msg.read) count++
+    }
+  }
+  // Also count messages in agent inboxes from boss that are unread (boss sent these, agent hasn't read)
+  // — intentionally excluded here: we want notifications for messages TO boss, not FROM boss
+  return count
+})
+
 // New space dialog
 const newSpaceDialogOpen = ref(false)
 const newSpaceName = ref('')
@@ -362,9 +380,23 @@ function submitNewSpace() {
                 :data-active="false"
                 @click="router.push('/' + selectedSpace + '/conversations')"
               >
-                <MessageSquare class="size-4" />
+                <div class="relative shrink-0">
+                  <MessageSquare class="size-4" />
+                  <!-- Unread boss-message dot -->
+                  <span
+                    v-if="bossUnreadCount > 0"
+                    class="absolute -top-1.5 -right-1.5 flex items-center justify-center rounded-full bg-red-500 text-white text-[9px] font-bold leading-none min-w-[14px] h-3.5 px-0.5"
+                    :title="`${bossUnreadCount} unread message${bossUnreadCount !== 1 ? 's' : ''} for boss`"
+                  >{{ bossUnreadCount }}</span>
+                </div>
                 <span>Conversations</span>
               </SidebarMenuButton>
+              <SidebarMenuBadge
+                v-if="bossUnreadCount > 0"
+                class="text-red-500 font-bold text-[10px]"
+              >
+                {{ bossUnreadCount }}
+              </SidebarMenuBadge>
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarGroupContent>


### PR DESCRIPTION
## Summary

Follow-up to PR #44 (TASK-035) based on boss feedback: indicators not visible enough, want prominent badge on Conversations nav.

### Fix 1 — More prominent Read/Delivered indicators (AgentMessages.vue)

Upgraded from plain text to a visual double-check pattern (iMessage style):
- **Read**: double overlapping check icons in primary color (blue) + "Read" text — clearly distinct from Delivered
- **Delivered**: single grey check + "Delivered" text
- Previously the check icon was `size-3` (12px), now `size-3.5` (14px) — slightly more prominent

### Fix 2 — Conversations nav unread badge (AppSidebar.vue)

Added a red badge on the Conversations sidebar nav item showing the count of unread messages sent to the boss:
- Reads `space.agents['boss'].messages` where `read === false`
- Shows as a red dot overlay on the `MessageSquare` icon **and** as a `SidebarMenuBadge` count
- Only appears when `bossUnreadCount > 0` — no noise when nothing pending
- Gives the boss immediate visibility that an agent has messaged them, without navigating into Conversations

## Test plan

- [x] `go test -race ./internal/coordinator/` passes
- [x] `npm run build` passes with zero TypeScript errors
- [ ] When agent sends message to 'boss': red badge appears on Conversations nav
- [ ] Badge clears once messages are read (backend marks read via ack)
- [ ] AgentMessages: boss-sent messages show double-blue-check when read, single-grey when delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)