### PR TITLE
fix(coordinator): persist work_dir to AgentConfig on agent creation (TASK-102)

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -1416,6 +1416,16 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 	if req.Role != "" && agent.Role == "" {
 		agent.Role = req.Role
 	}
+	// Persist work_dir (and any future create-time config) to AgentConfig so it
+	// is visible in the agent detail view and survives restarts.
+	if req.WorkDir != "" {
+		cfg := ks.agentConfig(canonical)
+		if cfg == nil {
+			cfg = &AgentConfig{}
+		}
+		cfg.WorkDir = req.WorkDir
+		ks.setAgentConfig(canonical, cfg)
+	}
 	if err := s.saveSpace(ks); err != nil {
 		s.mu.Unlock()
 		writeJSONError(w, fmt.Sprintf("save: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

When creating an agent via the UI, the working directory was passed to `TmuxCreateOpts` (so the tmux session starts in the right directory) but was **never written to `AgentConfig`**. As a result, `GET /config` returned an empty `work_dir` and the agent detail view showed nothing.

**Fix**: After registering the agent in the space, write `work_dir` into `AgentConfig` via `setAgentConfig` so it is persisted to the DB and returned by the config endpoint.

## Test plan

- [ ] Create agent with a work_dir via the UI dialog
- [ ] Navigate to agent detail — verify work_dir appears in the Config section
- [ ] Restart server, reload — verify work_dir still shows (persisted to DB)
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)