### PR TITLE
fix(spawn): replace /boss.ignite with plain-text ignition + spawn feedback (TASK-100)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -543,6 +543,25 @@ function setupSSE() {
     pushLog('agent_updated', `[${data.agent}] ${data.status}: ${data.summary}`)
   })
 
+  sse.on('agent_spawned', (data) => {
+    // New agent just spawned — add a placeholder immediately so the card
+    // appears in the UI without waiting for the agent's first status POST.
+    if (currentSpace.value && currentSpace.value.name === data.space) {
+      if (!currentSpace.value.agents[data.agent]) {
+        currentSpace.value.agents[data.agent] = {
+          status: 'idle',
+          summary: `${data.agent}: spawning…`,
+          updated_at: new Date().toISOString(),
+        } as AgentUpdate
+      }
+    }
+    // Schedule a full reload to pick up the real agent record from the backend
+    scheduleSpaceReload(data.space, 2000)
+    scheduleSpacesReload(500)
+    statusAnnouncement.value = `Agent ${data.agent} spawned`
+    pushLog('agent_spawned', `[${data.agent}] agent spawned`)
+  })
+
   sse.on('agent_removed', (data) => {
     // Remove agent in-place immediately for instant feedback
     if (currentSpace.value && currentSpace.value.name === data.space) {

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -190,7 +190,7 @@ async function handleSpawn() {
   lifecycleLoading.value = 'spawn'
   try {
     await api.spawnAgent(props.spaceName, props.agentName)
-    showToast('success', `${props.agentName} spawned — ignite sent in ~5s`)
+    showToast('success', `${props.agentName} spawned — ignition prompt sent in ~5s`)
   } catch (e) {
     showToast('error', e instanceof Error ? e.message : String(e))
   } finally {

--- a/frontend/src/composables/useSSE.ts
+++ b/frontend/src/composables/useSSE.ts
@@ -2,6 +2,7 @@ import { ref, type Ref } from 'vue'
 import type {
   SSEAgentUpdated,
   SSEAgentRemoved,
+  SSEAgentSpawned,
   SSEAgentMessage,
   SSESessionLiveness,
   SSEBroadcastProgress,
@@ -11,6 +12,7 @@ import type {
 // All SSE event types emitted by the Go backend
 export type SSEEventType =
   | 'agent_updated'
+  | 'agent_spawned'
   | 'agent_removed'
   | 'space_deleted'
   | 'agent_message'
@@ -21,6 +23,7 @@ export type SSEEventType =
 
 export type SSEEventMap = {
   agent_updated: SSEAgentUpdated
+  agent_spawned: SSEAgentSpawned
   agent_removed: SSEAgentRemoved
   space_deleted: string // space name
   agent_message: SSEAgentMessage
@@ -95,6 +98,7 @@ export function useSSE() {
   function attachListeners(es: EventSource) {
     const eventTypes: SSEEventType[] = [
       'agent_updated',
+      'agent_spawned',
       'agent_removed',
       'space_deleted',
       'agent_message',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -264,6 +264,11 @@ export interface SSEAgentRemoved {
   agent: string
 }
 
+export interface SSEAgentSpawned {
+  space: string
+  agent: string
+}
+
 export interface SSETaskUpdated {
   id: string
   space: string

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -1424,7 +1424,8 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 	s.mu.Unlock()
 
 	s.logEvent(fmt.Sprintf("[%s/%s] created via %s backend (session: %s)", spaceName, req.Name, backendName, sessionID))
-	s.broadcastSSE(spaceName, req.Name, "agent_spawned", req.Name)
+	spawnedPayload, _ := json.Marshal(map[string]string{"space": spaceName, "agent": req.Name})
+	s.broadcastSSE(spaceName, req.Name, "agent_spawned", string(spawnedPayload))
 
 	// Capture closure variables before goroutine.
 	initialMsg := req.InitialMessage
@@ -1442,8 +1443,11 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 		} else {
 			time.Sleep(5 * time.Second)
 		}
-		igniteCmd := fmt.Sprintf(`/boss.ignite "%s" "%s"`, agentNameForIgnite, spaceName)
-		if err := backend.SendInput(sessionID, igniteCmd); err != nil {
+		// Send plain-text ignition prompt directly — no slash command required.
+		s.mu.RLock()
+		igniteText := s.buildIgnitionText(spaceName, agentNameForIgnite, sessionID)
+		s.mu.RUnlock()
+		if err := backend.SendInput(sessionID, igniteText); err != nil {
 			s.logEvent(fmt.Sprintf("[%s/%s] create: ignite send failed: %v", spaceName, agentNameForIgnite, err))
 		}
 		if initialMsg != "" {


### PR DESCRIPTION
## Summary

- **Backend**: Replace `/boss.ignite` slash command with plain-text ignition prompt. The `buildIgnitionText()` function already existed and produces the correct bootstrap text — the spawn handler now sends that directly instead of the removed slash command.
- **Backend**: `agent_spawned` SSE event now carries `{space, agent}` JSON payload (was just the agent name string).
- **Frontend**: New `agent_spawned` SSE handler inserts a placeholder agent card immediately on spawn, so the new agent appears in the dashboard right away instead of ~30s later when the agent first POSTs its own status.
- **Frontend**: `SSEAgentSpawned` type added; `agent_spawned` added to SSE event listener list.

## Test plan

- [ ] Create a new tmux agent via the UI — verify it appears in the dashboard immediately (spawning… placeholder)
- [ ] Verify agent initializes correctly with the plain-text ignition (no `/boss.ignite` slash command in tmux)
- [ ] Verify the placeholder agent card transitions to real status once the agent posts its first update
- [ ] Run `go test -race ./internal/coordinator/` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)