### PR TITLE
feat(approval): Always Allow option + global approval banner (TASK-103)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -108,6 +108,13 @@ const currentAgentNames = computed<string[]>(() =>
   Object.keys(currentSpace.value?.agents ?? {}),
 )
 
+// Agents in the current space that have a pending approval
+const agentsNeedingApproval = computed<string[]>(() =>
+  Object.entries(tmuxStatus.value)
+    .filter(([, s]) => s.needs_approval)
+    .map(([name]) => name),
+)
+
 // Build hierarchy from agent parent fields so done/idle agents are included.
 // Merges API hierarchy data (role) with the complete agent roster.
 const effectiveHierarchy = computed<HierarchyTree | null>(() => {
@@ -279,16 +286,20 @@ async function handleBroadcastSpace() {
   }
 }
 
-async function handleApproveAgent() {
+async function handleApproveAgent(always = false) {
   if (!selectedSpace.value || !selectedAgent.value) return
   try {
-    await api.approveAgent(selectedSpace.value, selectedAgent.value)
+    await api.approveAgent(selectedSpace.value, selectedAgent.value, always)
     await loadSessionStatus(selectedSpace.value)
-    showStatus(`Approved ${selectedAgent.value}`)
+    showStatus(always ? `Always allowed for ${selectedAgent.value}` : `Approved ${selectedAgent.value}`)
   } catch (err) {
     console.error('Approve failed:', err)
     showError('Approval failed. Please try again.')
   }
+}
+
+async function handleAlwaysAllowAgent() {
+  return handleApproveAgent(true)
 }
 
 async function handleReplyAgent(text: string) {
@@ -822,6 +833,27 @@ onUnmounted(() => {
         @archive-space="handleArchiveSpace"
       />
       <SidebarInset class="flex flex-col h-dvh">
+        <!-- Global approval banner — shown whenever any agent in the current space needs approval -->
+        <div
+          v-if="agentsNeedingApproval.length > 0"
+          class="shrink-0 bg-destructive text-destructive-foreground px-4 py-2 flex items-center justify-between gap-3 text-sm font-text"
+          role="alert"
+          aria-live="assertive"
+        >
+          <span class="font-semibold">
+            ⚠ {{ agentsNeedingApproval.length === 1 ? agentsNeedingApproval[0] : agentsNeedingApproval.length + ' agents' }} waiting for approval
+          </span>
+          <div class="flex gap-2">
+            <button
+              v-for="name in agentsNeedingApproval"
+              :key="name"
+              class="underline underline-offset-2 hover:no-underline cursor-pointer"
+              @click="handleSelectAgent(name)"
+            >
+              {{ agentsNeedingApproval.length > 1 ? name : 'View' }}
+            </button>
+          </div>
+        </div>
         <!-- Header -->
         <header class="flex items-center gap-3 h-14 shrink-0 border-b px-4 overflow-hidden">
           <SidebarTrigger class="-ml-1" />
@@ -995,6 +1027,7 @@ onUnmounted(() => {
             :space-name="selectedSpace"
             :tmux-status="selectedAgentTmux"
             @approve="handleApproveAgent"
+            @always-allow="handleAlwaysAllowAgent"
             @reply="handleReplyAgent"
             @broadcast="handleBroadcastAgent"
             @delete="handleDeleteAgent()"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -176,9 +176,10 @@ class ApiClient {
 
   // --------------- Actions ---------------
 
-  approveAgent(space: string, agent: string): Promise<void> {
+  approveAgent(space: string, agent: string, always = false): Promise<void> {
+    const qs = always ? '?always=true' : ''
     return this.requestVoid(
-      `/spaces/${encodeURIComponent(space)}/approve/${encodeURIComponent(agent)}`,
+      `/spaces/${encodeURIComponent(space)}/approve/${encodeURIComponent(agent)}${qs}`,
       { method: 'POST' },
     )
   }

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -43,6 +43,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   approve: []
+  'always-allow': []
   reply: [text: string]
   broadcast: []
   delete: []
@@ -1133,29 +1134,33 @@ watch(() => props.agentName, () => {
       <section v-if="agent.session_id && agent.backend_type !== 'ambient'" class="space-y-3" aria-label="Tmux session controls">
         <h2 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Controls</h2>
 
-        <!-- Approval button -->
+        <!-- Approval buttons -->
         <div v-if="tmuxStatus?.needs_approval" class="space-y-2">
-          <Card class="border-primary/40 bg-primary/5" role="alert">
+          <Card class="border-destructive/60 bg-destructive/5 shadow-sm ring-1 ring-destructive/30" role="alert" aria-live="assertive">
             <CardContent class="p-4">
-              <div class="flex items-center justify-between gap-3">
-                <div>
-                  <p class="text-sm font-medium">Approval Required</p>
-                  <p v-if="tmuxStatus.tool_name" class="text-xs text-muted-foreground font-text mt-0.5">
-                    Tool: <span class="font-mono">{{ tmuxStatus.tool_name }}</span>
-                  </p>
-                  <p v-if="tmuxStatus.prompt_text" class="text-xs text-muted-foreground font-text mt-1 line-clamp-2">
-                    {{ tmuxStatus.prompt_text }}
-                  </p>
-                </div>
+              <p class="text-sm font-semibold text-destructive mb-1">⚠ Approval Required</p>
+              <p v-if="tmuxStatus.tool_name" class="text-xs text-muted-foreground font-text mb-0.5">
+                Tool: <span class="font-mono">{{ tmuxStatus.tool_name }}</span>
+              </p>
+              <p v-if="tmuxStatus.prompt_text" class="text-xs text-muted-foreground font-text mb-3 line-clamp-3">
+                {{ tmuxStatus.prompt_text }}
+              </p>
+              <div class="flex gap-2">
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <Button @click="emit('approve')" aria-label="Approve tool execution">
+                    <Button size="sm" @click="emit('approve')" aria-label="Approve tool execution once">
                       <ShieldCheck class="size-4" /> Approve
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>
-                    Allow the agent to proceed by sending 'y' to its tmux session
-                  </TooltipContent>
+                  <TooltipContent>Allow once (option 1: Yes)</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <Button size="sm" variant="outline" @click="emit('always-allow')" aria-label="Always allow this command">
+                      <ShieldCheck class="size-4" /> Always Allow
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Allow and don't ask again for this command (option 2)</TooltipContent>
                 </Tooltip>
               </div>
             </CardContent>

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -1103,22 +1103,33 @@ func (s *Server) handleApproveAgent(w http.ResponseWriter, r *http.Request, spac
 	// not match on a second read even though the agent is still waiting.
 	// We send the approval keystroke regardless and let the liveness monitor
 	// clear the interrupt on the next poll.
+	always := r.URL.Query().Get("always") == "true"
 	approval := backend.CheckApproval(sessionID)
-	if err := backend.Approve(sessionID); err != nil {
-		writeJSONError(w, canonical+": approve failed: "+err.Error(), http.StatusInternalServerError)
+	var approveErr error
+	if always {
+		approveErr = backend.AlwaysAllow(sessionID)
+	} else {
+		approveErr = backend.Approve(sessionID)
+	}
+	if approveErr != nil {
+		writeJSONError(w, canonical+": approve failed: "+approveErr.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.logEvent(fmt.Sprintf("[%s/%s] approval granted via dashboard (tool: %s)", spaceName, canonical, approval.ToolName))
+	mode := "approved"
+	if always {
+		mode = "always_allowed"
+	}
+	s.logEvent(fmt.Sprintf("[%s/%s] approval %s via dashboard (tool: %s)", spaceName, canonical, mode, approval.ToolName))
 	key := spaceName + "/" + canonical
-	approvalCtx := map[string]string{"tool": approval.ToolName}
+	approvalCtx := map[string]string{"tool": approval.ToolName, "mode": mode}
 	if started, was := s.approvalTracked[key]; was {
 		delete(s.approvalTracked, key)
 		approvalCtx["wait_seconds"] = fmt.Sprintf("%.1f", time.Since(started).Seconds())
 	}
 	s.interrupts.RecordResolved(spaceName, canonical, InterruptApproval,
-		approval.PromptText, "human", "approved", approvalCtx)
+		approval.PromptText, "human", mode, approvalCtx)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "approved", "agent": canonical, "tool": approval.ToolName})
+	json.NewEncoder(w).Encode(map[string]string{"status": mode, "agent": canonical, "tool": approval.ToolName})
 }
 
 func (s *Server) handleReplyAgent(w http.ResponseWriter, r *http.Request, spaceName, agentName string) {

--- a/internal/coordinator/session_backend.go
+++ b/internal/coordinator/session_backend.go
@@ -51,8 +51,12 @@ type SessionBackend interface {
 	// SendInput sends text to the session.
 	SendInput(sessionID string, text string) error
 
-	// Approve sends an approval response to a pending prompt.
+	// Approve sends an approval response to a pending prompt (option 1: "Yes").
 	Approve(sessionID string) error
+
+	// AlwaysAllow sends the "always allow" response to a pending prompt
+	// (option 2: "Yes, and don't ask again for this command").
+	AlwaysAllow(sessionID string) error
 
 	// Interrupt cancels the session's current work without killing it.
 	Interrupt(ctx context.Context, sessionID string) error

--- a/internal/coordinator/session_backend_ambient.go
+++ b/internal/coordinator/session_backend_ambient.go
@@ -442,6 +442,10 @@ func (b *AmbientSessionBackend) Approve(sessionID string) error {
 	return nil // Ambient sessions don't have terminal approval prompts
 }
 
+func (b *AmbientSessionBackend) AlwaysAllow(sessionID string) error {
+	return nil // Ambient sessions don't have terminal approval prompts
+}
+
 func (b *AmbientSessionBackend) Interrupt(ctx context.Context, sessionID string) error {
 	resp, err := b.doRequest(ctx, http.MethodPost, "/sessions/"+sessionID+"/interrupt", nil)
 	if err != nil {

--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -151,6 +151,10 @@ func (b *TmuxSessionBackend) Approve(sessionID string) error {
 	return tmuxApprove(sessionID)
 }
 
+func (b *TmuxSessionBackend) AlwaysAllow(sessionID string) error {
+	return tmuxAlwaysAllow(sessionID)
+}
+
 func (b *TmuxSessionBackend) Interrupt(ctx context.Context, sessionID string) error {
 	// Claude Code requires two Escape presses to fully cancel a running operation:
 	// the first Escape triggers the "Interrupt?" confirmation prompt, and the second

--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -214,6 +214,19 @@ func tmuxApprove(session string) error {
 	return exec.CommandContext(ctx2, "tmux", "send-keys", "-t", session, "Enter").Run()
 }
 
+func tmuxAlwaysAllow(session string) error {
+	// Send "2" to select "Yes, and don't ask again for this command" (option 2
+	// in the approval dialog), then Enter to confirm.
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxCmdTimeout)
+	defer cancel()
+	if err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", session, "2").Run(); err != nil {
+		return err
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxCmdTimeout)
+	defer cancel2()
+	return exec.CommandContext(ctx2, "tmux", "send-keys", "-t", session, "Enter").Run()
+}
+
 // tmuxIsIdle reports whether the tmux session appears to be waiting for input
 // (i.e., no agent or process is actively running). It is intentionally generous:
 // a session is "busy" only when there is positive evidence of activity.


### PR DESCRIPTION
## Summary

- **Always Allow button**: Alongside "Approve" (option 1: Yes), agent detail now shows "Always Allow" (option 2: Yes, and don't ask again for this command). Sends `?always=true` to the backend which calls `AlwaysAllow()` → sends "2" + Enter to the tmux session.
- **Global approval banner**: A red full-width banner appears at the top of the main content area whenever any agent in the current space has a pending approval. Clicking View / the agent name navigates directly to that agent.
- **Approval card styling**: Redesigned with destructive border/background and `aria-live="assertive"` for screen readers.

## API change

`POST /spaces/{space}/approve/{agent}?always=true` — new query param. Backwards compatible; without `?always=true` behaviour is unchanged.

## Test plan

- [ ] Trigger a tool approval in a non-privileged tmux agent
- [ ] Verify red banner appears at top of UI immediately (any view)
- [ ] Click "View" in banner → navigates to agent detail
- [ ] Click "Approve" → sends option 1, agent proceeds; approval clears
- [ ] Click "Always Allow" → sends option 2, agent proceeds without future prompts for this command
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)