### PR TITLE
fix(lifecycle): add shell init sleep in TmuxBackend.CreateSession (TASK-054)

### DIFF
--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -65,6 +65,10 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 		return "", fmt.Errorf("create tmux session: %w", err)
 	}
 
+	// Wait for the shell to initialise before sending keys — without this,
+	// send-keys races shell startup and the cd keystroke is silently dropped.
+	time.Sleep(300 * time.Millisecond)
+
 	if workDir != "" {
 		if err := tmuxSendKeys(sessionID, "cd "+shellQuote(workDir)); err != nil {
 			exec.CommandContext(ctx, "tmux", "kill-session", "-t", sessionID).Run() //nolint:errcheck


### PR DESCRIPTION
## Summary

- Add `time.Sleep(300ms)` after `tmux new-session` in `TmuxBackend.CreateSession` before any `send-keys` calls
- Fixes the working directory not being set when creating an agent from the UI

## Root cause

`TmuxBackend.CreateSession` calls `tmux new-session -d` then immediately sends the `cd <workDir>` keystroke. Without a delay, this races shell initialization — the shell hasn't started yet, so the keystroke is silently dropped and the agent starts in the default directory (not the requested working directory).

The same pattern was already used in `handleAgentSpawn` (`lifecycle.go`) which added a 5s sleep before sending the ignite command.

## Note

The original fix from LifecycleMgr targeted `agent_backend.go`, which no longer exists after the SessionBackend interface refactor (PR #58). This PR applies the same fix to the correct file: `session_backend_tmux.go`.

## Test plan

- [x] `go test -race ./internal/coordinator/` passes (188 tests)
- [ ] Manual: create agent with custom working directory → verify agent starts in correct dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)