### PR TITLE
fix(approval): fix broken tmux approval — remove re-check race, send '1'+Enter

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -1088,11 +1088,14 @@ func (s *Server) handleApproveAgent(w http.ResponseWriter, r *http.Request, spac
 		writeJSONError(w, canonical+": session not found", http.StatusBadRequest)
 		return
 	}
+	// Get current approval state for metadata (tool name, prompt text).
+	// Do NOT block on this check — the user explicitly clicked Approve in the
+	// dashboard (meaning an approval interrupt was already recorded by the
+	// liveness monitor). A re-check here is a race: the detection pattern may
+	// not match on a second read even though the agent is still waiting.
+	// We send the approval keystroke regardless and let the liveness monitor
+	// clear the interrupt on the next poll.
 	approval := backend.CheckApproval(sessionID)
-	if !approval.NeedsApproval {
-		writeJSONError(w, canonical+": not waiting for approval", http.StatusConflict)
-		return
-	}
 	if err := backend.Approve(sessionID); err != nil {
 		writeJSONError(w, canonical+": approve failed: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -196,9 +196,17 @@ func tmuxCheckApproval(session string) ApprovalInfo {
 }
 
 func tmuxApprove(session string) error {
+	// Send "1" to explicitly select "Yes" (option 1 in the approval dialog),
+	// then Enter to confirm. This is more robust than Enter alone, which
+	// depends on "1. Yes" already being focused (❯) in the menu.
 	ctx, cancel := context.WithTimeout(context.Background(), tmuxCmdTimeout)
 	defer cancel()
-	return exec.CommandContext(ctx, "tmux", "send-keys", "-t", session, "Enter").Run()
+	if err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", session, "1").Run(); err != nil {
+		return err
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxCmdTimeout)
+	defer cancel2()
+	return exec.CommandContext(ctx2, "tmux", "send-keys", "-t", session, "Enter").Run()
 }
 
 // tmuxIsIdle reports whether the tmux session appears to be waiting for input


### PR DESCRIPTION
## Summary

Fixes TASK-097 — Claude Code (in tmux) approval requests are non-functional when triggered from the dashboard.

### Root cause

**Race condition in `handleApproveAgent`**: The handler called `backend.CheckApproval(sessionID)` twice — once in the liveness monitor (which recorded the interrupt and showed the Approve button) and once in the approve handler itself. On the second call, the terminal state may have changed (different lines captured), causing the detection to return `NeedsApproval = false`. The handler then returned 409 "not waiting for approval", and the user saw "Approve failed".

**Weak approval keystroke**: `tmuxApprove()` only sent `Enter`, which works only if option 1 (Yes) is already focused with `❯`. Sending just Enter when focus is elsewhere in the menu could accidentally select the wrong option.

### Fix

- **`handlers_agent.go`**: Remove the `CheckApproval()` re-check guard. An approval interrupt was already recorded by the liveness monitor. Human intent (clicking Approve) overrides re-detection. The liveness monitor will clear the interrupt on the next poll after it's resolved.

- **`tmux.go`**: `tmuxApprove()` now sends `"1"` + `Enter` to explicitly select option 1 ("Yes") in the permission dialog, regardless of which item is currently focused.

## Test plan
- [ ] Spawn an agent without `--dangerously-skip-permissions`
- [ ] Trigger a tool use that requires permission (e.g. Bash command)
- [ ] Click Approve in the dashboard → approval should succeed
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)