### PR TITLE
fix(cli): TASK-095 — fix boss init MCP port and duplicate registration

### DIFF
--- a/cmd/boss/main.go
+++ b/cmd/boss/main.go
@@ -84,7 +84,11 @@ func serverURL() string {
 	if u := os.Getenv("BOSS_URL"); u != "" {
 		return strings.TrimRight(u, "/")
 	}
-	return "http://localhost:8899"
+	port := "8899"
+	if p := os.Getenv("COORDINATOR_PORT"); p != "" {
+		port = strings.TrimPrefix(p, ":")
+	}
+	return "http://localhost:" + port
 }
 
 func cmdServe(args []string) {
@@ -311,10 +315,10 @@ func cmdInit(args []string) {
 	}
 
 	// Step 2: register the MCP server with Claude.
+	// Remove any existing boss-mcp entry first so re-registration always succeeds.
 	mcpURL := baseURL + "/mcp"
-	mcpCmd := []string{"claude", "mcp", "add", "boss-mcp", "--transport", "http", mcpURL}
-	// Use os/exec to run the command.
-	if err := runMCPRegister(mcpCmd); err != nil {
+	runMCPRegister([]string{"claude", "mcp", "remove", "boss-mcp"}) //nolint:errcheck — ignore if not present
+	if err := runMCPRegister([]string{"claude", "mcp", "add", "boss-mcp", "--transport", "http", mcpURL}); err != nil {
 		fmt.Fprintf(os.Stderr, "boss init: MCP registration failed: %v\n", err)
 		fmt.Fprintf(os.Stderr, "  Run manually: claude mcp add boss-mcp --transport http %s\n", mcpURL)
 	} else {


### PR DESCRIPTION
## Summary

Two bugs fixed in `boss init` (introduced in #93):

**Bug 1 — Wrong port in MCP URL**: `serverURL()` defaulted to port `8899` and did not check `COORDINATOR_PORT`. Running `COORDINATOR_PORT=8889 boss init myspace` would register `http://localhost:8899/mcp` instead of `http://localhost:8889/mcp`. Fixed by reading `COORDINATOR_PORT` in `serverURL()`.

**Bug 2 — Duplicate registration fails**: `claude mcp add boss-mcp` exits with an error if `boss-mcp` already exists in the Claude local config. Fixed by silently running `claude mcp remove boss-mcp` before re-adding, making the registration idempotent.

## Test plan
- [x] All 225 tests pass
- [x] `COORDINATOR_PORT=8889 boss init myspace` now uses port `8889` in the MCP URL
- [x] Re-running `boss init` no longer fails with "already exists"

🤖 Generated with [Claude Code](https://claude.com/claude-code)