### PR TITLE
fix(task-044): fix space deletion and cross-space task ID collision

### DIFF
--- a/internal/coordinator/db/db.go
+++ b/internal/coordinator/db/db.go
@@ -71,6 +71,11 @@ func Open(dataDir string) (*gorm.DB, error) {
 // migrate runs GORM AutoMigrate for all models. Safe to call on every startup —
 // it only adds missing tables/columns; it never drops or alters existing data.
 func migrate(db *gorm.DB) error {
+	// Run manual migration before AutoMigrate so schema is correct before GORM
+	// inspects it.
+	if err := migrateTasksCompositeKey(db); err != nil {
+		return fmt.Errorf("migrate tasks composite key: %w", err)
+	}
 	return db.AutoMigrate(
 		&Space{},
 		&Agent{},
@@ -81,4 +86,94 @@ func migrate(db *gorm.DB) error {
 		&TaskEvent{},
 		&StatusSnapshot{},
 	)
+}
+
+// migrateTasksCompositeKey recreates the tasks table with a composite primary
+// key (space_name, id) if it currently has a single-column PK on id only.
+// This fixes cross-space task ID collisions: tasks with the same sequence
+// number (e.g. TASK-001) in different spaces were overwriting each other.
+//
+// SQLite does not support ALTER TABLE … DROP PRIMARY KEY, so we use the
+// standard SQLite table-recreation pattern: create new → copy → drop → rename.
+// The migration is idempotent: if the table already has the correct schema
+// (detected by checking the primary key pragma), it is a no-op.
+func migrateTasksCompositeKey(db *gorm.DB) error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+
+	// Check whether the tasks table exists at all. If not, AutoMigrate will
+	// create it fresh with the correct composite PK — nothing to do here.
+	var tableCount int
+	row := sqlDB.QueryRow(`SELECT count(*) FROM sqlite_master WHERE type='table' AND name='tasks'`)
+	if err := row.Scan(&tableCount); err != nil || tableCount == 0 {
+		return nil
+	}
+
+	// Inspect current primary key columns via the table_info pragma.
+	// SQLite returns pk>0 for primary-key columns; composite PKs have pk=1,2,...
+	rows, err := sqlDB.Query(`PRAGMA table_info(tasks)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type colInfo struct {
+		cid     int
+		name    string
+		typ     string
+		notnull int
+		dflt    interface{}
+		pk      int
+	}
+	var pkCols []string
+	for rows.Next() {
+		var c colInfo
+		if err := rows.Scan(&c.cid, &c.name, &c.typ, &c.notnull, &c.dflt, &c.pk); err != nil {
+			return err
+		}
+		if c.pk > 0 {
+			pkCols = append(pkCols, c.name)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	// Already has composite PK — nothing to do.
+	if len(pkCols) == 2 {
+		return nil
+	}
+
+	// Single-column PK (old schema): recreate with composite (space_name, id).
+	_, err = sqlDB.Exec(`
+		CREATE TABLE IF NOT EXISTS tasks_new (
+			id            TEXT NOT NULL,
+			space_name    TEXT NOT NULL,
+			title         TEXT NOT NULL,
+			description   TEXT,
+			status        TEXT NOT NULL DEFAULT 'backlog',
+			priority      TEXT DEFAULT 'medium',
+			assigned_to   TEXT,
+			created_by    TEXT NOT NULL,
+			labels        TEXT,
+			parent_task   TEXT,
+			subtasks      TEXT,
+			linked_branch TEXT,
+			linked_pr     TEXT,
+			created_at    DATETIME,
+			updated_at    DATETIME,
+			due_at        DATETIME,
+			PRIMARY KEY (space_name, id)
+		);
+		INSERT OR IGNORE INTO tasks_new
+			SELECT id, space_name, title, description, status, priority,
+			       assigned_to, created_by, labels, parent_task, subtasks,
+			       linked_branch, linked_pr, created_at, updated_at, due_at
+			FROM tasks;
+		DROP TABLE tasks;
+		ALTER TABLE tasks_new RENAME TO tasks;
+	`)
+	return err
 }

--- a/internal/coordinator/db/models.go
+++ b/internal/coordinator/db/models.go
@@ -126,9 +126,11 @@ type AgentNotification struct {
 func (AgentNotification) TableName() string { return "agent_notifications" }
 
 // Task represents a tracked work item.
+// ID is unique per space (e.g. TASK-001), not globally unique — the composite
+// primary key (space_name, id) prevents cross-space collisions in the DB.
 type Task struct {
-	ID           string    `gorm:"primarykey"`
-	SpaceName    string    `gorm:"index;not null"`
+	ID        string `gorm:"primaryKey;not null"`
+	SpaceName string `gorm:"primaryKey;not null;index"`
 	Title        string    `gorm:"not null"`
 	Description  string    `gorm:"type:text"`
 	Status       string    `gorm:"not null;default:'backlog'"`

--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -159,9 +159,11 @@ func (r *Repository) MarkNotificationsRead(spaceName, agentName string) error {
 // ---- Task operations ----
 
 // UpsertTask creates or updates a task.
+// Conflict is on the composite key (space_name, id) so tasks with the same
+// ID in different spaces are stored as distinct rows.
 func (r *Repository) UpsertTask(t *Task) error {
 	return r.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "id"}},
+		Columns: []clause.Column{{Name: "space_name"}, {Name: "id"}},
 		DoUpdates: clause.AssignmentColumns([]string{
 			"title", "description", "status", "priority", "assigned_to",
 			"labels", "parent_task", "subtasks", "linked_branch", "linked_pr",
@@ -230,6 +232,35 @@ func (r *Repository) DeleteTask(spaceName, taskID string) error {
 		return err
 	}
 	return r.db.Where("id = ? AND space_name = ?", taskID, spaceName).Delete(&Task{}).Error
+}
+
+// DeleteSpace removes a space and all its associated data (agents, messages,
+// notifications, tasks, comments, events, snapshots) in a single transaction.
+func (r *Repository) DeleteSpace(name string) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("space_name = ?", name).Delete(&TaskEvent{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("space_name = ?", name).Delete(&TaskComment{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("space_name = ?", name).Delete(&Task{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("space_name = ?", name).Delete(&AgentNotification{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("space_name = ?", name).Delete(&AgentMessage{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("space_name = ?", name).Delete(&StatusSnapshot{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("space_name = ?", name).Delete(&Agent{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("name = ?", name).Delete(&Space{}).Error
+	})
 }
 
 // ---- StatusSnapshot operations ----

--- a/internal/coordinator/db_adapter.go
+++ b/internal/coordinator/db_adapter.go
@@ -259,6 +259,15 @@ func (s *Server) saveSnapshotToDB(snap *StatusSnapshot) {
 	}
 }
 
+func (s *Server) deleteSpaceFromDB(spaceName string) {
+	if s.repo == nil {
+		return
+	}
+	if err := s.repo.DeleteSpace(spaceName); err != nil {
+		s.logEvent(fmt.Sprintf("warning: delete space %q from db: %v", spaceName, err))
+	}
+}
+
 func (s *Server) deleteAgentFromDB(spaceName, agentName string) {
 	if s.repo == nil {
 		return

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -280,6 +280,8 @@ func (s *Server) handleDeleteSpace(w http.ResponseWriter, _ *http.Request, space
 
 	os.Remove(s.spacePath(spaceName))
 	os.Remove(s.spaceMarkdownPath(spaceName))
+	os.Remove(filepath.Join(s.dataDir, spaceName+".events.jsonl"))
+	s.deleteSpaceFromDB(spaceName)
 
 	s.logEvent(fmt.Sprintf("space %q deleted", spaceName))
 	s.broadcastSSE(spaceName, "", "space_deleted", spaceName)

--- a/internal/coordinator/sqlite_test.go
+++ b/internal/coordinator/sqlite_test.go
@@ -98,6 +98,102 @@ func TestSQLiteJSONMigration(t *testing.T) {
 	}
 }
 
+// TestSQLiteDeleteSpacePersists verifies that deleting a space removes it from
+// the SQLite DB so it does not reappear after a server restart.
+func TestSQLiteDeleteSpacePersists(t *testing.T) {
+	t.Setenv("DB_TYPE", "sqlite")
+	dir := t.TempDir()
+
+	s := NewServer(":0", dir)
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	base := "http://localhost" + s.Port()
+
+	// Create a space with an agent.
+	postJSON(t, base+"/spaces/ghost-space/agent/Phantom", map[string]any{
+		"status": "active", "summary": "Phantom: will be deleted",
+	})
+
+	// Delete the space.
+	req, _ := http.NewRequest(http.MethodDelete, base+"/spaces/ghost-space/", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status %d", resp.StatusCode)
+	}
+
+	s.Stop()
+
+	// Restart and verify the space is gone.
+	s2 := NewServer(":0", dir)
+	t.Setenv("DB_TYPE", "sqlite")
+	if err := s2.Start(); err != nil {
+		t.Fatalf("restart Start: %v", err)
+	}
+	defer s2.Stop()
+
+	base2 := "http://localhost" + s2.Port()
+	status, body := getBody(t, base2+"/spaces/ghost-space/agent/Phantom")
+	if status != http.StatusNotFound {
+		t.Errorf("expected 404 for deleted space after restart, got %d: %s", status, body)
+	}
+}
+
+// TestSQLiteTaskCrossSpaceIsolation verifies that two spaces can each have a
+// TASK-001 without overwriting each other's data in the DB.
+func TestSQLiteTaskCrossSpaceIsolation(t *testing.T) {
+	t.Setenv("DB_TYPE", "sqlite")
+	dir := t.TempDir()
+
+	s := NewServer(":0", dir)
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	base := "http://localhost" + s.Port()
+
+	// SpaceA creates its first task.
+	postTaskJSON(t, base+"/spaces/space-a/tasks", map[string]any{
+		"title": "SpaceA first task",
+	}, "BotA")
+
+	// SpaceB creates its first task — same sequence number, different space.
+	postTaskJSON(t, base+"/spaces/space-b/tasks", map[string]any{
+		"title": "SpaceB first task",
+	}, "BotB")
+
+	s.Stop()
+
+	// Restart and verify both tasks are intact in their respective spaces.
+	s2 := NewServer(":0", dir)
+	t.Setenv("DB_TYPE", "sqlite")
+	if err := s2.Start(); err != nil {
+		t.Fatalf("restart Start: %v", err)
+	}
+	defer s2.Stop()
+
+	base2 := "http://localhost" + s2.Port()
+
+	_, bodyA := getBody(t, base2+"/spaces/space-a/tasks")
+	if !strings.Contains(bodyA, "SpaceA first task") {
+		t.Errorf("SpaceA task missing after restart, got: %s", bodyA)
+	}
+	if strings.Contains(bodyA, "SpaceB first task") {
+		t.Errorf("SpaceB task leaked into SpaceA after restart, got: %s", bodyA)
+	}
+
+	_, bodyB := getBody(t, base2+"/spaces/space-b/tasks")
+	if !strings.Contains(bodyB, "SpaceB first task") {
+		t.Errorf("SpaceB task missing after restart, got: %s", bodyB)
+	}
+	if strings.Contains(bodyB, "SpaceA first task") {
+		t.Errorf("SpaceA task leaked into SpaceB after restart, got: %s", bodyB)
+	}
+}
+
 func TestSQLiteInvalidDBType(t *testing.T) {
 	t.Setenv("DB_TYPE", "mysql")
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Fixes three related persistence bugs (TASK-044) that caused deleted spaces to reappear and tasks to leak across spaces after a server restart.

### Bug 1: Deleted spaces reappear after restart
`handleDeleteSpace` removed the `.json` and `.md` files but never deleted from SQLite. On restart `loadAllSpacesFromRepo()` reloaded the deleted space and all its agents.

**Fix:** Added `DeleteSpace()` to the repository (cascades all child rows in a transaction) and called it from `handleDeleteSpace`.

### Bug 2: Journal file resurrected deleted spaces
When SQLite is empty (e.g. the only space was just deleted), `loadAllSpaces()` falls back to `loadAllSpacesFromFiles()`, which picks up `.events.jsonl` files. The deletion only removed the `.json` and `.md` — the journal survived and resurrected the space.

**Fix:** `handleDeleteSpace` now also removes the `.events.jsonl` journal file.

### Bug 3: Cross-space task ID collision (tasks appear in wrong spaces)
Task IDs (`TASK-001`, `TASK-002`, …) are sequential per space, not globally unique. The `Task` model used `id` as the sole primary key, so when two spaces each created `TASK-001`, the second SQLite upsert conflicted on `id='TASK-001'` and overwrote the first space's task data (leaving `space_name` unchanged). After restart, tasks appeared in the wrong space.

**Fix:** Changed the `Task` model to a composite primary key `(space_name, id)`. Added a SQLite migration that recreates the `tasks` table with the correct schema for existing databases (SQLite cannot `ALTER TABLE` to change a primary key).

## Test plan
- `TestSQLiteDeleteSpacePersists`: deletes a space, restarts server, verifies space does not reappear
- `TestSQLiteTaskCrossSpaceIsolation`: two spaces each create `TASK-001`, restarts server, verifies each space only shows its own task
- All existing tests pass (`go test -race ./internal/coordinator/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)