### PR TITLE
fix(lifecycle): replace /boss.ignite with plain-text ignition on restart (TASK-104)

### DIFF
--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -569,8 +569,11 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 		} else {
 			time.Sleep(5 * time.Second)
 		}
-		igniteCmd := fmt.Sprintf(`/boss.ignite "%s" "%s"`, canonical, spaceName)
-		if err := backend.SendInput(sessionID, igniteCmd); err != nil {
+		// Send plain-text ignition prompt — no slash command required.
+		s.mu.RLock()
+		igniteText := s.buildIgnitionText(spaceName, canonical, sessionID)
+		s.mu.RUnlock()
+		if err := backend.SendInput(sessionID, igniteText); err != nil {
 			s.emit(DomainEvent{Level: LevelWarn, EventType: EventAgentRestarted, Space: spaceName, Agent: canonical,
 				Msg: fmt.Sprintf("restart: ignite send failed: %v", err)})
 		}


### PR DESCRIPTION
## Summary

The agent **restart** path in `lifecycle.go` still sent the removed `/boss.ignite` slash command. This fixes it to use `buildIgnitionText()` — the same approach used by the spawn path (fixed in TASK-100, PR #100).

All code paths that send ignition to agents now use plain-text prompts. No remaining `/boss.ignite` in production code paths.

## Test plan

- [ ] Restart a tmux agent via the UI → verify agent re-ignites correctly without slash command
- [ ] `go test -race ./internal/coordinator/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)