### PR TITLE
Add OpenShift deployment for jsell-agent-boss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+NAMESPACE     := jsell-agent-boss
+IMAGE_NAME    := boss-coordinator
+REGISTRY      := default-route-openshift-image-registry.apps.okd1.timslab
+IMAGE_TAG     := latest
+IMAGE         := $(REGISTRY)/$(NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+.PHONY: build install build-image push-image deploy rollout
+
+build:
+	cd frontend && npm install && npm run build
+	CGO_ENABLED=0 go build -o boss ./cmd/boss/
+
+install:
+	cd frontend && npm install && npm run build
+	CGO_ENABLED=0 go install ./cmd/boss/
+
+build-image:
+	podman build -t $(IMAGE) -f deploy/Dockerfile .
+
+push-image:
+	podman push $(IMAGE) --tls-verify=false
+
+deploy:
+	oc apply -f deploy/openshift/namespace.yaml
+	oc process -f deploy/openshift/postgresql-credentials.yaml | oc apply -f -
+	oc apply -f deploy/openshift/configmap.yaml
+	oc apply -f deploy/openshift/postgresql.yaml
+	oc apply -f deploy/openshift/deployment.yaml
+	oc apply -f deploy/openshift/service.yaml
+	oc apply -f deploy/openshift/route.yaml
+
+rollout: build-image push-image
+	oc rollout restart deploy/boss-coordinator -n $(NAMESPACE)

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Build Vue frontend
+FROM node:22-alpine AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+COPY internal/coordinator/frontend/.gitkeep ../internal/coordinator/frontend/.gitkeep
+RUN npm run build
+
+# Stage 2: Build Go binary
+FROM golang:1.24-alpine AS backend
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=frontend /internal/coordinator/frontend/ internal/coordinator/frontend/
+RUN CGO_ENABLED=0 GOOS=linux go build -o /boss ./cmd/boss/
+
+# Stage 3: Minimal runtime
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=backend /boss /boss
+EXPOSE 8899
+ENTRYPOINT ["/boss", "serve"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,89 @@
+# OpenShift Deployment
+
+Deploys jsell-agent-boss to an OKD/OpenShift cluster with PostgreSQL for persistent storage.
+
+## Prerequisites
+
+- `oc` CLI logged into the target cluster
+- `podman` installed
+- Access to the cluster's internal image registry
+
+## Registry Login
+
+```bash
+podman login default-route-openshift-image-registry.apps.okd1.timslab --tls-verify=false \
+  -u $(oc whoami) -p $(oc whoami -t)
+```
+
+## First Deploy
+
+From the repository root:
+
+```bash
+make build-image
+make push-image
+make deploy
+```
+
+`make deploy` processes the `postgresql-credentials.yaml` OpenShift Template, which auto-generates a random 16-character password. To override the defaults:
+
+```bash
+oc process -f deploy/openshift/postgresql-credentials.yaml \
+  -p POSTGRESQL_USER=myuser \
+  -p POSTGRESQL_PASSWORD=mypassword \
+  -p POSTGRESQL_DATABASE=mydb | oc apply -f -
+```
+
+## Subsequent Deploys
+
+```bash
+make rollout
+```
+
+Rebuilds the image, pushes it, and does a rolling restart of the boss-coordinator deployment. PostgreSQL is untouched — data persists across rollouts.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│ Namespace: jsell-agent-boss                 │
+│                                             │
+│  ┌─────────────────┐  ┌──────────────────┐  │
+│  │ boss-coordinator │  │   postgresql     │  │
+│  │ (distroless)     │─►│   (RHEL sclorg)  │  │
+│  │ :8899            │  │   :5432          │  │
+│  └────────┬─────────┘  └──────────────────┘  │
+│           │                    │              │
+│     ClusterIP              PVC 2Gi           │
+│     Service             postgresql-data      │
+│           │                                  │
+│     Route (edge TLS)                         │
+│     jsell-agent-boss.apps.okd1.timslab       │
+└─────────────────────────────────────────────┘
+```
+
+## Manifests
+
+| File | Resources |
+|------|-----------|
+| `openshift/namespace.yaml` | Namespace `jsell-agent-boss` |
+| `openshift/postgresql-credentials.yaml` | Template: PostgreSQL Secret (password auto-generated if not supplied) |
+| `openshift/configmap.yaml` | ConfigMap: `DB_TYPE=postgres`, `DATA_DIR`, `COORDINATOR_PORT` |
+| `openshift/postgresql.yaml` | PostgreSQL Deployment + Service + PVC (2Gi) |
+| `openshift/deployment.yaml` | boss-coordinator Deployment (from internal registry) |
+| `openshift/service.yaml` | ClusterIP Service on port 8899 |
+| `openshift/route.yaml` | Edge-terminated TLS Route |
+
+## Dockerfile
+
+Multi-stage build (`deploy/Dockerfile`):
+
+1. **node:22-alpine** — builds Vue frontend (`npm ci && npm run build`)
+2. **golang:1.24-alpine** — builds Go binary with `CGO_ENABLED=0` (pure-Go SQLite driver)
+3. **gcr.io/distroless/static-debian12:nonroot** — minimal runtime with just the binary
+
+## Notes
+
+- PostgreSQL uses `registry.redhat.io/rhel10/postgresql-16:10.1` (sclorg). No `anyuid` SCC required — it handles OpenShift's arbitrary UID assignment natively.
+- The boss-coordinator uses an `emptyDir` for `/data` (JSON/markdown cache). PostgreSQL is the source of truth; data survives pod restarts.
+- tmux-dependent features (`spawn`, `stop`, `restart`, `introspect`) are unavailable in the distroless container. The coordination API (blackboard, messaging, SSE, dashboard) works without tmux.

--- a/deploy/openshift/configmap.yaml
+++ b/deploy/openshift/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: boss-config
+  namespace: jsell-agent-boss
+data:
+  DB_TYPE: postgres
+  DATA_DIR: /data
+  COORDINATOR_PORT: "8899"
+  POSTGRESQL_DATABASE: boss

--- a/deploy/openshift/deployment.yaml
+++ b/deploy/openshift/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: boss-coordinator
+  namespace: jsell-agent-boss
+  labels:
+    app: boss-coordinator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: boss-coordinator
+  template:
+    metadata:
+      labels:
+        app: boss-coordinator
+    spec:
+      containers:
+        - name: boss-coordinator
+          image: image-registry.openshift-image-registry.svc:5000/jsell-agent-boss/boss-coordinator:latest
+          ports:
+            - containerPort: 8899
+          envFrom:
+            - configMapRef:
+                name: boss-config
+          env:
+            - name: DB_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: DB_DSN
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /spaces
+              port: 8899
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /spaces
+              port: 8899
+            initialDelaySeconds: 3
+            periodSeconds: 10
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/deploy/openshift/namespace.yaml
+++ b/deploy/openshift/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jsell-agent-boss

--- a/deploy/openshift/postgresql-credentials.yaml
+++ b/deploy/openshift/postgresql-credentials.yaml
@@ -1,0 +1,26 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: postgresql-credentials
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: postgresql-credentials
+      namespace: ${NAMESPACE}
+    type: Opaque
+    stringData:
+      POSTGRESQL_USER: ${POSTGRESQL_USER}
+      POSTGRESQL_PASSWORD: ${POSTGRESQL_PASSWORD}
+      DB_DSN: "host=postgresql port=5432 user=${POSTGRESQL_USER} password=${POSTGRESQL_PASSWORD} dbname=boss sslmode=disable"
+parameters:
+  - name: NAMESPACE
+    required: true
+    value: jsell-agent-boss
+  - name: POSTGRESQL_USER
+    required: true
+    value: boss
+  - name: POSTGRESQL_PASSWORD
+    required: true
+    generate: expression
+    from: "[a-zA-Z0-9]{16}"

--- a/deploy/openshift/postgresql.yaml
+++ b/deploy/openshift/postgresql.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+  namespace: jsell-agent-boss
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  namespace: jsell-agent-boss
+  labels:
+    app: postgresql
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: registry.redhat.io/rhel10/postgresql-16:10.1
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: POSTGRESQL_USER
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: POSTGRESQL_PASSWORD
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: boss-config
+                  key: POSTGRESQL_DATABASE
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /var/lib/pgsql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: postgresql-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  namespace: jsell-agent-boss
+  labels:
+    app: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: postgresql

--- a/deploy/openshift/route.yaml
+++ b/deploy/openshift/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: boss-coordinator
+  namespace: jsell-agent-boss
+  labels:
+    app: boss-coordinator
+spec:
+  host: jsell-agent-boss.apps.okd1.timslab
+  to:
+    kind: Service
+    name: boss-coordinator
+  port:
+    targetPort: 8899
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/deploy/openshift/service.yaml
+++ b/deploy/openshift/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: boss-coordinator
+  namespace: jsell-agent-boss
+  labels:
+    app: boss-coordinator
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8899
+      targetPort: 8899
+  selector:
+    app: boss-coordinator


### PR DESCRIPTION
Multi-stage Dockerfile (Node + Go + distroless), OpenShift manifests (PostgreSQL with RHEL sclorg image, boss-coordinator deployment, edge TLS route), and Makefile with build/install/build-image/push-image/ deploy/rollout targets. PostgreSQL credentials use an OpenShift Template to keep secrets out of git.

Also adds a makefile with `build` and `install` targets.