### PR TITLE
fix(mcp): add CORS headers to MCP endpoint

### DIFF
--- a/internal/coordinator/mcp_server.go
+++ b/internal/coordinator/mcp_server.go
@@ -121,10 +121,22 @@ func (s *Server) buildMCPHandler() http.Handler {
 		}, nil
 	})
 
-	return mcp.NewStreamableHTTPHandler(
+	handler := mcp.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcp.Server { return srv },
 		nil,
 	)
+
+	// Wrap with CORS headers so browser-based and cross-origin MCP clients can connect.
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
 }
 
 // handleSettings handles GET and PATCH /settings.


### PR DESCRIPTION
## Summary
- Wraps the MCP `StreamableHTTPHandler` with CORS middleware
- Handles OPTIONS preflight with `204 No Content`
- Sets `Access-Control-Allow-Origin: *`, matching existing SSE/protocol endpoints

## Test plan
- [x] `go build` and `go test -race` pass
- [ ] Manual: verify `OPTIONS /mcp` returns 204 with CORS headers
- [ ] Manual: verify cross-origin MCP requests succeed from browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)