### PR TITLE
fix(storage): TASK-094 — remove JSON dual-write; SQLite-only persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Boss
 
-A coordination server for multi-agent AI teams. Agents post structured status updates over HTTP; the server persists state as JSON and renders a real-time Vue dashboard.
+A coordination server for multi-agent AI teams. Agents post structured status updates over HTTP; the server persists state to SQLite and renders a real-time Vue dashboard.
 
 <img width="2534" height="1985" alt="Agent Boss dashboard" src="https://github.com/user-attachments/assets/dcf7db5a-08e7-49ad-b92f-5fcf4a277ff2" />
 
@@ -30,7 +30,7 @@ DATA_DIR=./data ./boss serve
 
 Open the dashboard at **http://localhost:8899**.
 
-Data persists across restarts — JSON files in `DATA_DIR` are loaded on startup.
+Data persists across restarts — stored in SQLite (`DATA_DIR/boss.db`). Legacy JSON files are read once on first startup to migrate existing data.
 
 ## Development (hot-reload frontend)
 
@@ -72,7 +72,7 @@ Agents post structured JSON to their channel. The server assembles a space docum
 
 ```
 Agent A ──POST JSON──┐
-Agent B ──POST JSON──┼──▶ Boss Server ──▶ KnowledgeSpace (JSON + SQLite)
+Agent B ──POST JSON──┼──▶ Boss Server ──▶ KnowledgeSpace (SQLite)
 Agent C ──POST JSON──┘         │
                                ▼
                         Vue dashboard (SSE)

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -268,11 +268,6 @@ func TestPersistence(t *testing.T) {
 	})
 	srv1.Stop()
 
-	jsonFile := filepath.Join(dataDir, "persist-test.json")
-	if _, err := os.Stat(jsonFile); os.IsNotExist(err) {
-		t.Fatal("expected persist-test.json to exist")
-	}
-
 	srv2 := NewServer(":0", dataDir)
 	if err := srv2.Start(); err != nil {
 		t.Fatal(err)
@@ -1030,15 +1025,6 @@ func TestDeleteSpaceCleansUpFiles(t *testing.T) {
 		Status: StatusDone, Summary: "test persistence cleanup",
 	})
 
-	jsonPath := filepath.Join(dataDir, "file-cleanup.json")
-	mdPath := filepath.Join(dataDir, "file-cleanup.md")
-	if _, err := os.Stat(jsonPath); os.IsNotExist(err) {
-		t.Fatal("expected json file to exist before delete")
-	}
-	if _, err := os.Stat(mdPath); os.IsNotExist(err) {
-		t.Fatal("expected md file to exist before delete")
-	}
-
 	req, _ := http.NewRequest(http.MethodDelete, base+"/spaces/file-cleanup/", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1046,11 +1032,10 @@ func TestDeleteSpaceCleansUpFiles(t *testing.T) {
 	}
 	resp.Body.Close()
 
-	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
-		t.Error("expected json file to be deleted")
-	}
-	if _, err := os.Stat(mdPath); !os.IsNotExist(err) {
-		t.Error("expected md file to be deleted")
+	// After delete the space should no longer be served.
+	code, _ := getBody(t, base+"/spaces/file-cleanup/agent/api")
+	if code == http.StatusOK {
+		t.Error("expected space to be gone after delete")
 	}
 }
 

--- a/internal/coordinator/storage.go
+++ b/internal/coordinator/storage.go
@@ -142,44 +142,12 @@ func (s *Server) loadSpace(name string) (*KnowledgeSpace, error) {
 	return &ks, nil
 }
 
-const maxBackups = 10
-
-func (s *Server) rotateBackups(spaceName string) {
-	backupDir := filepath.Join(s.dataDir, "backups")
-	os.MkdirAll(backupDir, 0755)
-
-	base := filepath.Join(backupDir, spaceName+".json")
-	for i := maxBackups; i > 1; i-- {
-		src := fmt.Sprintf("%s.%d", base, i-1)
-		dst := fmt.Sprintf("%s.%d", base, i)
-		os.Rename(src, dst)
-	}
-
-	src := s.spacePath(spaceName)
-	dst := fmt.Sprintf("%s.%d", base, 1)
-	data, err := os.ReadFile(src)
-	if err == nil {
-		os.WriteFile(dst, data, 0644)
-	}
-}
 
 func (s *Server) saveSpace(ks *KnowledgeSpace) error {
-	// Persist to SQLite (primary store).
-	s.persistSpaceToDB(ks)
-
+	// Refresh protocol before persisting so SQLite receives the updated SharedContracts.
 	s.refreshProtocol(ks)
-	data, err := json.MarshalIndent(ks, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal %s: %w", ks.Name, err)
-	}
-	s.rotateBackups(ks.Name)
-	if err := os.WriteFile(s.spacePath(ks.Name), data, 0644); err != nil {
-		return err
-	}
-	md := ks.RenderMarkdown()
-	if err := os.WriteFile(s.spaceMarkdownPath(ks.Name), []byte(md), 0644); err != nil {
-		s.logEvent(fmt.Sprintf("warning: failed to write markdown for %q: %v", ks.Name, err))
-	}
+	// Persist to SQLite (primary store). JSON/.md files are migration-only artifacts.
+	s.persistSpaceToDB(ks)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- **TASK-094**: Remove dual-write from `saveSpace()`. Previously every mutation wrote to both SQLite and `.json`/`.md` files. Now SQLite is the sole write target; JSON files are only produced during the one-time legacy import on empty-DB startup.

### Changes

- **`storage.go`**: Removed `rotateBackups()` and the `os.WriteFile()` calls for `.json` and `.md` in `saveSpace()`. Moved `refreshProtocol()` _before_ `persistSpaceToDB()` so the updated `SharedContracts` is included in the SQLite write.
- **`server_test.go`**: Updated `TestPersistence` (no longer asserts `.json` file exists) and `TestDeleteSpaceCleansUpFiles` (now verifies space is gone via API instead of checking file system).
- **`README.md`**: Updated persistence description to reflect SQLite-only writes.

## Test plan
- [x] All 225 tests pass (`go test -race -count=1 ./internal/coordinator/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)