### PR TITLE
fix(mcp): allow MCP-specific headers in CORS preflight

### DIFF
--- a/internal/coordinator/mcp_server.go
+++ b/internal/coordinator/mcp_server.go
@@ -169,7 +169,8 @@ func (s *Server) buildMCPHandler() http.Handler {
 	// Wrap with CORS headers so browser-based and cross-origin MCP clients can connect.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
+		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Summary
- Adds `Mcp-Session-Id`, `Mcp-Protocol-Version`, and `Last-Event-ID` to `Access-Control-Allow-Headers`
- Exposes `Mcp-Session-Id` via `Access-Control-Expose-Headers` so clients can read session IDs from responses
- Fixes "CORS Missing Allow Header" errors in the MCP Inspector web UI

## Test plan
- [ ] Open MCP Inspector at `http://localhost:6274`, connect to `http://localhost:8899/mcp`
- [ ] Verify no CORS errors in browser console
- [ ] Verify MCP resources are listed and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)