### PR TITLE
feat(lifecycle): TASK-073 — Interrupt button + rename Stop to Kill

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -274,6 +274,13 @@ class ApiClient {
     )
   }
 
+  interruptAgent(space: string, agent: string): Promise<void> {
+    return this.requestVoid(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/interrupt`,
+      { method: 'POST', headers: { 'X-Agent-Name': agent } },
+    )
+  }
+
   restartAgent(space: string, agent: string): Promise<{ ok: boolean; session_id: string }> {
     return this.request(
       `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/restart`,

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/alert-dialog'
 
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Bell, Trash2, ShieldCheck, Terminal, ChevronRight, X, HelpCircle, AlertTriangle, MessageSquareReply, Play, Square, RotateCcw, Loader2, CheckCircle2, XCircle, Radio, MessageSquare, ListTodo } from 'lucide-vue-next'
+import { Bell, Trash2, ShieldCheck, Terminal, ChevronRight, X, HelpCircle, AlertTriangle, MessageSquareReply, Play, Square, RotateCcw, Loader2, CheckCircle2, XCircle, Radio, MessageSquare, ListTodo, OctagonX } from 'lucide-vue-next'
 import StatusBadge from './StatusBadge.vue'
 import AgentMessages from './AgentMessages.vue'
 import AgentAvatar from './AgentAvatar.vue'
@@ -175,7 +175,7 @@ const attentionSectionClass = computed(() => {
 })
 
 // --------------- Lifecycle ---------------
-const lifecycleLoading = ref<'spawn' | 'stop' | 'restart' | null>(null)
+const lifecycleLoading = ref<'spawn' | 'stop' | 'interrupt' | 'restart' | null>(null)
 const lifecycleToast = ref<{ type: 'success' | 'error'; message: string } | null>(null)
 const stopConfirmOpen = ref(false)
 
@@ -203,7 +203,19 @@ async function handleStop() {
   lifecycleLoading.value = 'stop'
   try {
     await api.stopAgent(props.spaceName, props.agentName)
-    showToast('success', `${props.agentName} stopped`)
+    showToast('success', `${props.agentName} killed`)
+  } catch (e) {
+    showToast('error', e instanceof Error ? e.message : String(e))
+  } finally {
+    lifecycleLoading.value = null
+  }
+}
+
+async function handleInterrupt() {
+  lifecycleLoading.value = 'interrupt'
+  try {
+    await api.interruptAgent(props.spaceName, props.agentName)
+    showToast('success', `Escape sent to ${props.agentName}`)
   } catch (e) {
     showToast('error', e instanceof Error ? e.message : String(e))
   } finally {
@@ -500,13 +512,28 @@ watch(() => props.agentName, loadAgentTasks)
                 <TooltipTrigger as-child>
                   <Button
                     variant="ghost" size="sm"
+                    class="h-7 px-2 text-xs gap-1 text-amber-600/70 hover:text-amber-600 hover:bg-amber-500/10"
+                    :disabled="lifecycleLoading !== null"
+                    @click="handleInterrupt"
+                  >
+                    <Loader2 v-if="lifecycleLoading === 'interrupt'" class="size-3 animate-spin" />
+                    <OctagonX v-else class="size-3" />
+                    Interrupt
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Send Escape to the agent (interrupt current task)</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    variant="ghost" size="sm"
                     class="h-7 px-2 text-xs gap-1 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
                     :disabled="lifecycleLoading !== null"
                     @click="stopConfirmOpen = true"
                   >
                     <Loader2 v-if="lifecycleLoading === 'stop'" class="size-3 animate-spin" />
                     <Square v-else class="size-3" />
-                    Stop
+                    Kill
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Kill the agent's tmux session</TooltipContent>
@@ -846,19 +873,19 @@ watch(() => props.agentName, loadAgentTasks)
         </AlertDialogContent>
       </AlertDialog>
 
-      <!-- Stop agent confirmation AlertDialog -->
+      <!-- Kill agent confirmation AlertDialog -->
       <AlertDialog v-model:open="stopConfirmOpen">
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Stop agent?</AlertDialogTitle>
+            <AlertDialogTitle>Kill agent?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will kill the tmux session for <span class="font-semibold text-foreground">{{ agentName }}</span>. Any in-progress work will be interrupted. You can respawn the agent afterwards.
+              This will kill the tmux session for <span class="font-semibold text-foreground">{{ agentName }}</span>. Any in-progress work will be lost. You can respawn the agent afterwards.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction class="bg-destructive text-destructive-foreground hover:bg-destructive/90" @click="handleStop">
-              <Square class="size-4" /> Stop
+              <Square class="size-4" /> Kill
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -144,6 +144,8 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 				s.handleAgentSpawn(w, r, spaceName, agentName)
 			case "stop":
 				s.handleAgentStop(w, r, spaceName, agentName)
+			case "interrupt":
+				s.handleAgentInterrupt(w, r, spaceName, agentName)
 			case "restart":
 				s.handleAgentRestart(w, r, spaceName, agentName)
 			case "introspect":

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -318,6 +318,67 @@ func (s *Server) handleAgentStop(w http.ResponseWriter, r *http.Request, spaceNa
 	})
 }
 
+// handleAgentInterrupt handles POST /spaces/{space}/agent/{name}/interrupt.
+// Sends an interrupt (Escape key for Claude Code) to the agent's session without killing it.
+func (s *Server) handleAgentInterrupt(w http.ResponseWriter, r *http.Request, spaceName, agentName string) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		http.Error(w, fmt.Sprintf("space %q not found", spaceName), http.StatusNotFound)
+		return
+	}
+
+	s.mu.RLock()
+	canonical := resolveAgentName(ks, agentName)
+	agent, exists := ks.Agents[canonical]
+	var sessionName string
+	if exists {
+		sessionName = agent.SessionID
+	}
+	s.mu.RUnlock()
+
+	if !exists {
+		http.Error(w, fmt.Sprintf("agent %q not found", agentName), http.StatusNotFound)
+		return
+	}
+	if isNonSessionAgent(agent) {
+		nonSessionLifecycleError(w, agent.Registration.AgentType)
+		return
+	}
+	if sessionName == "" {
+		http.Error(w, fmt.Sprintf("agent %q has no registered session", canonical), http.StatusBadRequest)
+		return
+	}
+
+	backend := s.backendFor(agent)
+	if !backend.SessionExists(sessionName) {
+		http.Error(w, fmt.Sprintf("session %q not found", sessionName), http.StatusNotFound)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCmdTimeout)
+	defer cancel()
+	if err := backend.Interrupt(ctx, sessionName); err != nil {
+		http.Error(w, fmt.Sprintf("interrupt session: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	s.emit(DomainEvent{Level: LevelInfo, EventType: EventAgentStopped, Space: spaceName, Agent: canonical,
+		Msg:    fmt.Sprintf("interrupted (Escape sent to session %q)", sessionName),
+		Fields: map[string]string{"session_id": sessionName}})
+	s.broadcastSSE(spaceName, canonical, "agent_interrupted", canonical)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":    true,
+		"agent": canonical,
+	})
+}
+
 // handleAgentRestart handles POST /spaces/{space}/agent/{name}/restart.
 // Kills the existing session and spawns a new one.
 func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spaceName, agentName string) {


### PR DESCRIPTION
## Summary

- **Backend**: new `POST /spaces/{space}/agent/{name}/interrupt` endpoint that calls `backend.Interrupt()` (sends Escape key to the tmux session — correct for Claude Code agents, per boss directive)
- **Frontend**: renames existing Stop button → **Kill** (with updated confirmation dialog)
- **Frontend**: adds new **Interrupt** button (amber colour, OctagonX icon) that sends Escape to interrupt the current task without killing the session
- **API client**: adds `interruptAgent()` method

## Test plan
- [ ] Interrupt button appears in AgentDetail lifecycle controls (amber, between Restart and Kill)
- [ ] Clicking Interrupt sends POST to `/interrupt` endpoint and shows "Escape sent to \<agent\>" toast
- [ ] Kill button shows confirmation dialog saying "Kill agent?" before proceeding
- [ ] Backend `handleAgentInterrupt` calls `backend.Interrupt()` which sends Escape via tmux
- [ ] Non-session agents get 422 error from interrupt endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)