### PR TITLE
fix(task-039): remove body overflow:hidden to restore TaskDetailPanel scrollbar

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -217,12 +217,15 @@
   }
   html {
     height: 100%;
-    overflow: hidden;
   }
   body {
     @apply bg-background text-foreground font-sans antialiased;
     height: 100%;
-    overflow: hidden;
+    /* overflow is intentionally NOT set here. Page scroll is prevented by the
+       app layout (SidebarInset h-dvh + main overflow-hidden), not by body
+       overflow. Setting overflow: hidden on body breaks Radix UI portals
+       (Sheet/Dialog) that append to <body> — their internal scrollbars stop
+       working because the body's scroll context is locked. */
   }
   code, pre, .font-mono {
     font-family: 'Red Hat Mono', ui-monospace, monospace;


### PR DESCRIPTION
## Summary

Fixes the task detail panel scrollbar broken by PR #52.

**Root cause:** PR #52 added `overflow: hidden` to `html` and `body` to eliminate the double horizontal scrollbar on the Kanban view. This inadvertently broke the TaskDetailPanel's scrollbar — the task detail is a Radix UI Sheet that portals its content directly into `<body>`, and with `body { overflow: hidden }`, the portal's internal `overflow-y-auto` scroll context stops working correctly.

**Why it's safe to remove:** The double scrollbar prevention is already handled by the app layout itself:
- `KanbanView` root div: `flex flex-col h-full overflow-hidden` (clips board overflow)
- `App.vue <main>`: `flex-1 min-h-0 overflow-hidden` (clips main content overflow)

These two `overflow-hidden` layers prevent any horizontal or vertical page scroll without touching the body scroll context. The body `overflow: hidden` was redundant for preventing page scroll but harmful to portaled components.

## Test plan
- Open the Kanban board — verify there is still only ONE horizontal scrollbar (on the board, not the page) on narrow viewports
- Click a task card to open the TaskDetailPanel — verify the task detail can scroll vertically when the content is tall (comments, description, etc.)
- No regression on double scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)