### PR TITLE
docs: add SessionBackend abstraction design specs

### DIFF
--- a/.spec/SessionBackends/00-overview.md
+++ b/.spec/SessionBackends/00-overview.md
@@ -8,6 +8,7 @@
 | [02-session-backend-interface.md](02-session-backend-interface.md) | `SessionBackend` interface, data model changes, migration plan |
 | [03-tmux-backend.md](03-tmux-backend.md) | `TmuxSessionBackend` implementation, method mapping, file layout |
 | [04-ambient-backend.md](04-ambient-backend.md) | `AmbientSessionBackend` implementation, API mapping, behavioral differences |
+| [05-agentcore-feasibility.md](05-agentcore-feasibility.md) | AWS Bedrock AgentCore feasibility analysis |
 
 ## Summary
 
@@ -15,10 +16,11 @@
 
 - **tmux hardcoded everywhere**: 10+ functions in `tmux.go`, called directly from lifecycle
   handlers, liveness loop, broadcast, introspect, approve, and reply.
-- **Nascent `AgentBackend` interface** in `agent_backend.go` with `Spawn/Stop/List/Name`. Only
-  used by `handleCreateAgents`. All other code bypasses it.
+- **`AgentBackend` interface** in `agent_backend.go` (PR #47) with `Spawn/Stop/List/Name`.
+  Only used by `handleCreateAgents`. All other code bypasses it.
 - **`AgentUpdate.TmuxSession`** is the field that links an agent to its session. Used across
   types, DB models, handlers, frontend, scripts, and docs.
+- **`tmuxDefaultSession`** (PR #49, open) proposes space-scoped names `{space}-{agent}` — not adopted here.
 
 ### What this design introduces
 
@@ -27,15 +29,24 @@
   `ListSessions`), status (`GetStatus`), observability (`IsIdle`, `CaptureOutput`,
   `CheckApproval`), interaction (`SendInput`, `Approve`, `Interrupt`), and discovery
   (`DiscoverSessions`).
-- **`TmuxSessionBackend`** — pure wrapper around existing tmux functions. Zero behavior change.
+- **Role interfaces** (`SessionLifecycle`, `SessionObserver`, `SessionActor`) for
+  narrow consumer dependencies and easier testing.
+- **`TmuxSessionBackend`** — wraps existing tmux functions. Preserves current
+  `agentdeck_*` naming convention. Zero behavior change.
 - **`AmbientSessionBackend`** — backed by the ACP public API (`POST /sessions`,
-  `POST /message`, `GET /output`, `POST /stop`, `POST /interrupt`, etc.).
-- **`AgentUpdate.SessionID`** + **`AgentUpdate.BackendType`** — replaces `TmuxSession` with
-  backend-agnostic fields. Backward-compatible JSON unmarshaling for old `tmux_session` payloads.
-- **`Server.backends`** registry — map of backend name to implementation. Agents carry their
-  backend type; the server resolves the right implementation per-agent.
+  `POST /message`, `GET /output`, `DELETE /sessions/{id}`, `POST /interrupt`, etc.).
+  Depends on platform PR #855.
+- **Subsumes `AgentBackend`** — the existing interface from PR #47 is folded into
+  `SessionBackend`. `agent_backend.go` is deleted.
+- **`AgentUpdate.SessionID`** + **`AgentUpdate.BackendType`** — replaces `TmuxSession`
+  with backend-agnostic fields. No backward-compat shim (clean break).
+- **`Server.backends`** registry — map of backend name to implementation. Agents carry
+  their backend type; the server resolves the right implementation per-agent.
 - **`SessionStatus`** enum — unified status model (`unknown`, `pending`, `running`, `idle`,
-  `completed`, `failed`, `missing`) that both backends map into.
+  `completed`, `failed`, `missing`) that all backends map into.
+- **`BackendOpts interface{}`** — backend-specific creation options. Each backend defines
+  its own options struct (`TmuxCreateOpts`, `AmbientCreateOpts`), keeping backend-specific
+  code contained within each backend.
 
 ### Interface at a glance
 
