### PR TITLE
fix(tmux): TASK-082 — double Escape to fully interrupt Claude Code

### DIFF
--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -152,6 +152,14 @@ func (b *TmuxSessionBackend) Approve(sessionID string) error {
 }
 
 func (b *TmuxSessionBackend) Interrupt(ctx context.Context, sessionID string) error {
+	// Claude Code requires two Escape presses to fully cancel a running operation:
+	// the first Escape triggers the "Interrupt?" confirmation prompt, and the second
+	// confirms the cancellation. Sending both with a short delay makes a single
+	// "Interrupt" button press work end-to-end without needing a second click.
+	if err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", sessionID, "Escape").Run(); err != nil {
+		return err
+	}
+	time.Sleep(500 * time.Millisecond)
 	return exec.CommandContext(ctx, "tmux", "send-keys", "-t", sessionID, "Escape").Run()
 }
 


### PR DESCRIPTION
## Summary

Fixes TASK-082: tmux Interrupt button requires two clicks to actually interrupt.

**Root cause**: Claude Code's TUI requires two Escape presses to cancel a running operation:
1. First `Escape` → shows "Interrupt?" confirmation prompt  
2. Second `Escape` → confirms the cancellation

The previous implementation sent only one `Escape`, leaving the agent in the confirmation-prompt state. Users had to press Interrupt a second time ~3 seconds later to complete the cancel.

**Fix**: `TmuxSessionBackend.Interrupt()` now sends `Escape` twice with a 500ms delay between them, so a single Interrupt button press completes the full cancel sequence.

## Test plan

- [ ] Click Interrupt on a running tmux agent → agent stops in one click (not two)
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)