### PR TITLE
fix(task-038): allow duplicate agent names across spaces

### DIFF
--- a/internal/coordinator/agent_backend.go
+++ b/internal/coordinator/agent_backend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -57,7 +58,7 @@ func (b *TmuxBackend) Name() string { return "tmux" }
 // Spawn creates a new detached tmux session, launches the agent command, and
 // sends the /boss.ignite prompt after initialization.
 func (b *TmuxBackend) Spawn(ctx context.Context, spec AgentSpec) (AgentInfo, error) {
-	sessionName := spec.Name
+	sessionName := tmuxDefaultSession(spec.Space, spec.Name)
 
 	command := spec.Command
 	if command == "" {
@@ -155,6 +156,29 @@ func (b *CloudBackend) Stop(ctx context.Context, space, name string) error {
 // List is not yet implemented for the cloud backend.
 func (b *CloudBackend) List(ctx context.Context, space string) ([]AgentInfo, error) {
 	return nil, fmt.Errorf("cloud backend: %w", ErrNotImplemented)
+}
+
+// tmuxDefaultSession generates a tmux-safe session name that is unique per space+agent pair.
+// Format: {sanitized-space}-{sanitized-agent}, replacing non-alphanumeric characters with hyphens.
+// This prevents tmux session name collisions when the same agent name is used in different spaces.
+func tmuxDefaultSession(spaceName, agentName string) string {
+	clean := func(s string) string {
+		var b strings.Builder
+		for _, r := range strings.ToLower(s) {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+				b.WriteRune(r)
+			} else {
+				b.WriteByte('-')
+			}
+		}
+		return strings.Trim(b.String(), "-")
+	}
+	sp := clean(spaceName)
+	ag := clean(agentName)
+	if sp == "" {
+		return ag
+	}
+	return sp + "-" + ag
 }
 
 // shellQuote wraps a string in single quotes, escaping any existing single quotes.

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -118,7 +118,7 @@ func (s *Server) handleAgentSpawn(w http.ResponseWriter, r *http.Request, spaceN
 
 	sessionName := req.TmuxSession
 	if sessionName == "" {
-		sessionName = agentName
+		sessionName = tmuxDefaultSession(spaceName, agentName)
 	}
 	command := req.Command
 	if command == "" {
@@ -353,11 +353,11 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 	agent.TmuxSession = ""
 	s.mu.Unlock()
 
-	// Spawn a new session using the canonical name as session name
-	newSession := canonical
+	// Spawn a new session using a space-scoped name to avoid cross-space collisions.
+	newSession := tmuxDefaultSession(spaceName, canonical)
 	if tmuxSessionExists(newSession) {
-		// Append -new suffix if canonical name is taken
-		newSession = canonical + "-new"
+		// Append -new suffix if the session name is already taken.
+		newSession = newSession + "-new"
 	}
 
 	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxCmdTimeout)


### PR DESCRIPTION
## Summary
- Root cause: `TmuxBackend.Spawn` used `spec.Name` as the tmux session name, causing collision when the same agent name was used in different spaces
- Fix: `tmuxDefaultSession(space, agent)` generates a space-scoped session name as `{sanitized-space}-{sanitized-agent}`
- Same fix applied to `handleAgentRestart` in `lifecycle.go`

## Details
Agents posting a status update (`POST /spaces/{space}/agent/{name}`) already worked correctly across spaces — the 500 error only occurred when spawning agents via `POST /spaces/{space}/agents` (the agent creation UI endpoint). Tmux session names are global and the previous code used only the agent name, so `DupAgent` in `Space1` and `DupAgent` in `Space2` both tried to create a session named `DupAgent`.

After this fix, the sessions are named `space1-dupagent` and `space2-dupagent`, allowing the same agent name to exist in multiple spaces.

## Test plan
- [ ] Spawn agent named `Foo` in space `Alpha` → session `alpha-foo` created
- [ ] Spawn agent named `Foo` in space `Beta` → session `beta-foo` created (no 500)
- [ ] Existing agents with manually-set `tmux_session` values are unaffected (only the default changes)
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)