### PR TITLE
fix(observability): TASK-051 fixup — thread-safe testLogger + EventAgentStaleCleared

### DIFF
--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -75,7 +75,7 @@ func (s *Server) checkStaleness() {
 						Msg:    fmt.Sprintf("marked stale (last update: %s ago)", now.Sub(agent.UpdatedAt).Round(time.Second)),
 						Fields: map[string]string{"idle_duration": now.Sub(agent.UpdatedAt).Round(time.Second).String()}})
 				} else {
-					s.emit(DomainEvent{Level: LevelInfo, EventType: EventAgentStale, Space: spaceName, Agent: name,
+					s.emit(DomainEvent{Level: LevelInfo, EventType: EventAgentStaleCleared, Space: spaceName, Agent: name,
 						Msg: "staleness cleared"})
 				}
 			}

--- a/internal/coordinator/logger.go
+++ b/internal/coordinator/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -29,6 +30,7 @@ const (
 
 	// Liveness events
 	EventAgentStale        EventType = "liveness.agent_stale"
+	EventAgentStaleCleared EventType = "liveness.agent_stale_cleared"
 	EventHeartbeatReceived EventType = "liveness.heartbeat_received"
 	EventNudgeTriggered    EventType = "liveness.nudge_triggered"
 
@@ -174,14 +176,19 @@ func NewLogger(out *os.File) Logger {
 
 // testLogger collects emitted DomainEvents in memory for use in tests.
 type testLogger struct {
+	mu     sync.Mutex
 	events []DomainEvent
 }
 
 func (l *testLogger) Log(e DomainEvent) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.events = append(l.events, e)
 }
 
 func (l *testLogger) last() *DomainEvent {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	if len(l.events) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Addresses 2 minor issues from LifecycleSME code review of TASK-051 (PR #64, merged).

- **Issue 1**: `testLogger` was not thread-safe. Added `sync.Mutex` to `Log()` and `last()` to prevent `-race` failures in future tests that spawn background goroutines.
- **Issue 2**: `EventAgentStale` was reused for both "marked stale" and "staleness cleared" events. Added `EventAgentStaleCleared EventType = "liveness.agent_stale_cleared"` constant and use it for the cleared case in `lifecycle.go`, so consumers can distinguish state transitions by `event_type` alone.

## Test plan

- [x] `go test -race ./internal/coordinator/` passes (30s, all tests green)
- [x] `EventAgentStaleCleared` used in `checkStaleness()` cleared branch
- [x] `testLogger` now safe for concurrent use

🤖 Generated with [Claude Code](https://claude.com/claude-code)