### PR TITLE
fix: inject persona prompts into ignition text for tmux agents

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -680,6 +680,16 @@ func (s *Server) handleIgnition(w http.ResponseWriter, r *http.Request, spaceNam
 
 	s.mu.RLock()
 	text := s.buildIgnitionText(spaceName, agentName, sessionID)
+	// Prepend persona prompts if the agent has personas configured.
+	// Mirrors the same logic in mcp_server.go for MCP-connected agents.
+	if ks, ok := s.spaces[spaceName]; ok {
+		canonical := resolveAgentName(ks, agentName)
+		if cfg := ks.agentConfig(canonical); cfg != nil && len(cfg.Personas) > 0 {
+			if personaPrompt := s.assemblePersonaPrompt(cfg.Personas); personaPrompt != "" {
+				text = personaPrompt + "\n\n" + text
+			}
+		}
+	}
 	s.mu.RUnlock()
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -572,6 +572,14 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 		// Send plain-text ignition prompt — no slash command required.
 		s.mu.RLock()
 		igniteText := s.buildIgnitionText(spaceName, canonical, sessionID)
+		// Prepend persona prompts if configured (mirrors handleIgnition and mcp_server.go).
+		if ks, ok := s.spaces[spaceName]; ok {
+			if cfg := ks.agentConfig(canonical); cfg != nil && len(cfg.Personas) > 0 {
+				if personaPrompt := s.assemblePersonaPrompt(cfg.Personas); personaPrompt != "" {
+					igniteText = personaPrompt + "\n\n" + igniteText
+				}
+			}
+		}
 		s.mu.RUnlock()
 		if err := backend.SendInput(sessionID, igniteText); err != nil {
 			s.emit(DomainEvent{Level: LevelWarn, EventType: EventAgentRestarted, Space: spaceName, Agent: canonical,


### PR DESCRIPTION
## Summary

- Personas were stored and editable but never delivered to tmux-backed agents at ignition/restart time
- The MCP path (`mcp_server.go`) correctly prepended persona prompts, but the HTTP `/ignition/{agent}` endpoint and the restart `buildIgnitionText()` call did not
- Both paths now prepend the assembled persona prompt before delivering to the agent

## Root Cause

`handleIgnition()` returned `buildIgnitionText()` with no persona prepend. Tmux agents curl this endpoint at startup to get their context — so they never received their persona.

The restart path in `lifecycle.go` had the same gap: it called `buildIgnitionText()` directly and sent it to the session without prepending personas.

## Changes

- `handlers_agent.go`: `handleIgnition` now prepends `assemblePersonaPrompt()` to the ignition text (mirrors `mcp_server.go`)
- `lifecycle.go`: restart goroutine also prepends persona prompts before `SendInput`

## Test plan
- Assign a persona to an agent, spawn it → ignition text includes the persona prompt at the top
- Restart the agent → same persona prompt appears in the re-sent ignition text
- Agents with no personas: behavior unchanged
- `go test -race ./internal/coordinator/` passes

Fixes TASK-109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)