### PR TITLE
fix(task-039): improve Kanban UX on small screens

### DIFF
--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -53,7 +53,7 @@ const statusHeaderClass: Record<TaskStatus, string> = {
 
 <template>
   <div
-    class="flex flex-col w-64 shrink-0 rounded-lg bg-muted/40 border border-border transition-colors max-h-full"
+    class="flex flex-col w-56 sm:w-64 shrink-0 rounded-lg bg-muted/40 border border-border transition-colors max-h-full"
     :class="{ 'ring-2 ring-primary/50 border-primary/50 bg-primary/5': isDragOver }"
     @dragover="onDragOver"
     @dragleave="onDragLeave"

--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -222,7 +222,7 @@ onUnmounted(() => {
 <template>
   <div class="flex flex-col h-full overflow-hidden">
     <!-- Toolbar -->
-    <div class="flex items-center gap-3 px-6 py-3 border-b border-border shrink-0">
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-2 px-4 sm:px-6 py-2 sm:py-3 border-b border-border shrink-0">
       <h2 class="text-sm font-semibold">Kanban Board</h2>
       <span class="text-xs text-muted-foreground">{{ filteredTasks.length }} task{{ filteredTasks.length !== 1 ? 's' : '' }}</span>
 
@@ -233,11 +233,11 @@ onUnmounted(() => {
           v-model="filterSearch"
           type="search"
           placeholder="Search tasks…"
-          class="pl-6 pr-2 h-7 text-xs border border-border rounded bg-background outline-none focus:border-primary w-40"
+          class="pl-6 pr-2 h-7 text-xs border border-border rounded bg-background outline-none focus:border-primary w-32 sm:w-40"
         />
       </div>
 
-      <div class="flex items-center gap-2 ml-auto">
+      <div class="flex items-center gap-2 ml-auto flex-wrap">
         <!-- Overdue filter -->
         <Button
           variant="outline"
@@ -319,7 +319,7 @@ onUnmounted(() => {
     <!-- Board -->
     <div
       v-else
-      class="flex gap-3 p-4 overflow-x-auto overflow-y-hidden flex-1"
+      class="flex gap-3 p-3 sm:p-4 overflow-x-auto overflow-y-hidden flex-1 scroll-smooth"
       @dragend="draggingTaskId = null"
     >
       <KanbanColumn

--- a/frontend/src/components/TaskDetailPanel.vue
+++ b/frontend/src/components/TaskDetailPanel.vue
@@ -206,7 +206,7 @@ async function setDueDate(value: string) {
 
 <template>
   <Sheet :open="open" @update:open="emit('update:open', $event)">
-    <SheetContent class="w-[480px] sm:w-[540px] overflow-y-auto flex flex-col gap-0 p-0">
+    <SheetContent class="w-full sm:w-[480px] md:w-[540px] overflow-y-auto flex flex-col gap-0 p-0">
       <div v-if="task" class="flex flex-col h-full">
         <!-- Header -->
         <SheetHeader class="px-6 pt-6 pb-4 border-b border-border">


### PR DESCRIPTION
## Summary
- **Toolbar wrapping**: Kanban toolbar now wraps to multiple rows on narrow viewports instead of overflowing (added `flex-wrap gap-y-2`)
- **Narrower search input on mobile**: `w-32` on mobile, `w-40` on sm+
- **Column width**: `w-56` on mobile → `w-64` on sm+; more columns visible before horizontal scroll kicks in
- **TaskDetailPanel sheet overflow fix**: Changed fixed `w-[480px]` to `w-full sm:w-[480px] md:w-[540px]` — on screens < 480px the panel previously overflowed the viewport
- **Smoother horizontal scroll**: Added `scroll-smooth` to board container

## Test plan
- [ ] On a ~375px wide viewport (mobile emulation): toolbar wraps cleanly, no overflow
- [ ] On a ~768px viewport (tablet): 3+ columns visible before scrolling, detail panel fills width
- [ ] On desktop: no visual regression, columns still 256px
- [ ] All 48 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)