### PR TITLE
fix(task-042): serve index.html for all non-API routes (SPA deep-link)

### DIFF
--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -11,11 +11,13 @@ import (
 	"time"
 )
 
+// handleRoot serves the Vue SPA index.html for all non-API routes.
+// Since this handler is registered as "/" (catch-all in Go's ServeMux),
+// it receives every request that doesn't match a more specific pattern
+// (i.e., every path that isn't /spaces/, /events, /assets/, etc.).
+// Serving index.html for all such paths lets Vue Router handle client-side
+// navigation, enabling deep-linking to URLs like /SpaceName or /SpaceName/kanban.
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
-		http.NotFound(w, r)
-		return
-	}
 	// Serve Vue SPA index.html: runtime FRONTEND_DIR takes priority, then embedded.
 	if s.frontendDir != "" {
 		indexPath := filepath.Join(s.frontendDir, "index.html")

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -3369,3 +3369,36 @@ func TestNotificationPruning(t *testing.T) {
 	}
 }
 
+// TestSPAFallback verifies that deep-linked frontend paths (e.g. /SpaceName,
+// /SpaceName/kanban) are handled by handleRoot instead of returning Go's
+// default "404 page not found" response. This allows Vue Router to handle
+// client-side navigation when the user navigates directly to a URL.
+//
+// In tests there is no compiled frontend, so all these paths return a 404
+// with "frontend not available" — but that's still correct: they all go
+// through handleRoot rather than getting the raw http.NotFound response.
+func TestSPAFallback(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	// Fetch what the root path returns — this is our baseline SPA response.
+	_, rootBody := getBody(t, base+"/")
+
+	spaPaths := []string{
+		"/AgentBossDevTeam",
+		"/AgentBossDevTeam/kanban",
+		"/some-space/agent/foo",
+		"/unknown-deep-path",
+	}
+	for _, path := range spaPaths {
+		_, body := getBody(t, base+path)
+		// Deep-linked paths must return the same body as "/" — either the SPA
+		// index.html (in production) or "frontend not available" (in tests).
+		// They must NOT return Go's default "404 page not found\n".
+		if body != rootBody {
+			t.Errorf("GET %s: expected same body as /, got: %.100s", path, body)
+		}
+	}
+}
+


### PR DESCRIPTION
## Summary

Direct navigation to frontend URLs like `/AgentBossDevTeam` or `/AgentBossDevTeam/kanban` returned `404 page not found` when served from the embedded Go binary, while `npm run dev` worked fine (Vite proxy handles SPA fallback automatically).

**Root cause:** `handleRoot` checked `r.URL.Path != "/"` and returned `http.NotFound` for all other paths. Since `"/"` is the catch-all in Go's `http.ServeMux`, it receives every request not matched by `/spaces/`, `/assets/`, `/events`, etc. — all of which are frontend routes that should serve `index.html`.

**Fix:** Remove the path guard in `handleRoot` so `index.html` is served for all paths that reach the catch-all handler, letting Vue Router handle the client-side routing.

## Test plan
- [x] `TestSPAFallback` added: verifies `/SpaceName`, `/SpaceName/kanban`, etc. return the same response as `/` (not Go's default `404 page not found`)
- [x] All existing tests pass (`go test -race ./internal/coordinator/`)
- [ ] Build the binary (`go build -o /tmp/boss ./cmd/boss/`), navigate directly to `http://localhost:8899/AgentBossDevTeam` — should load the SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)