### PR TITLE
fix(lifecycle): TASK-071/072 — skip-permissions opt-in + task nudge

### DIFF
--- a/internal/coordinator/handlers_task.go
+++ b/internal/coordinator/handlers_task.go
@@ -685,6 +685,12 @@ func (s *Server) notifyTaskAssigned(spaceName, taskID, taskTitle, assignedTo, as
 	s.logEvent(fmt.Sprintf("[%s/%s] Task %s assigned by %s — notification delivered", spaceName, canonical, taskID, assignedBy))
 	s.journal.Append(spaceName, EventMessageSent, canonical, &msg)
 
+	// Schedule a tmux nudge so the agent is prompted to check in and act on the task.
+	// Same mechanism used by the direct message handler (handlers_agent.go).
+	s.nudgeMu.Lock()
+	s.nudgePending[spaceName+"/"+canonical] = time.Now()
+	s.nudgeMu.Unlock()
+
 	sseData, _ := json.Marshal(map[string]interface{}{
 		"space":    spaceName,
 		"agent":    canonical,

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -96,7 +96,7 @@ func (s *Server) checkStaleness() {
 // spawnRequest is the optional body for POST /spaces/{space}/agent/{name}/spawn.
 type spawnRequest struct {
 	SessionID      string `json:"session_id,omitempty"`      // defaults to agent name
-	Command        string `json:"command,omitempty"`         // defaults to "claude --dangerously-skip-permissions"
+	Command        string `json:"command,omitempty"`         // defaults to "claude"; --dangerously-skip-permissions applied via global server toggle
 	Width          int    `json:"width,omitempty"`           // tmux window width, default 220
 	Height         int    `json:"height,omitempty"`          // tmux window height, default 50
 	Backend        string `json:"backend,omitempty"`         // "tmux" (default) or "ambient"
@@ -146,6 +146,13 @@ func (s *Server) handleAgentSpawn(w http.ResponseWriter, r *http.Request, spaceN
 	}
 
 	ctx := context.Background()
+	// For tmux sessions, apply the global skip-permissions toggle when no explicit
+	// command was provided. This is the only place the flag is injected — individual
+	// agents cannot opt in or out independently.
+	spawnCommand := req.Command
+	if backend.Name() == "tmux" && s.allowSkipPermissions && spawnCommand == "" {
+		spawnCommand = "claude --dangerously-skip-permissions"
+	}
 	var createOpts SessionCreateOpts
 	if backend.Name() == "ambient" {
 		createOpts = SessionCreateOpts{
@@ -158,7 +165,7 @@ func (s *Server) handleAgentSpawn(w http.ResponseWriter, r *http.Request, spaceN
 	} else {
 		createOpts = SessionCreateOpts{
 			SessionID: sessionName,
-			Command:   req.Command,
+			Command:   spawnCommand,
 			BackendOpts: TmuxCreateOpts{
 				Width:  req.Width,
 				Height: req.Height,

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -71,6 +71,11 @@ type Server struct {
 	backends       map[string]SessionBackend
 	defaultBackend string
 	logger         Logger
+	// allowSkipPermissions, when true, appends --dangerously-skip-permissions to every
+	// tmux-backend agent launch command. Controlled by the BOSS_ALLOW_SKIP_PERMISSIONS
+	// environment variable (default off). This is a deliberate operator-level toggle —
+	// one decision applies to all agents uniformly.
+	allowSkipPermissions bool
 }
 
 func NewServer(port, dataDir string) *Server {
@@ -97,9 +102,10 @@ func NewServer(port, dataDir string) *Server {
 		stalenessThreshold: thresh,
 		registrations:      make(map[string]*AgentRegistrationRecord),
 		journal:            NewEventJournal(dataDir),
-		backends:           map[string]SessionBackend{"tmux": NewTmuxSessionBackend()},
-		defaultBackend:     "tmux",
-		logger:             NewLogger(os.Stdout),
+		backends:             map[string]SessionBackend{"tmux": NewTmuxSessionBackend()},
+		defaultBackend:       "tmux",
+		logger:               NewLogger(os.Stdout),
+		allowSkipPermissions: os.Getenv("BOSS_ALLOW_SKIP_PERMISSIONS") == "true",
 	}
 
 	if apiURL := os.Getenv("AMBIENT_API_URL"); apiURL != "" {

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -3537,3 +3537,52 @@ func TestStaleTaskDetection(t *testing.T) {
 		t.Error("done task should never be stale regardless of age")
 	}
 }
+
+// TestSkipPermissionsDefaultOff verifies that the global allowSkipPermissions flag
+// defaults to false and that setting BOSS_ALLOW_SKIP_PERMISSIONS=true enables it.
+func TestSkipPermissionsDefaultOff(t *testing.T) {
+	// Default: flag must be off.
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	if srv.allowSkipPermissions {
+		t.Error("allowSkipPermissions should be false by default")
+	}
+}
+
+func TestSkipPermissionsEnvVar(t *testing.T) {
+	t.Setenv("BOSS_ALLOW_SKIP_PERMISSIONS", "true")
+	dataDir := t.TempDir()
+	srv := NewServer(":0", dataDir)
+	if !srv.allowSkipPermissions {
+		t.Error("allowSkipPermissions should be true when BOSS_ALLOW_SKIP_PERMISSIONS=true")
+	}
+}
+
+// TestTaskAssignNudgesAgent verifies that assigning a task schedules a tmux nudge
+// for the assigned agent so they are prompted to check in. GH-81 regression test.
+func TestTaskAssignNudgesAgent(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+	space := "nudgetaskspace"
+
+	// Create a task and assign it to an agent.
+	postTaskJSON(t, taskURL(base, space, ""), map[string]any{
+		"title": "Work item", "assigned_to": "Worker",
+	}, "Boss").Body.Close()
+
+	// Nudge should be queued for Worker. resolveAgentName preserves input case for
+	// unregistered agents, so check case-insensitively.
+	srv.nudgeMu.Lock()
+	var found bool
+	for k := range srv.nudgePending {
+		if strings.EqualFold(k, space+"/Worker") {
+			found = true
+			break
+		}
+	}
+	srv.nudgeMu.Unlock()
+	if !found {
+		t.Error("expected nudge to be queued for Worker after task assignment, but nudgePending was empty")
+	}
+}

--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -39,7 +39,7 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 	sessionID := opts.SessionID
 	command := opts.Command
 	if command == "" {
-		command = "claude --dangerously-skip-permissions"
+		command = "claude"
 	}
 
 	width := 220


### PR DESCRIPTION
## Summary

Fixes two high-priority GitHub issues:

### TASK-071 / GH-79: `--dangerously-skip-permissions` is now opt-in

Previously the tmux backend launched all agents with `claude --dangerously-skip-permissions` by default — a security risk that violated the principle of least privilege.

**Changes:**
- `session_backend_tmux.go`: default command is now `claude` (no flags)
- `server.go`: new `allowSkipPermissions bool` field, controlled by `BOSS_ALLOW_SKIP_PERMISSIONS=true` env var (default `false`)
- `lifecycle.go`: global toggle is applied at spawn time for tmux agents only; per-agent `command` override still works as before
- Operators who want `--dangerously-skip-permissions` set `BOSS_ALLOW_SKIP_PERMISSIONS=true` once — applies uniformly to all tmux agents

### TASK-072 / GH-81: Task assignment now nudges the assigned agent

When a task was created/assigned to a tmux agent, a message was delivered to their queue but no tmux nudge was sent — so agents would not check in until their next scheduled heartbeat.

**Changes:**
- `handlers_task.go`: `notifyTaskAssigned` now schedules `nudgePending` after message delivery, using the same mechanism as the direct message handler

## Test plan

- [x] `TestSkipPermissionsDefaultOff` — flag is false by default
- [x] `TestSkipPermissionsEnvVar` — flag is true when `BOSS_ALLOW_SKIP_PERMISSIONS=true`
- [x] `TestTaskAssignNudgesAgent` — nudge queued when task assigned (GH-81 regression guard)
- [x] Full test suite: `go test -race ./internal/coordinator/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)