### PR TITLE
fix(ui): persist conversation read state via backend ACK

### DIFF
--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -112,13 +112,27 @@ function unreadCount(conv: Conversation): number {
   // Agent-to-agent conversations never show unread badges
   if (!isBossConversation(conv)) return 0
   if (readKeys.value.has(conv.key)) return 0
-  // Count messages not yet read (prefer backend read field when available)
-  return conv.messages.filter(m => m.read === false || m.read === undefined).length
+  // Only count messages directed at boss that haven't been acknowledged on the backend
+  return conv.messages.filter(m => m.recipient === 'boss' && !m.read).length
 }
 
-// Mark conversation as read when selected
+// ACK all unread messages to boss in a conversation so the backend persists read state.
+// This clears the sidebar badge (which reads msg.read from live space data) and ensures
+// the conversation stays read after navigate-away + return.
+function ackBossMessages(conv: Conversation) {
+  if (!isBossConversation(conv)) return
+  const unread = conv.messages.filter(m => m.recipient === 'boss' && !m.read)
+  for (const msg of unread) {
+    api.ackMessage(props.space.name, 'boss', msg.id, 'boss').catch(() => {})
+  }
+}
+
+// Mark conversation as read (optimistic local state) and ACK on backend
 watch(selectedKey, key => {
-  if (key) readKeys.value.add(key)
+  if (!key) return
+  readKeys.value.add(key)
+  const conv = conversations.value.find(c => c.key === key)
+  if (conv) ackBossMessages(conv)
 })
 
 // Pre-select from preselectAgent prop (set by App.vue from router param or when starting new conv)
@@ -243,7 +257,12 @@ function scrollThreadToBottom() {
 watch(selectedKey, () => scrollThreadToBottom())
 watch(
   () => selectedConversation.value?.messages.length,
-  () => scrollThreadToBottom(),
+  () => {
+    scrollThreadToBottom()
+    // ACK any new unread messages that arrived while this conversation is open
+    const conv = selectedConversation.value
+    if (conv) ackBossMessages(conv)
+  },
 )
 
 // ── Inline compose ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three related bugs fixed in the conversations UI:

- **Navigate-away resets read state**: `readKeys` was a local `ref(new Set())` that reset on every component unmount. Opening a conversation marked it read locally, but navigating away and back created a fresh component with an empty Set, making all conversations unread again.

- **Sidebar badge never cleared**: `bossUnreadCount` in AppSidebar reads `msg.read` from live space data (SSE). Since `ackMessage` was never called, the backend never set `read: true`, so the badge stayed forever regardless of user interaction.

- **`unreadCount` counted wrong messages**: The old filter `m.read === false || m.read === undefined` caught boss→agent messages where `read` is simply absent (those are in the agent's inbox, not boss's). Only messages with `recipient === 'boss'` should count toward boss's unread total.

## Fix

- Add `ackBossMessages(conv)` helper that calls `api.ackMessage(space, 'boss', id, 'boss')` for every unread message where `recipient === 'boss'`
- Call it when a conversation is selected (clears badge immediately and persists across navigation)
- Call it when the message count changes in the currently open conversation (handles SSE-pushed new messages)
- Fix `unreadCount` filter: `m.recipient === 'boss' && !m.read`

The `readKeys` optimistic local state is kept for immediate visual feedback; the backend ACK makes the state durable.

## Test plan
- [ ] Open a conversation with a boss message → unread badge shows
- [ ] Click the conversation → badge clears in conversation list and sidebar immediately
- [ ] Navigate to another view and back → conversation still shows as read (no badge)
- [ ] New message arrives via SSE while conversation is open → auto-ACKed, no badge shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)