### PR TITLE
fix(tmux): correct approval detection blocked by idle heuristic (TASK-101)

### DIFF
--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -164,19 +164,24 @@ func tmuxCheckApproval(session string) ApprovalInfo {
 	}
 	var toolName string
 	var contentLines []string
+	toolKeywords := []string{"Bash", "Read", "Write", "Edit", "MultiEdit", "Glob", "Grep", "WebFetch", "NotebookEdit", "Task"}
 	for _, l := range lines[:promptIdx] {
-		if !strings.Contains(l, "│") {
-			continue
-		}
 		trimmed := strings.TrimSpace(l)
+		// Strip box-drawing borders (old-style dialog) or plain spaces (new-style).
 		inner := strings.TrimSpace(strings.ReplaceAll(trimmed, "│", ""))
 		if inner == "" {
 			continue
 		}
+		// Skip box corners/edges
 		if strings.HasPrefix(inner, "╭") || strings.HasPrefix(inner, "╰") || strings.HasPrefix(inner, "─") {
 			continue
 		}
-		for _, kw := range []string{"Bash", "Read", "Write", "Edit", "MultiEdit", "Glob", "Grep", "WebFetch", "NotebookEdit", "Task"} {
+		// Skip meta lines like "This command requires approval"
+		if strings.Contains(inner, "requires approval") {
+			continue
+		}
+		// Try to extract tool name from this line
+		for _, kw := range toolKeywords {
 			if strings.HasPrefix(inner, kw+" ") || inner == kw || strings.HasPrefix(inner, kw+"(") {
 				toolName = kw
 				break
@@ -253,10 +258,15 @@ func lineIsIdleIndicator(line string) bool {
 	// ── Claude Code prompt with suggestion ──
 	// Claude Code shows "❯" as its prompt. When idle it may auto-fill a
 	// suggested prompt after the ❯ (e.g. "❯ give me something to work on").
-	// A line starting with ❯ means the agent is waiting for input regardless
-	// of what follows (user-typed text or auto-suggestion).
+	// A line starting with ❯ means the agent is waiting for input, UNLESS
+	// it is a numbered menu option (e.g. "❯ 1. Yes") — those appear inside
+	// the approval dialog and must NOT be treated as idle.
 	if strings.HasPrefix(trimmed, "❯") {
-		return true
+		after := strings.TrimSpace(strings.TrimPrefix(trimmed, "❯"))
+		isNumberedOption := len(after) > 0 && after[0] >= '1' && after[0] <= '9' && len(after) > 1 && after[1] == '.'
+		if !isNumberedOption {
+			return true
+		}
 	}
 
 	// ── Shell prompts ──


### PR DESCRIPTION
## Root Cause

`tmuxIsIdle()` treated any line starting with `❯` as an idle indicator (Claude Code's text input prompt). But the approval dialog shows `❯ 1. Yes` as the highlighted menu option — also starting with `❯`.

This caused `tmuxIsIdle()` to return `true` when the approval dialog was visible, making `tmuxCheckApproval()` exit early without ever detecting the pending approval. Result: `needs_approval` was never set, no approval button appeared in the UI.

## Fix

- **`tmuxIsIdle`**: exclude `❯ N.` patterns (numbered menu options) from the idle check. The approval dialog line `❯ 1. Yes` now falls through correctly.
- **`tmuxCheckApproval`**: remove the `│`-only filter on content lines so the border-free approval dialog format is handled. Also skip "requires approval" meta lines. Both dialog styles (boxed and plain) now extract tool name and prompt text correctly.

## Test plan

- [ ] Create non-privileged tmux agent; trigger a tool that requires approval
- [ ] Verify approval badge appears in space overview and approval card + button appears in agent detail
- [ ] Click Approve — verify agent proceeds
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)