### PR TITLE
feat(lifecycle): hexagonal agent backend + agent creation UI (TASK-036)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -234,6 +234,26 @@ class ApiClient {
 
   // --------------- Lifecycle ---------------
 
+  createAgent(
+    space: string,
+    spec: {
+      name: string
+      work_dir?: string
+      command?: string
+      backend?: 'tmux' | 'cloud'
+      width?: number
+      height?: number
+      parent?: string
+      role?: string
+    },
+  ): Promise<{ ok: boolean; agent: string; backend: string; session: string; space: string }> {
+    return this.request(`/spaces/${encodeURIComponent(space)}/agents`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(spec),
+    })
+  }
+
   spawnAgent(space: string, agent: string, command?: string): Promise<{ ok: boolean; tmux_session: string }> {
     return this.request(
       `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/spawn`,

--- a/frontend/src/components/AgentCreateDialog.vue
+++ b/frontend/src/components/AgentCreateDialog.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { api } from '@/api/client'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+const props = defineProps<{
+  open: boolean
+  space: string
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  created: [agentName: string]
+}>()
+
+const agentName = ref('')
+const workDir = ref('')
+const backend = ref<'tmux' | 'cloud'>('tmux')
+const submitting = ref(false)
+const errorMsg = ref('')
+
+function reset() {
+  agentName.value = ''
+  workDir.value = ''
+  backend.value = 'tmux'
+  errorMsg.value = ''
+}
+
+async function submit() {
+  const name = agentName.value.trim()
+  if (!name) return
+  submitting.value = true
+  errorMsg.value = ''
+  try {
+    await api.createAgent(props.space, {
+      name,
+      work_dir: workDir.value.trim() || undefined,
+      backend: backend.value,
+    })
+    const created = name
+    reset()
+    emit('created', created)
+    emit('update:open', false)
+  } catch (e: unknown) {
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="(v) => { if (!v) reset(); emit('update:open', v) }">
+    <DialogContent class="sm:max-w-[440px]">
+      <DialogHeader>
+        <DialogTitle>Add Agent</DialogTitle>
+        <DialogDescription>
+          Spawn a new agent in <span class="font-medium">{{ space }}</span>.
+        </DialogDescription>
+      </DialogHeader>
+
+      <form class="flex flex-col gap-4 py-2" @submit.prevent="submit">
+        <!-- Agent Name -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Agent Name <span class="text-destructive">*</span>
+          </label>
+          <Input
+            v-model="agentName"
+            placeholder="e.g. MyAgent"
+            autocomplete="off"
+            required
+          />
+        </div>
+
+        <!-- Working Directory -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Working Directory (optional)
+          </label>
+          <Input
+            v-model="workDir"
+            placeholder="e.g. /home/user/my-project"
+            autocomplete="off"
+            class="font-mono text-sm"
+          />
+          <p class="text-xs text-muted-foreground">
+            The agent's tmux session will <code>cd</code> to this directory before starting.
+          </p>
+        </div>
+
+        <!-- Backend selector -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">Backend</label>
+          <div class="flex gap-2">
+            <button
+              type="button"
+              :class="[
+                'flex-1 rounded border px-3 py-1.5 text-sm transition-colors',
+                backend === 'tmux'
+                  ? 'border-primary bg-primary/10 text-primary font-medium'
+                  : 'border-border bg-background hover:bg-muted/50',
+              ]"
+              @click="backend = 'tmux'"
+            >
+              tmux
+            </button>
+            <div class="relative flex-1" title="Cloud backend coming soon">
+              <button
+                type="button"
+                disabled
+                class="w-full rounded border border-border bg-muted/30 px-3 py-1.5 text-sm text-muted-foreground cursor-not-allowed"
+              >
+                cloud
+              </button>
+              <span class="absolute -top-1.5 -right-1.5 rounded-full bg-muted px-1 text-[9px] text-muted-foreground font-medium leading-4">
+                soon
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <p v-if="errorMsg" class="text-xs text-destructive">{{ errorMsg }}</p>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" @click="emit('update:open', false)">Cancel</Button>
+          <Button type="submit" :disabled="!agentName.trim() || submitting">
+            {{ submitting ? 'Creating…' : 'Add Agent' }}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -43,6 +43,7 @@ import {
   Clock,
   Layers,
   Search,
+  Plus,
 } from 'lucide-vue-next'
 import StatusBadge from './StatusBadge.vue'
 import InterruptTracker from './InterruptTracker.vue'
@@ -50,6 +51,7 @@ import AgentAvatar from './AgentAvatar.vue'
 import AgentProfileCard from './AgentProfileCard.vue'
 import GanttTimeline from './GanttTimeline.vue'
 import HierarchyView from './HierarchyView.vue'
+import AgentCreateDialog from './AgentCreateDialog.vue'
 import { prLink } from '@/lib/utils'
 
 const props = defineProps<{
@@ -72,6 +74,7 @@ const emit = defineEmits<{
 
 const agentSearch = ref('')
 const activeTab = ref('agents')
+const agentCreateDialogOpen = ref(false)
 const deleteDialogOpen = ref(false)
 const deleteDialogAgent = ref<string | null>(null)
 const deleteSpaceDialogOpen = ref(false)
@@ -301,6 +304,18 @@ const activeSections = computed(() => [
           </p>
         </div>
         <div class="flex items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                size="sm"
+                @click="agentCreateDialogOpen = true"
+              >
+                <Plus class="size-4" />
+                Add Agent
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Spawn a new agent in this space</TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
               <Button
@@ -917,6 +932,12 @@ const activeSections = computed(() => [
           </form>
         </DialogContent>
       </Dialog>
+
+      <AgentCreateDialog
+        v-model:open="agentCreateDialogOpen"
+        :space="space.name"
+        @created="() => {}"
+      />
     </div>
   </ScrollArea>
 </template>

--- a/internal/coordinator/agent_backend.go
+++ b/internal/coordinator/agent_backend.go
@@ -1,0 +1,174 @@
+package coordinator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// ErrNotImplemented is returned by backend adapters that have not yet been implemented.
+var ErrNotImplemented = errors.New("not implemented")
+
+// AgentSpec describes the desired configuration for a new agent.
+type AgentSpec struct {
+	Name    string `json:"name"`
+	Space   string `json:"space"`
+	WorkDir string `json:"work_dir,omitempty"` // working directory for the agent process
+	Command string `json:"command,omitempty"`  // defaults to "claude --dangerously-skip-permissions"
+	Width   int    `json:"width,omitempty"`    // tmux window width, default 220
+	Height  int    `json:"height,omitempty"`   // tmux window height, default 50
+	Parent  string `json:"parent,omitempty"`   // parent agent name for hierarchy
+	Role    string `json:"role,omitempty"`     // display label
+}
+
+// AgentInfo describes a running agent as reported by a backend.
+type AgentInfo struct {
+	Name      string    `json:"name"`
+	Space     string    `json:"space"`
+	Backend   string    `json:"backend"`
+	SessionID string    `json:"session_id,omitempty"` // backend-specific session identifier
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
+
+// AgentBackend is the port (interface) for agent lifecycle management.
+// Concrete adapters (TmuxBackend, CloudBackend) implement this interface.
+type AgentBackend interface {
+	// Spawn creates and starts a new agent according to spec.
+	Spawn(ctx context.Context, spec AgentSpec) (AgentInfo, error)
+
+	// Stop terminates a running agent by name in the given space.
+	Stop(ctx context.Context, space, name string) error
+
+	// List returns all agents managed by this backend in the given space.
+	List(ctx context.Context, space string) ([]AgentInfo, error)
+
+	// Name returns the backend identifier string (e.g. "tmux", "cloud").
+	Name() string
+}
+
+// TmuxBackend is the AgentBackend adapter that manages agents via local tmux sessions.
+type TmuxBackend struct{}
+
+// Name returns "tmux".
+func (b *TmuxBackend) Name() string { return "tmux" }
+
+// Spawn creates a new detached tmux session, launches the agent command, and
+// sends the /boss.ignite prompt after initialization.
+func (b *TmuxBackend) Spawn(ctx context.Context, spec AgentSpec) (AgentInfo, error) {
+	sessionName := spec.Name
+
+	command := spec.Command
+	if command == "" {
+		command = "claude --dangerously-skip-permissions"
+	}
+	width := spec.Width
+	if width <= 0 {
+		width = 220
+	}
+	height := spec.Height
+	if height <= 0 {
+		height = 50
+	}
+
+	if tmuxSessionExists(sessionName) {
+		return AgentInfo{}, fmt.Errorf("tmux session %q already exists", sessionName)
+	}
+
+	// Create detached tmux session.
+	if err := exec.CommandContext(ctx, "tmux", "new-session", "-d", "-s", sessionName,
+		"-x", fmt.Sprintf("%d", width), "-y", fmt.Sprintf("%d", height)).Run(); err != nil {
+		return AgentInfo{}, fmt.Errorf("create tmux session: %w", err)
+	}
+
+	// Change directory if specified.
+	if spec.WorkDir != "" {
+		if err := tmuxSendKeys(sessionName, "cd "+shellQuote(spec.WorkDir)); err != nil {
+			exec.CommandContext(ctx, "tmux", "kill-session", "-t", sessionName).Run() //nolint:errcheck
+			return AgentInfo{}, fmt.Errorf("cd to workdir: %w", err)
+		}
+	}
+
+	// Launch agent command.
+	if err := tmuxSendKeys(sessionName, command); err != nil {
+		exec.CommandContext(ctx, "tmux", "kill-session", "-t", sessionName).Run() //nolint:errcheck
+		return AgentInfo{}, fmt.Errorf("launch agent command: %w", err)
+	}
+
+	return AgentInfo{
+		Name:      spec.Name,
+		Space:     spec.Space,
+		Backend:   "tmux",
+		SessionID: sessionName,
+		StartedAt: time.Now().UTC(),
+	}, nil
+}
+
+// Stop kills the tmux session with the given name.
+func (b *TmuxBackend) Stop(ctx context.Context, space, name string) error {
+	if !tmuxSessionExists(name) {
+		return fmt.Errorf("tmux session %q not found", name)
+	}
+	if err := exec.CommandContext(ctx, "tmux", "kill-session", "-t", name).Run(); err != nil {
+		return fmt.Errorf("kill tmux session: %w", err)
+	}
+	return nil
+}
+
+// List returns AgentInfo for every active tmux session (not space-filtered, since
+// tmux sessions are global). Callers should filter by Name if needed.
+func (b *TmuxBackend) List(ctx context.Context, space string) ([]AgentInfo, error) {
+	sessions, err := tmuxListSessions()
+	if err != nil {
+		return nil, fmt.Errorf("list tmux sessions: %w", err)
+	}
+	out := make([]AgentInfo, 0, len(sessions))
+	for _, s := range sessions {
+		out = append(out, AgentInfo{
+			Name:      s,
+			Space:     space,
+			Backend:   "tmux",
+			SessionID: s,
+		})
+	}
+	return out, nil
+}
+
+// CloudBackend is a stub AgentBackend adapter for future cloud-based agent infrastructure.
+// All methods return ErrNotImplemented.
+type CloudBackend struct{}
+
+// Name returns "cloud".
+func (b *CloudBackend) Name() string { return "cloud" }
+
+// Spawn is not yet implemented for the cloud backend.
+func (b *CloudBackend) Spawn(ctx context.Context, spec AgentSpec) (AgentInfo, error) {
+	return AgentInfo{}, fmt.Errorf("cloud backend: %w", ErrNotImplemented)
+}
+
+// Stop is not yet implemented for the cloud backend.
+func (b *CloudBackend) Stop(ctx context.Context, space, name string) error {
+	return fmt.Errorf("cloud backend: %w", ErrNotImplemented)
+}
+
+// List is not yet implemented for the cloud backend.
+func (b *CloudBackend) List(ctx context.Context, space string) ([]AgentInfo, error) {
+	return nil, fmt.Errorf("cloud backend: %w", ErrNotImplemented)
+}
+
+// shellQuote wraps a string in single quotes, escaping any existing single quotes.
+// This is used to safely pass directory paths to the shell.
+func shellQuote(s string) string {
+	// Replace ' with '\'' (end quote, literal single quote, start quote).
+	out := "'"
+	for _, c := range s {
+		if c == '\'' {
+			out += "'\\''"
+		} else {
+			out += string(c)
+		}
+	}
+	out += "'"
+	return out
+}

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -1196,3 +1196,117 @@ func (s *Server) handleMessageAck(w http.ResponseWriter, r *http.Request, spaceN
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "acked", "message_id": msgID})
 }
+
+// createAgentRequest is the body for POST /spaces/{space}/agents.
+type createAgentRequest struct {
+	Name    string `json:"name"`
+	WorkDir string `json:"work_dir,omitempty"`
+	Command string `json:"command,omitempty"`
+	Backend string `json:"backend,omitempty"` // "tmux" (default) or "cloud"
+	Width   int    `json:"width,omitempty"`
+	Height  int    `json:"height,omitempty"`
+	Parent  string `json:"parent,omitempty"`
+	Role    string `json:"role,omitempty"`
+}
+
+// handleCreateAgents handles POST /spaces/{space}/agents.
+// It creates a new agent using the specified backend (default: tmux).
+func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spaceName string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req createAgentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		writeJSONError(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	backendName := req.Backend
+	if backendName == "" {
+		backendName = "tmux"
+	}
+
+	var backend AgentBackend
+	switch backendName {
+	case "tmux":
+		backend = &TmuxBackend{}
+	case "cloud":
+		backend = &CloudBackend{}
+	default:
+		writeJSONError(w, fmt.Sprintf("unknown backend %q; supported: tmux, cloud", backendName), http.StatusBadRequest)
+		return
+	}
+
+	spec := AgentSpec{
+		Name:    req.Name,
+		Space:   spaceName,
+		WorkDir: req.WorkDir,
+		Command: req.Command,
+		Width:   req.Width,
+		Height:  req.Height,
+		Parent:  req.Parent,
+		Role:    req.Role,
+	}
+
+	info, err := backend.Spawn(r.Context(), spec)
+	if err != nil {
+		writeJSONError(w, fmt.Sprintf("spawn: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Register the new agent in the space.
+	ks := s.getOrCreateSpace(spaceName)
+	s.mu.Lock()
+	agentKey := strings.ToLower(req.Name)
+	agent, exists := ks.Agents[agentKey]
+	if !exists {
+		agent = &AgentUpdate{
+			Status:    StatusIdle,
+			Summary:   fmt.Sprintf("%s: spawned via %s backend", req.Name, backendName),
+			UpdatedAt: time.Now().UTC(),
+		}
+		ks.Agents[agentKey] = agent
+	}
+	agent.TmuxSession = info.SessionID
+	if req.Parent != "" && agent.Parent == "" {
+		agent.Parent = strings.ToLower(req.Parent)
+		rebuildChildren(ks)
+	}
+	if req.Role != "" && agent.Role == "" {
+		agent.Role = req.Role
+	}
+	if err := s.saveSpace(ks); err != nil {
+		s.mu.Unlock()
+		writeJSONError(w, fmt.Sprintf("save: %v", err), http.StatusInternalServerError)
+		return
+	}
+	s.mu.Unlock()
+
+	s.logEvent(fmt.Sprintf("[%s/%s] created via %s backend (session: %s)", spaceName, req.Name, backendName, info.SessionID))
+	s.broadcastSSE(spaceName, req.Name, "agent_spawned", req.Name)
+
+	// Send ignite asynchronously after agent has time to initialize.
+	go func() {
+		time.Sleep(5 * time.Second)
+		igniteCmd := fmt.Sprintf(`/boss.ignite "%s" "%s"`, req.Name, spaceName)
+		if err := tmuxSendKeys(info.SessionID, igniteCmd); err != nil {
+			s.logEvent(fmt.Sprintf("[%s/%s] create: ignite send failed: %v", spaceName, req.Name, err))
+		}
+	}()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":      true,
+		"agent":   req.Name,
+		"backend": backendName,
+		"session": info.SessionID,
+		"space":   spaceName,
+	})
+}

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -176,6 +176,8 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 			rest = strings.TrimRight(strings.Join(parts[2:], "/"), "/")
 		}
 		s.handleSpaceTasks(w, r, spaceName, rest)
+	case "agents":
+		s.handleCreateAgents(w, r, spaceName)
 	case "hierarchy":
 		s.handleSpaceHierarchy(w, r, spaceName)
 	case "history":


### PR DESCRIPTION
## Summary

- **AgentBackend interface** (`agent_backend.go`): port with `Spawn`, `Stop`, `List` methods and `AgentSpec`/`AgentInfo` types
- **TmuxBackend adapter**: extracts and wraps existing tmux spawn logic; supports `workDir` (cd before starting claude)
- **CloudBackend stub**: returns `ErrNotImplemented` with clear message — makes future cloud extension obvious
- **`POST /spaces/{space}/agents`** endpoint: creates agent via chosen backend (`backend: "tmux" | "cloud"`), registers in space, sends ignite after 5s
- **`AgentCreateDialog.vue`**: name, working directory, backend selector (cloud grayed out with "soon" badge)
- **SpaceOverview**: "Add Agent" primary button in header; agent appears in list immediately via SSE on success

## Architecture

Hexagonal design: `AgentBackend` is the port; `TmuxBackend` and `CloudBackend` are adapters. New backends drop in without touching handler code.

## Test plan

- [x] `go test -race ./internal/coordinator/` — all 179 tests pass
- [x] Frontend builds clean (`npm run build`)
- [x] Go binary builds with embedded frontend
- [ ] Manual: click "Add Agent", fill name + workdir, click create → agent appears in list
- [ ] Manual: cloud backend shows as disabled in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)