### PR TITLE
ci: add GitHub Actions to gate PRs with Go tests (TASK-048)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Go tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test -race -v ./internal/coordinator/


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `go test -race -v ./internal/coordinator/` on all PRs targeting `main` and on pushes to `main`
- Uses `go-version-file: go.mod` so the workflow always matches the project's declared Go version
- Enables race detector (`-race`) to catch concurrent access bugs

## Next step (manual)

After merging, enable branch protection in GitHub repo settings:
- **Settings → Branches → Add rule** for `main`
- Check **Require status checks to pass before merging**
- Select the `Go tests` check

## Test plan

- [x] `go test -race -v ./internal/coordinator/` passes locally (11 tests)
- Workflow triggers on PR creation and push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)