@@ -69,7 +80,7 @@ type SessionBackend interface {
 |------|---------------|-----------------|
 | Interface definition | New: `session_backend.go` | New file |
 | Tmux backend | New: `session_backend_tmux.go` | Wraps existing functions |
-| Old backend | Delete: `agent_backend.go` | Superseded |
+| Old backend | Delete: `agent_backend.go` | Superseded (folded into SessionBackend) |
 | Tmux primitives | `tmux.go` | Unchanged (kept as unexported helpers) |
 | Data model | `types.go`, `db/models.go`, `db/convert.go`, `db_adapter.go` | Rename `TmuxSession` -> `SessionID`, add `BackendType` |
 | Server | `server.go` | Add `backends` map, `backendFor()` helper |
@@ -79,3 +90,13 @@ type SessionBackend interface {
 | Broadcast | `tmux.go` (orchestration funcs) | Route through backend |
 | Frontend | `types/index.ts`, `AgentDetail.vue`, `client.ts` | Rename `tmux_session` -> `session_id` |
 | Tests | `server_test.go`, `hierarchy_test.go`, `lifecycle_test.go` | Update field names, add mock backend tests |
+
+### Known gaps (deferred)
+
+| Gap | Notes |
+|-----|-------|
+| Context/tool injection for Ambient | Ambient sessions don't inherit local boss commands. Needs workflow or MCP server approach. Deferred to Phase 2. |
+| Cross-space session name collisions | Current `agentdeck_*` naming doesn't include space. Same agent name in two spaces can collide. PR #49 proposes a fix but is out of scope here. |
+| Session ownership/filtering | `tmuxListSessions` returns all sessions, not just agent-boss. Mitigated by naming convention but not solved. |
+| Idle detection brittleness | `isShellPrompt` relies on PS1 heuristics. Claude Code hooks would be cleaner. |
+| Model switching compaction risk | Switching from opus to haiku with large context triggers compaction. Needs separate evaluation. |

--- a/.spec/SessionBackends/01-tmux-audit.md
+++ b/.spec/SessionBackends/01-tmux-audit.md
@@ -7,7 +7,7 @@ Every place in the codebase that directly touches tmux, categorized by purpose.
 | Function | What it does | Called by |
 |----------|-------------|-----------|
 | `tmuxAvailable()` | Checks if `tmux` binary is in PATH | `TmuxAutoDiscover`, `BroadcastCheckIn`, `SingleAgentCheckIn`, `checkAllSessionLiveness` |
-| `tmuxListSessions()` | Runs `tmux list-sessions -F #S` | `tmuxSessionExists`, `TmuxAutoDiscover` |
+| `tmuxListSessions()` | Runs `tmux list-sessions -F #S`. **Note:** returns ALL tmux sessions on the machine, not just agent-boss sessions. Needs filtering/tagging mechanism (see §Session Ownership below). | `tmuxSessionExists`, `TmuxAutoDiscover` |
 | `tmuxSessionExists(session)` | Checks if a named session is in the list | `handleAgentSpawn`, `handleAgentStop`, `handleAgentRestart`, `handleAgentIntrospect`, `BroadcastCheckIn`, `handleApproveAgent`, `handleReplyAgent`, `handleSpaceTmuxStatus`, `TmuxBackend.Spawn`, `TmuxBackend.Stop`, `checkAllSessionLiveness` |
 | `tmuxCapturePaneLines(session, n)` | Runs `tmux capture-pane -t session -p`, returns last N non-empty lines | `tmuxIsIdle`, `tmuxCheckApproval`, `handleAgentIntrospect`, `handleSpaceTmuxStatus` |
 | `tmuxCapturePaneLastLine(session)` | Wrapper: captures last 1 line | `handleSpaceTmuxStatus` |
@@ -22,7 +22,7 @@ Every place in the codebase that directly touches tmux, categorized by purpose.
 | Function | What it does |
 |----------|-------------|
 | `lineIsIdleIndicator(line)` | Returns true if a line matches known idle patterns: `>`, shell `$`/`%`/`#`, Claude Code hints, status bars |
-| `isShellPrompt(line)` | Detects `$`, `%`, `>`, `#`, `>` as trailing prompt characters |
+| `isShellPrompt(line)` | Detects `$`, `%`, `>`, `#` as trailing prompt characters. **Brittle:** assumes PS1 follows convention. A cleaner approach would be using [Claude Code hooks](https://code.claude.com/docs/en/hooks) to emit structured idle/busy signals instead of parsing terminal output. |
 | `waitForIdle(session, timeout)` | Polls `tmuxIsIdle` every 3s until idle or timeout |
 | `waitForBoardPost(space, agent, since, timeout)` | Polls `agentUpdatedAt` every 3s (not tmux-specific, but used exclusively by broadcast which is tmux-only) |
 
@@ -108,3 +108,22 @@ Every place in the codebase that directly touches tmux, categorized by purpose.
 | `docs/lifecycle-spec.md` | Spawn/stop/restart reference `tmux_session` |
 | `docs/api-reference.md` | API docs reference `tmux_session` |
 | `docs/hierarchy-design.md` | Compares parent stickiness to `TmuxSession` |
+
+## Session Ownership
+
+`tmuxListSessions()` returns ALL tmux sessions on the machine — not just those
+created by agent-boss. This means discovery and liveness can incorrectly interact
+with unrelated sessions.
+
+Currently, agent-boss sessions are identified by naming convention only:
+- Legacy: `agentdeck_{name}_{timestamp}` (parsed by `parseTmuxAgentName`)
+- PR #49: `{space}-{agent}` (parsed by space prefix matching)
+
+Neither convention provides a strong ownership guarantee. Options for improvement:
+- **tmux environment variable**: set `@agent_boss=true` on sessions at creation,
+  filter by it during listing
+- **Dedicated tmux server**: use `tmux -L agent-boss` to isolate sessions entirely
+- **Prefix convention**: require a fixed prefix (e.g., `ab-{space}-{agent}`) that
+  is unlikely to collide with user sessions
+
+This is out of scope for the current refactoring but should be addressed.

--- a/.spec/SessionBackends/02-session-backend-interface.md
+++ b/.spec/SessionBackends/02-session-backend-interface.md
@@ -13,17 +13,20 @@ without forking the entire coordinator.
 ## Design Goals
 
 1. **Single interface** that covers the full lifecycle: create, destroy, observe, interact
-2. **Drop-in tmux implementation** that wraps existing functions with zero behavior change
-3. **Ambient backend** implementable against the ACP public API
-4. **Per-agent backend selection** — agents in the same space can use different backends
-5. **Backward compatible** — existing `TmuxSession` field, ignition `?tmux_session=` param, and
-   all API responses continue to work
+2. **Subsume `AgentBackend`** — the new `SessionBackend` replaces the existing `AgentBackend`
+   interface from PR #47. `AgentBackend.Spawn` maps to `CreateSession`, `Stop` maps to
+   `KillSession`, `List` maps to `ListSessions`, `Name` maps to `Name`.
+3. **Drop-in tmux implementation** that wraps existing functions with zero behavior change
+4. **Ambient backend** implementable against the ACP public API
+5. **Per-agent backend selection** — agents in the same space can use different backends
 
 ## Non-Goals
 
 - Changing the agent protocol (blackboard, messages, tasks, SSE)
 - Modifying the frontend beyond renaming JSON fields
 - Implementing the Ambient backend in this design doc (separate spec)
+- Backward compatibility with `tmux_session` JSON field or `?tmux_session=` query param
+  (no production agents running — clean break)
 
 ---
 
@@ -34,6 +37,9 @@ without forking the entire coordinator.
 // Each backend (tmux, ambient, etc.) implements this interface.
 // The coordinator routes operations through it instead of calling
 // tmux functions directly.
+//
+// This replaces the existing AgentBackend interface (Spawn/Stop/List/Name)
+// with full lifecycle coverage.
 type SessionBackend interface {
     // --- Identity ---
 
@@ -53,9 +59,9 @@ type SessionBackend interface {
     // For ambient: calls POST /sessions with the command as the task.
     CreateSession(ctx context.Context, opts SessionCreateOpts) (string, error)
 
-    // KillSession stops/destroys a session by ID.
+    // KillSession permanently destroys a session by ID.
     // For tmux: kills the tmux session (gone forever).
-    // For ambient: calls POST /sessions/{id}/stop (session data preserved).
+    // For ambient: calls DELETE /sessions/{id} (permanent removal).
     KillSession(ctx context.Context, sessionID string) error
 
     // SessionExists checks whether a session with the given ID is alive.
@@ -107,8 +113,10 @@ type SessionBackend interface {
 
     // Interrupt cancels the session's current work without killing it.
     // The session remains alive and can accept new messages.
-    // For tmux: sends Ctrl-C (C-c) to the session.
+    // For tmux: sends Escape key to interrupt Claude Code.
     // For ambient: calls POST /sessions/{id}/interrupt.
+    // Note: this is a new capability — no equivalent exists in the
+    // current codebase. Claude Code uses Escape (not Ctrl-C) to interrupt.
     Interrupt(ctx context.Context, sessionID string) error
 
     // --- Discovery ---
@@ -122,7 +130,47 @@ type SessionBackend interface {
 }
 ```
 
-**Method count: 13** (was 11 in the initial draft; +`GetStatus`, +`Interrupt`)
+**Method count: 13** — maps 1:1 from the existing `AgentBackend` (4 methods) plus the 9
+additional operations that are currently hardcoded as direct tmux calls.
+
+### Role Interfaces
+
+The 13-method interface is large. Backends that don't support certain roles (e.g.,
+Ambient has no approval flow) must implement no-op methods. To support smaller
+consumers and cleaner testing, the interface is decomposable into role interfaces:
+
+```go
+// SessionLifecycle covers session creation and destruction.
+type SessionLifecycle interface {
+    CreateSession(ctx context.Context, opts SessionCreateOpts) (string, error)
+    KillSession(ctx context.Context, sessionID string) error
+    SessionExists(sessionID string) bool
+    ListSessions() ([]string, error)
+}
+
+// SessionObserver covers session status and observability.
+type SessionObserver interface {
+    GetStatus(ctx context.Context, sessionID string) (SessionStatus, error)
+    IsIdle(sessionID string) bool
+    CaptureOutput(sessionID string, lines int) ([]string, error)
+    CheckApproval(sessionID string) ApprovalInfo
+}
+
+// SessionActor covers session interaction.
+type SessionActor interface {
+    SendInput(sessionID string, text string) error
+    Approve(sessionID string) error
+    Interrupt(ctx context.Context, sessionID string) error
+}
+```
+
+`SessionBackend` embeds all three plus identity and discovery. Smaller consumers
+(e.g., the liveness loop only needs `SessionObserver`) can depend on the narrow
+interface. This makes testing easier — mock only the role you're testing.
+
+**Implementation note:** All backends still implement the full `SessionBackend`.
+The role interfaces are for *consumers*, not *providers*. Go's structural typing
+means any `SessionBackend` automatically satisfies all three role interfaces.
 
 ### Supporting Types
 
@@ -140,19 +188,23 @@ const (
     SessionStatusMissing   SessionStatus = "missing"    // session does not exist
 )
 
-// SessionCreateOpts holds parameters for creating a new session.
-// Each backend uses the fields relevant to it and ignores the rest.
+// SessionCreateOpts holds common parameters for creating a new session.
+// Backend-specific options are passed via the BackendOpts field.
 type SessionCreateOpts struct {
-    // Common
-    SessionID string // desired session name/ID (backend may adjust)
-    Command   string // tmux: shell command to run; ambient: initial task/prompt
+    SessionID string      // desired session name/ID (backend may adjust)
+    Command   string      // tmux: shell command to run; ambient: initial task/prompt
+    BackendOpts interface{} // backend-specific options (TmuxCreateOpts, AmbientCreateOpts, etc.)
+}
 
-    // Tmux-specific (ignored by ambient)
+// TmuxCreateOpts holds tmux-specific session creation options.
+type TmuxCreateOpts struct {
     WorkDir string // working directory to cd into before launching
     Width   int    // terminal width (default 220)
     Height  int    // terminal height (default 50)
+}
 
-    // Ambient-specific (ignored by tmux)
+// AmbientCreateOpts holds Ambient-specific session creation options.
+type AmbientCreateOpts struct {
     DisplayName string        // human-readable session name
     Model       string        // Claude model to use
     Repos       []SessionRepo // repositories to clone into the session
@@ -193,28 +245,8 @@ SessionID   string `json:"session_id,omitempty"`
 BackendType string `json:"backend_type,omitempty"` // "tmux", "ambient", etc.
 ```
 
-**Backward compatibility:** The JSON tag changes from `tmux_session` to `session_id`. Since agents
-POST status updates and the server preserves `SessionID` as a sticky field, old agents sending
-`tmux_session` will need a migration shim in the JSON unmarshaler:
-
-```go
-func (u *AgentUpdate) UnmarshalJSON(data []byte) error {
-    type Alias AgentUpdate
-    aux := &struct {
-        TmuxSession string `json:"tmux_session,omitempty"`
-        *Alias
-    }{Alias: (*Alias)(u)}
-    if err := json.Unmarshal(data, aux); err != nil {
-        return err
-    }
-    // Backward compat: accept tmux_session if session_id is empty
-    if u.SessionID == "" && aux.TmuxSession != "" {
-        u.SessionID = aux.TmuxSession
-        u.BackendType = "tmux"
-    }
-    return nil
-}
-```
+**No backward compatibility shim.** No production agents are running. This is a clean
+break — all references to `tmux_session` are updated in a single pass.
 
 ### DB schema
 
@@ -230,10 +262,11 @@ func (u *AgentUpdate) UnmarshalJSON(data []byte) error {
 -- Before:
 GET /spaces/{space}/ignition/{agent}?tmux_session=X
 
--- After (both accepted, old one triggers compat path):
+-- After:
 GET /spaces/{space}/ignition/{agent}?session_id=X&backend=tmux
-GET /spaces/{space}/ignition/{agent}?tmux_session=X  (compat: sets session_id=X, backend=tmux)
 ```
+
+Old `?tmux_session=` param is removed. No compat path.
 
 ---
 
@@ -280,6 +313,46 @@ func (s *Server) backendFor(agent *AgentUpdate) SessionBackend {
 
 ---
 
+## Reconciliation with `AgentBackend` (PR #47)
+
+The existing `AgentBackend` interface from PR #47 is **folded into** `SessionBackend`.
+`agent_backend.go` is deleted, and all callers are migrated.
+
+| `AgentBackend` method | `SessionBackend` equivalent | Notes |
+|----------------------|---------------------------|-------|
+| `Name()` | `Name()` | Identical |
+| `Spawn(ctx, spec)` | `CreateSession(ctx, opts)` | `AgentSpec` fields map to `SessionCreateOpts` + `TmuxCreateOpts` |
+| `Stop(ctx, space, name)` | `KillSession(ctx, sessionID)` | Callers must resolve the session ID first |
+| `List(ctx, space)` | `ListSessions()` | Backend returns all sessions; caller filters by space |
+
+### `AgentSpec` -> `SessionCreateOpts` mapping
+
+```go
+// AgentSpec (PR #47):
+type AgentSpec struct {
+    Space, Name, Command, WorkDir string
+    Width, Height int
+}
+
+// Becomes:
+opts := SessionCreateOpts{
+    SessionID:   spec.Name,
+    Command:     spec.Command,
+    BackendOpts: TmuxCreateOpts{
+        WorkDir: spec.WorkDir,
+        Width:   spec.Width,
+        Height:  spec.Height,
+    },
+}
+```
+
+### `handleCreateAgents` migration
+
+This is the only consumer of `AgentBackend`. It currently calls `s.backend.Spawn(ctx, spec)`.
+After migration, it calls `s.backendFor(agent).CreateSession(ctx, opts)`.
+
+---
+
 ## Migration Plan: Which Code Changes
 
 ### Phase 1: Interface + TmuxBackend (this PR)
@@ -287,21 +360,61 @@ func (s *Server) backendFor(agent *AgentUpdate) SessionBackend {
 | Current code | Change |
 |-------------|--------|
 | `tmux.go` top-level functions | Keep as-is. `TmuxSessionBackend` delegates to them. |
-| `agent_backend.go` | Replace `AgentBackend` with `SessionBackend`. Remove `TmuxBackend`/`CloudBackend` (superseded). |
+| `agent_backend.go` | Delete entirely. `AgentBackend`, `TmuxBackend`, `CloudBackend`, `AgentSpec`, `AgentInfo` all superseded. `tmuxDefaultSession` and `shellQuote` move to `session_backend_tmux.go`. |
 | `lifecycle.go` handlers | Route through `s.backendFor(agent)` instead of calling tmux directly |
 | `liveness.go` loop | Route through backend instead of calling tmux directly |
 | `handlers_agent.go` approve/reply/introspect/tmux-status | Route through backend |
+| `handlers_agent.go` `handleCreateAgents` | Replace `s.backend.Spawn` with `s.backendFor(agent).CreateSession` |
 | `tmux.go` broadcast/check-in | Route through backend for sendkeys/idle/approve |
 | `types.go` `AgentUpdate` | Rename `TmuxSession` -> `SessionID`, add `BackendType` |
 | `db/models.go` | Rename column |
 | `db/convert.go` | Update field mappings |
-| `handlers_agent.go` ignition | Accept both `?session_id=` and `?tmux_session=` |
+| `handlers_agent.go` ignition | Replace `?tmux_session=` with `?session_id=&backend=` |
 | `server.go` | Add `backends` map, initialize with tmux backend |
 | Frontend types | Rename `tmux_session` -> `session_id` |
 
 ### Phase 2: Ambient Backend (follow-up PR)
 
 Implement `AmbientSessionBackend` using ACP public API. Separate spec.
+
+---
+
+## Migration Sequencing
+
+The rename and refactoring must be done in a specific order to avoid breaking
+the build at any intermediate step:
+
+```
+Step 1: Add new files
+  - session_backend.go (interface, types)
+  - session_backend_tmux.go (TmuxSessionBackend)
+  Both compile independently. Existing code unchanged.
+
+Step 2: Add backend registry to Server
+  - server.go: add backends map, defaultBackend, backendFor()
+  - Initialize with TmuxSessionBackend in NewServer()
+  Existing code still works — backends is additive.
+
+Step 3: Migrate handlers one at a time
+  - Each handler switches from direct tmux calls to s.backendFor(agent)
+  - Do this file-by-file: lifecycle.go, liveness.go, handlers_agent.go, tmux.go (broadcast)
+  - Each file is independently testable after migration.
+
+Step 4: Rename data model fields
+  - types.go: TmuxSession -> SessionID, add BackendType
+  - db/models.go, db/convert.go, db_adapter.go: rename column
+  - handlers_agent.go: update ignition query param
+  - Frontend: update types and components
+  This is the "big bang" step — do it all at once since field
+  names are referenced across the stack.
+
+Step 5: Delete old code
+  - Delete agent_backend.go
+  - Remove any remaining direct tmux calls from handlers
+  - Remove isNonTmuxAgent / nonTmuxLifecycleError helpers
+```
+
+Each step produces a compilable, testable codebase.
 
 ---
 
@@ -316,7 +429,7 @@ Before:
   tmuxSendKeys(session, igniteCmd)
 
 After:
-  backend := s.backends["tmux"]  // or from request
+  backend := s.backendFor(agent)  // or from request
   sessionID, err := backend.CreateSession(ctx, opts)
   backend.SendInput(sessionID, igniteCmd)
 ```
@@ -403,7 +516,7 @@ After:
 
 ### `handleSpaceTmuxStatus` -> generalize to `handleSpaceSessionStatus`
 
-Rename route from `/api/tmux-status` to `/api/session-status` (keep `/api/tmux-status` as alias).
+Rename route from `/api/tmux-status` to `/api/session-status`.
 Response struct rename `tmuxAgentStatus` -> `agentSessionStatus`.
 
 ### `BroadcastCheckIn` / `SingleAgentCheckIn` -> route through backend
@@ -444,30 +557,18 @@ After:
 ### `/api/tmux-status` -> `/api/session-status`
 
 ```json
-// Before:
-{ "agent": "FE", "session": "agentdeck_FE_1", "registered": true, "exists": true, "idle": false, "needs_approval": true }
-
-// After:
-{ "agent": "FE", "session_id": "agentdeck_FE_1", "backend": "tmux", "registered": true, "exists": true, "idle": false, "needs_approval": true }
+{ "agent": "FE", "session_id": "myspace-FE", "backend": "tmux", "registered": true, "exists": true, "idle": false, "needs_approval": true }
 ```
 
 ### Agent JSON
 
 ```json
-// Before:
-{ "status": "active", "tmux_session": "FE", ... }
-
-// After:
 { "status": "active", "session_id": "FE", "backend_type": "tmux", ... }
 ```
 
 ### Spawn/restart responses
 
 ```json
-// Before:
-{ "ok": true, "tmux_session": "FE" }
-
-// After:
 { "ok": true, "session_id": "FE", "backend": "tmux" }
 ```
 
@@ -477,8 +578,7 @@ After:
 
 ### `tmux_liveness` -> `session_liveness`
 
-Keep `tmux_liveness` as an alias for one release cycle. The payload changes from
-`"session": "X"` to `"session_id": "X"` with a new `"backend": "tmux"` field.
+Rename the event type. No alias — clean break.
 
 ---
 
@@ -487,4 +587,4 @@ Keep `tmux_liveness` as an alias for one release cycle. The payload changes from
 1. **All existing tests pass** after refactoring (behavior-preserving)
 2. **New unit tests** for `TmuxSessionBackend` implementing `SessionBackend`
 3. **Mock backend** for integration tests that don't require tmux
-4. **Backward compat tests** for `tmux_session` JSON field and `?tmux_session=` query param
+4. **Role interface tests** — verify backends satisfy `SessionObserver`, etc.

--- a/.spec/SessionBackends/03-tmux-backend.md
+++ b/.spec/SessionBackends/03-tmux-backend.md
@@ -16,7 +16,8 @@ type TmuxSessionBackend struct {
 
 ## Method Mapping
 
-Every method delegates to an existing function from `tmux.go`. No new tmux logic is introduced.
+Every method delegates to an existing function from `tmux.go`. No new tmux logic is introduced
+except `GetStatus` (composite of existing checks) and `Interrupt` (new: sends Escape key).
 
 | SessionBackend method | Delegates to | Notes |
 |----------------------|-------------|-------|
@@ -26,12 +27,34 @@ Every method delegates to an existing function from `tmux.go`. No new tmux logic
 | `KillSession(ctx, id)` | `exec.Command("tmux", "kill-session", ...)` | Extracted from `handleAgentStop` |
 | `SessionExists(id)` | `tmuxSessionExists(id)` | Unchanged |
 | `ListSessions()` | `tmuxListSessions()` | Unchanged |
+| `GetStatus(ctx, id)` | `tmuxSessionExists` + `tmuxIsIdle` | New composite: missing/idle/running/unknown |
 | `IsIdle(id)` | `tmuxIsIdle(id)` | Unchanged — all idle detection logic preserved |
 | `CaptureOutput(id, n)` | `tmuxCapturePaneLines(id, n)` | Unchanged |
 | `CheckApproval(id)` | `tmuxCheckApproval(id)` | Returns exported `ApprovalInfo` instead of `approvalInfo` |
 | `SendInput(id, text)` | `tmuxSendKeys(id, text)` | Unchanged |
 | `Approve(id)` | `tmuxApprove(id)` | Unchanged |
-| `DiscoverSessions()` | `tmuxListSessions()` + `parseTmuxAgentName()` | Returns `map[agentName]sessionID` |
+| `Interrupt(ctx, id)` | `tmux send-keys -t id Escape` | New: sends Escape key (Claude Code interrupt). Not Ctrl-C. |
+| `DiscoverSessions()` | `tmuxListSessions()` + `parseTmuxAgentName()` | Returns `map[agentName]sessionID` using existing `agentdeck_*` naming |
+
+## Session Naming
+
+Session naming is **unchanged** from the current codebase. Sessions use the
+`agentdeck_{name}_{timestamp}` convention, parsed by `parseTmuxAgentName()`.
+
+### Known issue: cross-space collisions
+
+The current naming convention does not include the space name. If the same agent
+name (e.g., "FE") exists in two spaces, their sessions could collide. PR #49
+(open) proposes `tmuxDefaultSession(space, agent)` → `{space}-{agent}` to fix
+this, but that change is **out of scope** for this refactoring.
+
+This must be resolved before multi-space deployments are common. Options include:
+- Adopt PR #49's `{space}-{agent}` convention
+- Use `agentdeck_{space}_{agent}_{timestamp}` to preserve backward compat with discovery
+- Add `Space` to `SessionCreateOpts` so the backend can incorporate it
+
+When the naming convention does change, `DiscoverSessions()` and
+`parseTmuxAgentName()` will need corresponding updates.
 
 ## Implementation
 
@@ -60,11 +83,19 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
         return "", fmt.Errorf("tmux session %q already exists", sessionID)
     }
 
-    width := opts.Width
+    // Extract tmux-specific options
+    var tmuxOpts TmuxCreateOpts
+    if opts.BackendOpts != nil {
+        if to, ok := opts.BackendOpts.(TmuxCreateOpts); ok {
+            tmuxOpts = to
+        }
+    }
+
+    width := tmuxOpts.Width
     if width <= 0 {
         width = 220
     }
-    height := opts.Height
+    height := tmuxOpts.Height
     if height <= 0 {
         height = 50
     }
@@ -77,9 +108,9 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
     }
 
     // cd to work dir if specified
-    if opts.WorkDir != "" {
+    if tmuxOpts.WorkDir != "" {
         time.Sleep(300 * time.Millisecond)
-        if err := tmuxSendKeys(sessionID, "cd "+shellQuote(opts.WorkDir)); err != nil {
+        if err := tmuxSendKeys(sessionID, "cd "+shellQuote(tmuxOpts.WorkDir)); err != nil {
             exec.CommandContext(ctx, "tmux", "kill-session", "-t", sessionID).Run()
             return "", fmt.Errorf("cd to workdir: %w", err)
         }
@@ -111,6 +142,19 @@ func (b *TmuxSessionBackend) ListSessions() ([]string, error) {
     return tmuxListSessions()
 }
 
+func (b *TmuxSessionBackend) GetStatus(ctx context.Context, sessionID string) (SessionStatus, error) {
+    if !b.Available() {
+        return SessionStatusUnknown, nil
+    }
+    if !tmuxSessionExists(sessionID) {
+        return SessionStatusMissing, nil
+    }
+    if tmuxIsIdle(sessionID) {
+        return SessionStatusIdle, nil
+    }
+    return SessionStatusRunning, nil
+}
+
 func (b *TmuxSessionBackend) IsIdle(sessionID string) bool {
     return tmuxIsIdle(sessionID)
 }
@@ -130,6 +174,13 @@ func (b *TmuxSessionBackend) SendInput(sessionID string, text string) error {
 
 func (b *TmuxSessionBackend) Approve(sessionID string) error {
     return tmuxApprove(sessionID)
+}
+
+func (b *TmuxSessionBackend) Interrupt(ctx context.Context, sessionID string) error {
+    // Claude Code uses Escape to interrupt, not Ctrl-C.
+    interruptCtx, cancel := context.WithTimeout(ctx, tmuxCmdTimeout)
+    defer cancel()
+    return exec.CommandContext(interruptCtx, "tmux", "send-keys", "-t", sessionID, "Escape").Run()
 }
 
 func (b *TmuxSessionBackend) DiscoverSessions() (map[string]string, error) {
@@ -167,12 +218,23 @@ The low-level functions remain in `tmux.go` as unexported helpers:
 - `tmuxCapturePaneLastLine(session)` — only used by tmux-status handler, can stay
 - `tmuxIsIdle(session)`
 - `lineIsIdleIndicator(line)` — pure function, stays
-- `isShellPrompt(line)` — pure function, stays
+- `isShellPrompt(line)` — pure function, stays (see idle detection note below)
 - `tmuxCheckApproval(session)`
 - `tmuxApprove(session)`
 - `tmuxSendKeys(session, text)`
 - `parseTmuxAgentName(session)` — used by DiscoverSessions
 - `shellQuote(s)` — used by CreateSession
+
+### Idle detection brittleness
+
+`isShellPrompt` and `lineIsIdleIndicator` rely on heuristic terminal output
+matching (checking for `$`, `%`, `>`, `#` as prompt characters). This is
+inherently fragile — non-standard PS1 configurations will break it.
+
+A cleaner approach for future work would be to use
+[Claude Code hooks](https://code.claude.com/docs/en/hooks) to emit structured
+idle/busy signals instead of parsing terminal output. This is out of scope for
+the current refactoring but noted as a known limitation.
 
 ## What moves out of `tmux.go`
 
@@ -196,16 +258,31 @@ They move to the coordinator layer and use the `SessionBackend` interface:
 | `agent_backend.go` `AgentBackend` interface | Superseded by `SessionBackend` |
 | `agent_backend.go` `TmuxBackend` struct | Superseded by `TmuxSessionBackend` |
 | `agent_backend.go` `CloudBackend` struct | Superseded by future `AmbientSessionBackend` |
-| `agent_backend.go` `AgentSpec` struct | Replaced by `SessionCreateOpts` |
+| `agent_backend.go` `AgentSpec` struct | Replaced by `SessionCreateOpts` + `TmuxCreateOpts` |
 | `agent_backend.go` `AgentInfo` struct | No longer needed; `SessionID` + `BackendType` on agent record |
+| `agent_backend.go` `tmuxDefaultSession` | Out of scope for this refactoring (PR #49 concern) |
+| `agent_backend.go` `shellQuote` | Moves to `session_backend_tmux.go` |
 | `tmuxSessionAliases` global var | Moves into `TmuxSessionBackend.sessionAliases` field |
+
+## Session Ownership / Filtering
+
+Currently `tmuxListSessions()` returns ALL tmux sessions on the machine, not just
+agent-boss sessions. This is a pre-existing issue that the refactoring preserves
+but does not fix.
+
+Sessions are identified by naming convention only (`agentdeck_{name}_{timestamp}`).
+For stronger ownership guarantees, a future enhancement could:
+- Tag sessions with a tmux environment variable (e.g., `@agent_boss=true`)
+- Use a dedicated tmux server socket (`tmux -L agent-boss`)
+
+This is out of scope for the current refactoring.
 
 ## File Layout After Refactoring
 
 ```
 internal/coordinator/
-  session_backend.go         # SessionBackend interface, SessionCreateOpts, ApprovalInfo
-  session_backend_tmux.go    # TmuxSessionBackend implementation
+  session_backend.go         # SessionBackend interface, SessionCreateOpts, ApprovalInfo, role interfaces
+  session_backend_tmux.go    # TmuxSessionBackend implementation + shellQuote
   tmux.go                    # Low-level tmux primitives (unchanged, unexported)
   # agent_backend.go         # DELETED (superseded)
 ```

--- a/.spec/SessionBackends/04-ambient-backend.md
+++ b/.spec/SessionBackends/04-ambient-backend.md
@@ -2,6 +2,9 @@
 
 Implementation of `SessionBackend` backed by the Ambient Code Platform public API.
 
+**Dependency:** Requires [platform PR #855](https://github.com/ambient-code/platform/pull/855)
+to be merged. Assumes no major changes to the OpenAPI spec.
+
 ## Ambient Public API Summary
 
 | Endpoint | Method | Purpose |
@@ -37,12 +40,53 @@ The two backends have fundamentally different interaction models:
 | "Send input" | `tmux send-keys` text + Enter | `POST /sessions/{id}/message` |
 | "Approval check" | Parse terminal for "Do you want...?" | Not applicable (sessions run with configured permissions). Returns `NeedsApproval: false`. |
 | "Approve" | `tmux send-keys Enter` | Not applicable. No-op. |
-| "Kill" | `tmux kill-session` (gone forever) | `POST /sessions/{id}/stop` (session data preserved) |
+| "Kill" (permanent) | `tmux kill-session` (gone forever) | `DELETE /sessions/{id}` (permanent removal) |
+| "Stop" (preserve) | Not available | `POST /sessions/{id}/stop` (pod terminated, session data preserved) |
 | "Create" | `tmux new-session -d -s name` | `POST /sessions` (async pod creation) |
 | "Discovery" | Parse `agentdeck_*` session names | List sessions, match by `display_name` convention |
-| "Interrupt" | `tmux send-keys C-c` | `POST /sessions/{id}/interrupt` |
+| "Interrupt" | `tmux send-keys Escape` | `POST /sessions/{id}/interrupt` |
 | "Status" | Inferred from existence + idle + approval | Explicit: pending/running/completed/failed |
 | "Resume" | Not possible (create new session) | `POST /sessions/{id}/start` |
+
+### Kill vs Stop
+
+Ambient distinguishes between two levels of session termination:
+
+- **`DELETE /sessions/{id}`** — permanent. Removes the session resource and all
+  associated data. This is the semantic equivalent of `tmux kill-session`.
+- **`POST /sessions/{id}/stop`** — graceful. Stops the pod but preserves session
+  data, output history, and the session resource. The session can be resumed
+  later with `POST /sessions/{id}/start`.
+
+`KillSession` maps to `DELETE` (permanent), matching the tmux behavior. The
+stop/resume flow is a separate Ambient capability not exposed in the current
+interface. A future `StopSession`/`ResumeSession` pair could be added as an
+optimization — the coordinator's `handleAgentRestart` currently does kill + create,
+which works for both backends.
+
+---
+
+## Known Gap: Context and Tool Injection
+
+**Problem:** Tmux sessions are launched in an environment where agent-boss commands
+(`/boss.check`, `/boss.ignite`, etc.) are available as Claude Code slash commands
+or via the CLAUDE.md configuration. The session inherits the local filesystem
+context, MCP servers, and tool configurations.
+
+Ambient sessions are remote Kubernetes pods. They do not automatically have access
+to agent-boss commands. The boss commands must be provided through one of:
+
+1. **Ambient workflows** — structured configs defining system prompts, slash
+   commands, and tool access. This is the Ambient-native approach but requires
+   designing a workflow specifically for agent-boss.
+2. **Session creation options** — some minimal context can be passed at creation
+   time via the `task` field and repo configuration.
+3. **MCP server configuration** — Ambient sessions can connect to MCP servers.
+   An agent-boss MCP server could expose boss commands as tools.
+
+**Decision:** Defer to Phase 2 implementation. This gap will surface during
+Ambient backend integration and must be resolved before Ambient agents can
+participate in the broadcast/check-in flow.
 
 ---
 
@@ -113,40 +157,34 @@ for scenarios like: "agent is stuck on a bad task, cancel and reassign."
 ```go
 // Interrupt cancels the session's current work without killing the session.
 // The session remains alive and can accept new messages.
-// For tmux: sends Ctrl-C (C-c) to the session.
+// For tmux: sends Escape key to the session (Claude Code interrupt).
 // For ambient: calls POST /sessions/{id}/interrupt.
 Interrupt(ctx context.Context, sessionID string) error
 ```
 
-### Gap 3: `SessionCreateOpts` needs ambient-specific fields
+Note: this is a new capability. No equivalent exists in the current codebase.
+For tmux, the implementation sends the Escape key (Claude Code uses Escape, not
+Ctrl-C, to interrupt).
+
+### Gap 3: `SessionCreateOpts` needs backend-specific options
 
 **Problem:** Ambient sessions need `task` (initial prompt), `display_name`, `model`,
-and `repos`. The current `SessionCreateOpts` only has tmux-specific fields (`Width`,
-`Height`).
+and `repos`. These are not relevant to tmux.
 
-**Solution:** Make `SessionCreateOpts` a union of all backend fields. Each backend
-ignores fields it doesn't use.
+**Solution:** Use a generic `BackendOpts interface{}` field on `SessionCreateOpts`.
+Each backend defines its own options struct and type-asserts at runtime.
 
 ```go
 type SessionCreateOpts struct {
-    // Common
-    SessionID string // desired session name/ID
-    Command   string // tmux: shell command; ambient: mapped to task
-
-    // Tmux-specific (ignored by ambient)
-    WorkDir string
-    Width   int
-    Height  int
-
-    // Ambient-specific (ignored by tmux)
-    DisplayName string            // human-readable session name
-    Model       string            // Claude model to use
-    Repos       []SessionRepo     // repositories to clone
+    SessionID   string      // desired session name/ID
+    Command     string      // tmux: shell command; ambient: mapped to task
+    BackendOpts interface{} // backend-specific (TmuxCreateOpts, AmbientCreateOpts, etc.)
 }
 
-type SessionRepo struct {
-    URL    string `json:"url"`
-    Branch string `json:"branch,omitempty"`
+type AmbientCreateOpts struct {
+    DisplayName string        // human-readable session name
+    Model       string        // Claude model to use
+    Repos       []SessionRepo // repositories to clone
 }
 ```
 
@@ -229,16 +267,25 @@ func (b *AmbientSessionBackend) CreateSession(ctx context.Context, opts SessionC
     body := map[string]interface{}{
         "task": opts.Command, // Command maps to the initial task/prompt
     }
-    if opts.DisplayName != "" {
-        body["display_name"] = opts.DisplayName
+
+    // Extract ambient-specific options
+    var ambientOpts AmbientCreateOpts
+    if opts.BackendOpts != nil {
+        if ao, ok := opts.BackendOpts.(AmbientCreateOpts); ok {
+            ambientOpts = ao
+        }
+    }
+
+    if ambientOpts.DisplayName != "" {
+        body["display_name"] = ambientOpts.DisplayName
     } else if opts.SessionID != "" {
         body["display_name"] = opts.SessionID
     }
-    if opts.Model != "" {
-        body["model"] = opts.Model
+    if ambientOpts.Model != "" {
+        body["model"] = ambientOpts.Model
     }
-    if len(opts.Repos) > 0 {
-        body["repos"] = opts.Repos
+    if len(ambientOpts.Repos) > 0 {
+        body["repos"] = ambientOpts.Repos
     }
 
     // POST /v1/sessions
@@ -256,12 +303,12 @@ ignite prompt as their first message anyway.
 
 #### `KillSession(ctx, id) error`
 
-Maps to `POST /v1/sessions/{id}/stop`. Does NOT delete — preserves session data.
+Maps to `DELETE /v1/sessions/{id}`. Permanently removes the session.
 
 ```go
 func (b *AmbientSessionBackend) KillSession(ctx context.Context, sessionID string) error {
-    // POST /v1/sessions/{id}/stop
-    // Accept 202 (stopped) or 422 (already stopped) as success
+    // DELETE /v1/sessions/{id}
+    // Accept 200 (deleted) or 404 (already gone) as success
 }
 ```
 
@@ -451,20 +498,38 @@ end time, and event stream. This is important for:
   message. This may not work as intended — Ambient sessions have a fixed model
   set at creation. Model switching may need to be a no-op or handled differently.
 
-### 4. No approval flow
+### 4. Model switching concern
+
+The broadcast check-in flow switches agents to a cheaper model (`/model haiku`)
+before sending the check-in prompt, then restores the work model afterward. This
+is problematic for two reasons:
+
+- **Ambient:** Sessions have a fixed model set at creation. `/model` is a Claude
+  Code slash command, not an Ambient API concept. Sending it as a message would
+  be interpreted as a task, not a model switch.
+- **Context compaction risk:** Even for tmux, switching from opus (1M context) to
+  haiku with 300K tokens in context would trigger compaction, potentially losing
+  important context.
+
+For non-tmux backends, the coordinator should skip model switching entirely.
+For tmux, the model-switch behavior is preserved but the compaction risk should
+be evaluated separately.
+
+### 5. No approval flow
 
 Ambient sessions run with the permissions configured at session creation. There
 are no interactive approval prompts. The entire approval detection + interrupt
 ledger pipeline in the liveness loop becomes a no-op for Ambient agents.
 
-### 5. Persistent sessions
+### 6. Persistent sessions
 
 Tmux sessions are ephemeral — if the machine reboots, they're gone. Ambient
 sessions are persistent Kubernetes resources with stored state. `KillSession`
-(= stop) preserves the session and its history. This means:
+(= `DELETE`) permanently removes the session. For non-destructive pause, use
+the Ambient-specific `POST /stop` endpoint (not exposed in the interface).
 
-- Sessions can be resumed (`POST /start`) after being stopped
-- Session output/history survives restarts
+- Sessions can be resumed (`POST /start`) after being stopped (not killed)
+- Session output/history survives stops
 - The coordinator could reconnect to existing sessions after its own restart
 
 ---
@@ -533,7 +598,8 @@ tmux-dependent flow. Here's how it adapts for Ambient:
 ### Ambient adaptation
 
 ```
-1. Skip model switch:       Ambient sessions have a fixed model (or handle it via message)
+1. Skip model switch:       Ambient sessions have a fixed model; model switching
+                            risks context compaction even for tmux (see §4 above)
 2. Check status:            backend.GetStatus() == idle
 3. Send check-in:           backend.SendInput("/boss.check Agent Space")
 4. Wait for board post:     poll agentUpdatedAt() every 3s (same — blackboard is boss-side)
@@ -541,9 +607,8 @@ tmux-dependent flow. Here's how it adapts for Ambient:
 6. Check status:            backend.GetStatus() == idle
 ```
 
-The key difference: steps 1 and 5 (model switching) may be no-ops for Ambient.
 The coordinator should check `backend.Name()` and skip model switching for
-non-tmux backends, or attempt it as a message and tolerate failure.
+non-tmux backends.
 
 ---
 
@@ -551,7 +616,7 @@ non-tmux backends, or attempt it as a message and tolerate failure.
 
 ```
 internal/coordinator/
-  session_backend.go              # Interface, types, SessionStatus
+  session_backend.go              # Interface, types, SessionStatus, role interfaces
   session_backend_tmux.go         # TmuxSessionBackend
   session_backend_ambient.go      # AmbientSessionBackend (this spec)
   tmux.go                         # Low-level tmux primitives (unchanged)

--- a/.spec/SessionBackends/05-agentcore-feasibility.md
+++ b/.spec/SessionBackends/05-agentcore-feasibility.md
@@ -1,0 +1,221 @@
+# AWS Bedrock AgentCore — SessionBackend Feasibility Analysis
+
+Can the `SessionBackend` interface (13 methods) support an AgentCore backend?
+
+**Short answer:** Yes, but with significant client-side state management.
+AgentCore is a lower-level hosting primitive than Ambient — it provides
+"invoke" and "stop", not managed session lifecycle. The interface design
+is sound and requires no new methods, but an AgentCore implementation
+would be substantially more complex than the Ambient one.
+
+---
+
+## What is AgentCore?
+
+AgentCore is a **"bring your own agent code" serverless hosting platform**.
+You package your agent as a Docker container exposing `/invocations` (request
+handler) and `/ping` (health check) on port 8080. AgentCore runs it in
+isolated microVMs with per-session compute, memory, and filesystem isolation.
+
+This is fundamentally different from Ambient, which is a **managed Claude
+session service** — you say "create a session with this task" and the platform
+runs Claude Code for you.
+
+### Two-Tier API
+
+| Tier | Purpose | Key Operations |
+|------|---------|----------------|
+| **Control Plane** | Manage runtime *definitions* (like a Deployment template) | `CreateAgentRuntime`, `GetAgentRuntime`, `UpdateAgentRuntime`, `DeleteAgentRuntime`, `ListAgentRuntimes` |
+| **Data Plane** | Interact with individual sessions | `InvokeAgentRuntime`, `StopRuntimeSession` |
+
+The control plane manages the *deployment* of your agent code. The data plane
+manages *sessions* within that deployment. For our use case, the coordinator
+would pre-deploy a Claude Code agent as an AgentCore Runtime, then manage
+individual sessions via the data plane.
+
+### Session Model
+
+- Sessions are **implicit** — created automatically on first `InvokeAgentRuntime`
+  call with a new `runtimeSessionId`.
+- Each session gets a dedicated **microVM** with isolated resources.
+- Sessions auto-terminate after **15 minutes of inactivity** (configurable).
+- Maximum session lifetime: **8 hours**.
+- Session state is **ephemeral** — no persistence after termination.
+- There is **no "list sessions" API** — you must track session IDs yourself.
+
+### Authentication
+
+AWS IAM or OAuth 2.0 (via AgentCore Identity). Go SDK:
+`github.com/aws/aws-sdk-go-v2/service/bedrockagentcore`
+
+---
+
+## Interface Mapping
+
+### Methods that map cleanly (5 of 13)
+
+| Method | AgentCore Mapping | Notes |
+|--------|------------------|-------|
+| `Name()` | Returns `"agentcore"` | Trivial |
+| `Available()` | `GetAgentRuntime(runtimeARN)` returns 200 | Checks if the pre-deployed runtime exists and is active |
+| `KillSession(ctx, id)` | `StopRuntimeSession(runtimeARN, sessionID)` | Direct mapping. Terminates the microVM. |
+| `SendInput(id, text)` | `InvokeAgentRuntime(runtimeARN, sessionID, payload)` | Sends payload to agent. Returns streaming response. |
+| `Approve(id)` | No-op (return nil) | Agent code handles its own tool permissions |
+
+### Methods that work but with semantic differences (2 of 13)
+
+| Method | AgentCore Mapping | Semantic Difference |
+|--------|------------------|-------------------|
+| `CreateSession(ctx, opts)` | `InvokeAgentRuntime` with a new UUID as `runtimeSessionId` | No explicit "create" — session springs into existence on first invoke. The initial `opts.Command` becomes the first invocation payload. Backend must wait for streaming response to confirm the session started. |
+| `CheckApproval(id)` | Returns `ApprovalInfo{NeedsApproval: false}` | Same as Ambient — agent code manages its own permissions. No terminal to parse. |
+
+### Methods with significant gaps (6 of 13)
+
+| Method | Gap | Workaround |
+|--------|-----|-----------|
+| `SessionExists(id)` | **No API to query session existence.** Sessions are either active (accepting invocations) or terminated (gone). No status endpoint. | Backend must maintain a **local session registry** — track created sessions and mark them terminated on stop/timeout. Alternatively, attempt a lightweight invoke and interpret errors, but this is fragile. |
+| `ListSessions()` | **No `ListRuntimeSessions` API exists.** You can list *runtimes* but not *sessions within a runtime*. | Backend must maintain a **local session registry** of all session IDs it has created. |
+| `GetStatus(ctx, id)` | **No external session status API.** The `/ping` endpoint is internal to the agent container — it's how AgentCore infrastructure monitors the agent, not how external callers query status. | Backend must **infer status** from local state: just created → `pending`/`running`, last invoke returned output → `running`, invoke failed with session-not-found → `missing`, locally marked stopped → `completed`. Very approximate. |
+| `IsIdle(id)` | **`/ping` is internal.** Reports `Healthy` (idle) or `HealthyBusy` (working) but only to AgentCore infrastructure, not to external API callers. | Backend could embed a custom status endpoint in the agent code that the coordinator calls directly. Or track idle state based on whether the last streaming invoke response has completed. Both require custom agent code changes. |
+| `CaptureOutput(id, lines)` | **No transcript/output API.** Output comes back as a streaming response from `InvokeAgentRuntime`. There's no after-the-fact "get output" endpoint. | Backend must **capture and buffer** streaming output from every `InvokeAgentRuntime` call. Store the last N lines in memory or a local store. This means the coordinator must be the one invoking (or subscribing to) the agent to capture its output. |
+| `DiscoverSessions()` | **No list sessions API.** | Backend returns only sessions it has locally registered. Cannot discover sessions created by other coordinators or external callers. |
+
+### Methods with partial gaps (1 of 13)
+
+| Method | Gap | Workaround |
+|--------|-----|-----------|
+| `Interrupt(ctx, id)` | `StopRuntimeSession` is **destructive** — it terminates the microVM entirely. There's no "cancel current work but keep session alive" equivalent. Unlike Ambient's `POST /interrupt` which cancels the current run while preserving the session. | If the agent code supports it, send a special "interrupt" message via `InvokeAgentRuntime`. But this requires custom agent code and won't work if the agent is busy (AgentCore won't accept new invocations while status is `HealthyBusy`). In practice, interrupt = kill + recreate for AgentCore. |
+
+---
+
+## Conceptual Comparison
+
+| Concept | Tmux | Ambient | AgentCore |
+|---------|------|---------|-----------|
+| What runs the agent | Local tmux + Claude CLI | Platform-managed Claude pod | Your Docker container in a microVM |
+| Session creation | Explicit (`tmux new-session`) | Explicit (`POST /sessions`) | Implicit (first invoke) |
+| Session listing | `tmux list-sessions` | `GET /sessions` | **Not available** |
+| Session status | Inferred from terminal | `GET /sessions/{id}` status field | **Not available externally** |
+| Idle detection | Parse terminal output | Check run status via API | `/ping` internal only |
+| Output capture | Read terminal pane | `GET /sessions/{id}/output` | Streaming during invoke only |
+| Send input | `tmux send-keys` | `POST /sessions/{id}/message` | `InvokeAgentRuntime` |
+| Kill session | `tmux kill-session` | `POST /sessions/{id}/stop` | `StopRuntimeSession` |
+| Interrupt (non-destructive) | `tmux send-keys C-c` | `POST /sessions/{id}/interrupt` | **Not available** |
+| Session persistence | Ephemeral (lost on reboot) | Persistent (K8s resource) | Ephemeral (lost on terminate) |
+| Discovery | Parse session names | List + match display_name | **Not available** |
+| Model flexibility | Any (runs locally) | Configured at creation | Any (you deploy the model call) |
+
+---
+
+## Architecture: What an AgentCore Backend Would Require
+
+### Pre-requisite: Deploy Claude Code as an AgentCore Runtime
+
+Before the backend can create sessions, a Claude Code agent must be
+deployed as an AgentCore Runtime. This is a one-time setup:
+
+```
+1. Package Claude Code CLI in a container
+2. Implement /invocations handler (receives prompts, runs Claude, streams output)
+3. Implement /ping handler (reports Healthy/HealthyBusy)
+4. CreateAgentRuntime with the container image
+5. Store the Runtime ARN in coordinator config
+```
+
+This is entirely outside the `SessionBackend` interface — it's infrastructure
+setup, similar to having tmux installed or Ambient deployed.
+
+### Client-Side State Store
+
+The AgentCore backend would need a local state store to compensate for
+the missing APIs:
+
+```go
+type AgentCoreSessionBackend struct {
+    runtimeARN string
+    client     *bedrockagentcore.Client
+
+    mu       sync.RWMutex
+    sessions map[string]*agentCoreSession // sessionID -> state
+}
+
+type agentCoreSession struct {
+    id        string
+    createdAt time.Time
+    status    SessionStatus           // locally tracked
+    output    *ring.Buffer            // circular buffer of last N output lines
+    lastInvoke time.Time
+}
+```
+
+### Estimated Implementation Complexity
+
+| Backend | Lines of code (est.) | External dependencies | Client-side state needed |
+|---------|---------------------|----------------------|------------------------|
+| Tmux | ~150 | tmux binary | None |
+| Ambient | ~300 | HTTP client | None (API is stateful) |
+| AgentCore | ~500-700 | AWS SDK Go v2 | Session registry, output buffer, status tracking |
+
+---
+
+## Verdict
+
+### The interface works — no changes needed
+
+All 13 methods can be implemented against AgentCore. No new methods are
+required. The gaps are all solvable with client-side state management.
+
+### But the implementation is substantially more complex
+
+AgentCore is designed as a low-level hosting platform, not a managed
+session service. It gives you two operations — invoke and stop — and
+expects you to build session management on top. This means:
+
+1. **Session tracking**: Must maintain a local registry of all sessions
+2. **Output buffering**: Must capture and store streaming output
+3. **Status inference**: Must derive status from local state rather than querying an API
+4. **No interrupt**: Must accept kill-and-recreate as the "interrupt" pattern
+5. **No discovery**: Can only find sessions the coordinator itself created
+6. **Custom agent code**: Need to build and deploy a Claude Code container
+
+### Comparison to Ambient
+
+Ambient's API was practically designed for this interface — nearly 1:1 mapping
+with rich session lifecycle, status, output, and interrupt APIs. AgentCore
+requires the backend to replicate what Ambient provides natively.
+
+### When AgentCore makes sense
+
+Despite the complexity, AgentCore would be the right choice when:
+
+- Running on AWS infrastructure (native IAM integration)
+- Need model flexibility beyond Claude (AgentCore is model-agnostic)
+- Want per-session compute isolation (dedicated microVMs)
+- Already have agent code that isn't Claude Code (LangGraph, CrewAI, etc.)
+- Need the AWS ecosystem (CloudWatch, X-Ray, IAM, VPC integration)
+
+### Recommendation
+
+AgentCore support is feasible as a Phase 3 backend (after tmux and Ambient),
+but it's a larger effort. The interface design is validated — it accommodates
+AgentCore's minimal API surface without requiring new methods. The complexity
+lives entirely in the implementation, not the interface.
+
+---
+
+## Sources
+
+- [Amazon Bedrock AgentCore Overview](https://aws.amazon.com/bedrock/agentcore/)
+- [AgentCore Runtime — How it Works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-how-it-works.html)
+- [InvokeAgentRuntime API Reference](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_InvokeAgentRuntime.html)
+- [StopRuntimeSession API Reference](https://docs.aws.amazon.com/bedrock-agentcore/latest/APIReference/API_StopRuntimeSession.html)
+- [CreateAgentRuntime API Reference](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_CreateAgentRuntime.html)
+- [GetAgentRuntime API Reference](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_GetAgentRuntime.html)
+- [ListAgentRuntimes API Reference](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_ListAgentRuntimes.html)
+- [Session Isolation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-sessions.html)
+- [Lifecycle Configuration](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-lifecycle-settings.html)
+- [Async and Long-Running Agents](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-long-run.html)
+- [HTTP Protocol Contract](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-http-protocol-contract.html)
+- [AgentCore Observability](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability.html)
+- [Go SDK — bedrockagentcore package](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/bedrockagentcore)
+- [AgentCore Python SDK (GitHub)](https://github.com/aws/bedrock-agentcore-sdk-python)


### PR DESCRIPTION
Design specs for replacing hardcoded tmux with a pluggable SessionBackend interface supporting tmux and Ambient backends.