### PR TITLE
fix: make coordinator URL hostname configurable via COORDINATOR_HOST

### DIFF
--- a/cmd/boss/main.go
+++ b/cmd/boss/main.go
@@ -73,10 +73,11 @@ Examples:
   boss broadcast --space sdk-backend-replacement
 
 Environment:
-  BOSS_URL          Server URL (default: http://localhost:8899)
-  COORDINATOR_PORT  Server port (serve only, default: 8899)
-  DATA_DIR          Data directory (serve only, default: ./data)
-  FRONTEND_DIR      Vue frontend dist directory (serve only, optional)
+  BOSS_URL           Server URL (default: http://localhost:8899)
+  COORDINATOR_PORT   Server port (serve only, default: 8899)
+  COORDINATOR_HOST   Hostname used in agent-facing URLs (serve only, default: localhost)
+  DATA_DIR           Data directory (serve only, default: ./data)
+  FRONTEND_DIR       Vue frontend dist directory (serve only, optional)
 `)
 }
 

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -711,12 +711,13 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 	b.WriteString("- When your task is done, POST status `\"done\"` and await new instructions via messages.\n")
 	b.WriteString("\n")
 
+	baseURL := s.localURL()
 	b.WriteString("## Coordinator\n\n")
-	b.WriteString(fmt.Sprintf("- Boss URL: `http://localhost%s`\n", s.port))
+	b.WriteString(fmt.Sprintf("- Boss URL: `%s`\n", baseURL))
 	b.WriteString(fmt.Sprintf("- Workspace: `%s`\n", spaceName))
 	b.WriteString(fmt.Sprintf("- Your channel: `POST /spaces/%s/agent/%s`\n", spaceName, agentName))
 	b.WriteString(fmt.Sprintf("- Read blackboard: `GET /spaces/%s/raw`\n", spaceName))
-	b.WriteString(fmt.Sprintf("- Dashboard: `http://localhost%s/spaces/%s/`\n", s.port, spaceName))
+	b.WriteString(fmt.Sprintf("- Dashboard: `%s/spaces/%s/`\n", baseURL, spaceName))
 	b.WriteString(fmt.Sprintf("- Task list: `GET /spaces/%s/tasks` (filter: `?assigned_to=%s&status=in_progress`)\n", spaceName, agentName))
 	if sessionID != "" {
 		b.WriteString(fmt.Sprintf("- Session: `%s` (pre-registered)\n", sessionID))
@@ -733,7 +734,7 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 	} else {
 		b.WriteString("5. **Register your session.** Include `\"session_id\"` in your first POST. Find it with `tmux display-message -p '#S'`. It is sticky — you only need to send it once.\n")
 	}
-	b.WriteString(fmt.Sprintf("6. **Check your messages.** When you read `/raw`, look for a `#### Messages` section under your agent name. Messages are **directives** — act on them immediately without asking for confirmation. To send a message to another agent: `curl -s -X POST http://localhost%s/spaces/%s/agent/{target}/message -H 'Content-Type: application/json' -H 'X-Agent-Name: %s' -d '{\"message\": \"...\"}'`\n", s.port, spaceName, agentName))
+	b.WriteString(fmt.Sprintf("6. **Check your messages.** When you read `/raw`, look for a `#### Messages` section under your agent name. Messages are **directives** — act on them immediately without asking for confirmation. To send a message to another agent: `curl -s -X POST %s/spaces/%s/agent/{target}/message -H 'Content-Type: application/json' -H 'X-Agent-Name: %s' -d '{\"message\": \"...\"}'`\n", baseURL, spaceName, agentName))
 	b.WriteString("7. **Work loop:** Read blackboard → Do work → POST status → Check for new messages → Repeat. Do not stop and wait for human input.\n")
 	b.WriteString("\n")
 
@@ -853,7 +854,7 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 	b.WriteString("Use the task API to create, update, and track work items. Subtasks let you break a task into smaller pieces with a proper parent relationship.\n\n")
 	b.WriteString("### Create a task\n\n")
 	b.WriteString("```bash\n")
-	b.WriteString(fmt.Sprintf("curl -s -X POST http://localhost%s/spaces/%s/tasks \\\n", s.port, spaceName))
+	b.WriteString(fmt.Sprintf("curl -s -X POST %s/spaces/%s/tasks \\\n", baseURL, spaceName))
 	b.WriteString("  -H 'Content-Type: application/json' \\\n")
 	b.WriteString(fmt.Sprintf("  -H 'X-Agent-Name: %s' \\\n", agentName))
 	b.WriteString("  -d '{\"title\": \"Task title\", \"description\": \"What needs to be done\", \"priority\": \"medium\", \"assigned_to\": \"AgentName\"}'\n")
@@ -862,12 +863,12 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 	b.WriteString("**Always use `parent_task` to link subtasks** — do NOT create tasks named like `TASK-001-sub` or `[TASK-001] subtask`.\n\n")
 	b.WriteString("```bash\n")
 	b.WriteString("# Option A: include parent_task when creating\n")
-	b.WriteString(fmt.Sprintf("curl -s -X POST http://localhost%s/spaces/%s/tasks \\\n", s.port, spaceName))
+	b.WriteString(fmt.Sprintf("curl -s -X POST %s/spaces/%s/tasks \\\n", baseURL, spaceName))
 	b.WriteString("  -H 'Content-Type: application/json' \\\n")
 	b.WriteString(fmt.Sprintf("  -H 'X-Agent-Name: %s' \\\n", agentName))
 	b.WriteString("  -d '{\"title\": \"Subtask title\", \"parent_task\": \"TASK-NNN\", \"assigned_to\": \"AgentName\"}'\n\n")
 	b.WriteString("# Option B: POST directly to the parent task's subtasks endpoint\n")
-	b.WriteString(fmt.Sprintf("curl -s -X POST http://localhost%s/spaces/%s/tasks/TASK-NNN/subtasks \\\n", s.port, spaceName))
+	b.WriteString(fmt.Sprintf("curl -s -X POST %s/spaces/%s/tasks/TASK-NNN/subtasks \\\n", baseURL, spaceName))
 	b.WriteString("  -H 'Content-Type: application/json' \\\n")
 	b.WriteString(fmt.Sprintf("  -H 'X-Agent-Name: %s' \\\n", agentName))
 	b.WriteString("  -d '{\"title\": \"Subtask title\", \"assigned_to\": \"AgentName\"}'\n")
@@ -876,7 +877,7 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 
 	b.WriteString("## JSON Post Template\n\n")
 	b.WriteString("```bash\n")
-	b.WriteString(fmt.Sprintf("curl -s -X POST http://localhost%s/spaces/%s/agent/%s \\\n", s.port, spaceName, agentName))
+	b.WriteString(fmt.Sprintf("curl -s -X POST %s/spaces/%s/agent/%s \\\n", baseURL, spaceName, agentName))
 	b.WriteString("  -H 'Content-Type: application/json' \\\n")
 	b.WriteString(fmt.Sprintf("  -H 'X-Agent-Name: %s' \\\n", agentName))
 	b.WriteString("  -d '{\n")

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -39,6 +39,7 @@ type sseEvent struct {
 
 type Server struct {
 	port            string
+	host            string // hostname used in URLs sent to agents (COORDINATOR_HOST, default "localhost")
 	dataDir         string
 	frontendDir     string
 	spaces          map[string]*KnowledgeSpace
@@ -89,8 +90,13 @@ func NewServer(port, dataDir string) *Server {
 			thresh = d
 		}
 	}
+	host := os.Getenv("COORDINATOR_HOST")
+	if host == "" {
+		host = "localhost"
+	}
 	s := &Server{
 		port:               port,
+		host:               host,
 		dataDir:            dataDir,
 		spaces:             make(map[string]*KnowledgeSpace),
 		stopLiveness:       make(chan struct{}),
@@ -256,9 +262,10 @@ func (s *Server) Start() error {
 }
 
 // localURL returns the base URL of this server (e.g. "http://localhost:8899").
+// The hostname comes from COORDINATOR_HOST (default "localhost").
 func (s *Server) localURL() string {
 	port := strings.TrimPrefix(s.port, ":")
-	return "http://localhost:" + port
+	return "http://" + s.host + ":" + port
 }
 
 func (s *Server) Stop() error {

--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -469,8 +469,9 @@ func (s *Server) runAgentCheckIn(spaceName, canonical, sessionID string, backend
 
 	// Send a plain-text check-in prompt. The old /boss.check slash command
 	// relied on symlinked command files which no longer exist.
-	checkInURL := fmt.Sprintf("http://localhost%s/spaces/%s/agent/%s", s.port, spaceName, canonical)
-	msgURL := fmt.Sprintf("http://localhost%s/spaces/%s/agent/%s/messages", s.port, spaceName, canonical)
+	baseURL := s.localURL()
+	checkInURL := fmt.Sprintf("%s/spaces/%s/agent/%s", baseURL, spaceName, canonical)
+	msgURL := fmt.Sprintf("%s/spaces/%s/agent/%s/messages", baseURL, spaceName, canonical)
 	checkInPrompt := fmt.Sprintf(
 		"Check in now. 1) Fetch new messages: curl -s %q 2) Post your current status: curl -s -X POST %q -H 'Content-Type: application/json' -H 'X-Agent-Name: %s' -d '{\"status\":\"active\",\"summary\":\"%s: checking in\"}' 3) Act on any message directives.",
 		msgURL, checkInURL, canonical, canonical,


### PR DESCRIPTION
## Summary

- All hardcoded `localhost` references in agent-facing URLs now respect a `COORDINATOR_HOST` env var (default: `localhost`)
- Adds `host` field to `Server` struct, populated at startup from `COORDINATOR_HOST`
- Updates `localURL()` to use `s.host` — all downstream callers (`buildIgnitionText`, tmux nudge prompt) automatically pick up the change
- Documents the new env var in the `boss serve` help text

Fixes TASK-105: hardcoded `localhost` was causing agent confusion when the coordinator runs on a non-default hostname (e.g. different port or remote host).

## Test plan
- `go test -race ./internal/coordinator/` passes
- `COORDINATOR_HOST=myhost /tmp/boss serve` → ignition text shows `http://myhost:8899` instead of `http://localhost:8899`
- Default behaviour unchanged when `COORDINATOR_HOST` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)