### PR TITLE
fix(db): use Save() instead of Create() for task comments/events (TASK-055)

### DIFF
--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -215,12 +215,12 @@ func (r *Repository) ListTasks(spaceName string, filters map[string]string) ([]*
 
 // SaveComment adds a comment to a task.
 func (r *Repository) SaveComment(c *TaskComment) error {
-	return r.db.Create(c).Error
+	return r.db.Save(c).Error
 }
 
 // SaveTaskEvent records a task lifecycle event.
 func (r *Repository) SaveTaskEvent(e *TaskEvent) error {
-	return r.db.Create(e).Error
+	return r.db.Save(e).Error
 }
 
 // DeleteTask removes a task and its comments/events.


### PR DESCRIPTION
## Summary

- Change `SaveComment` and `SaveTaskEvent` in `db/repository.go` from `db.Create()` to `db.Save()` (upsert by PK)

## Root cause

`persistSpaceToDB` iterates every task in a space and calls `saveTaskCommentToDB` / `saveTaskEventToDB` for every comment and event on every write. These called `db.Create()` which issues a plain `INSERT`. On any subsequent write after the initial insert, the same rows are re-inserted → `UNIQUE constraint failed: task_events.id` / `task_comments.id` spam in logs.

## Fix

`db.Save()` issues `INSERT OR UPDATE` (upsert keyed on PK), making `persistSpaceToDB` idempotent. No behavior change for new records; existing records are just refreshed in place.

## Test plan

- [x] `go test -race ./internal/coordinator/` passes (188 tests)
- [x] No UNIQUE constraint errors in server logs after multiple task/comment writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)