### PR TITLE
fix(protocol): use dynamic coordinator URL instead of hardcoded localhost:8899

### DIFF
--- a/internal/coordinator/mcp_server.go
+++ b/internal/coordinator/mcp_server.go
@@ -114,12 +114,13 @@ func (s *Server) buildMCPHandler() http.Handler {
 		Description: "The agent communication and collaboration protocol",
 		MIMEType:    "text/markdown",
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		text := strings.ReplaceAll(protocolTemplate, "{COORDINATOR_URL}", s.localURL())
 		return &mcp.ReadResourceResult{
 			Contents: []*mcp.ResourceContents{
 				{
 					URI:      "boss://protocol",
 					MIMEType: "text/markdown",
-					Text:     protocolTemplate,
+					Text:     text,
 				},
 			},
 		}, nil

--- a/internal/coordinator/protocol.md
+++ b/internal/coordinator/protocol.md
@@ -1,8 +1,8 @@
 ## Agent Communication Protocol
 
-### Coordinator (8899)
+### Coordinator
 
-All agents use `http://localhost:8899` exclusively.
+All agents use `{COORDINATOR_URL}` exclusively.
 
 Space: `{SPACE}`
 
@@ -12,30 +12,30 @@ Space: `{SPACE}`
 
 | Action | Command |
 |--------|---------|
-| Post status (JSON) | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/agent/{name} -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"status":"...","summary":"...","items":[...]}'` |
-| Send message to agent | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/agent/{target}/message -H 'Content-Type: application/json' -H 'X-Agent-Name: {sender}' -d '{"message":"..."}'` |
-| Read my section | `curl -s http://localhost:8899/spaces/{SPACE}/agent/{name}` |
-| Read full blackboard | `curl -s http://localhost:8899/spaces/{SPACE}/raw` |
-| Poll my messages | `curl -s "http://localhost:8899/spaces/{SPACE}/agent/{name}/messages?since=<cursor>"` |
-| ACK a message | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/agent/{name}/messages/{id}/ack -H 'X-Agent-Name: {name}'` |
-| Dashboard | `http://localhost:8899/spaces/{SPACE}/` |
+| Post status (JSON) | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name} -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"status":"...","summary":"...","items":[...]}'` |
+| Send message to agent | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{target}/message -H 'Content-Type: application/json' -H 'X-Agent-Name: {sender}' -d '{"message":"..."}'` |
+| Read my section | `curl -s {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}` |
+| Read full blackboard | `curl -s {COORDINATOR_URL}/spaces/{SPACE}/raw` |
+| Poll my messages | `curl -s "{COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/messages?since=<cursor>"` |
+| ACK a message | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/messages/{id}/ack -H 'X-Agent-Name: {name}'` |
+| Dashboard | `{COORDINATOR_URL}/spaces/{SPACE}/` |
 
 #### Task Management
 
 | Action | Command |
 |--------|---------|
-| Create task | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/tasks -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"title":"...","assigned_to":"...","priority":"high"}'` |
-| List tasks | `curl -s "http://localhost:8899/spaces/{SPACE}/tasks?assigned_to={name}&status=in_progress"` |
-| Move task status | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/tasks/{id}/move -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"status":"done"}'` |
-| Update task (PR link) | `curl -s -X PUT http://localhost:8899/spaces/{SPACE}/tasks/{id} -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"linked_pr":"#123"}'` |
+| Create task | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/tasks -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"title":"...","assigned_to":"...","priority":"high"}'` |
+| List tasks | `curl -s "{COORDINATOR_URL}/spaces/{SPACE}/tasks?assigned_to={name}&status=in_progress"` |
+| Move task status | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/tasks/{id}/move -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"status":"done"}'` |
+| Update task (PR link) | `curl -s -X PUT {COORDINATOR_URL}/spaces/{SPACE}/tasks/{id} -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"linked_pr":"#123"}'` |
 
 #### Agent Lifecycle (tmux agents)
 
 | Action | Command |
 |--------|---------|
-| Spawn | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/agent/{name}/spawn -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{}'` |
-| Restart | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/agent/{name}/restart -H 'X-Agent-Name: {name}'` |
-| Stop | `curl -s -X POST http://localhost:8899/spaces/{SPACE}/agent/{name}/stop -H 'X-Agent-Name: {name}'` |
+| Spawn | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/spawn -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{}'` |
+| Restart | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/restart -H 'X-Agent-Name: {name}'` |
+| Stop | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/stop -H 'X-Agent-Name: {name}'` |
 
 ### Rules
 
@@ -74,10 +74,10 @@ Space: `{SPACE}`
 
 ```bash
 # Initial fetch — get all pending messages + cursor
-curl -s "http://localhost:8899/spaces/{SPACE}/agent/{name}/messages"
+curl -s "{COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/messages"
 
 # Subsequent polls — pass cursor from previous response
-curl -s "http://localhost:8899/spaces/{SPACE}/agent/{name}/messages?since=<cursor>"
+curl -s "{COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/messages?since=<cursor>"
 ```
 
 Store the `cursor` and pass it as `?since=` on each poll. Empty `messages` = no new messages.

--- a/internal/coordinator/storage.go
+++ b/internal/coordinator/storage.go
@@ -157,7 +157,9 @@ func (s *Server) refreshProtocol(ks *KnowledgeSpace) {
 	}
 	// Only set protocol if SharedContracts is empty (don't overwrite manual edits)
 	if ks.SharedContracts == "" {
-		ks.SharedContracts = strings.ReplaceAll(protocolTemplate, "{SPACE}", ks.Name)
+		p := strings.ReplaceAll(protocolTemplate, "{SPACE}", ks.Name)
+		p = strings.ReplaceAll(p, "{COORDINATOR_URL}", s.localURL())
+		ks.SharedContracts = p
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replaces 19 hardcoded `http://localhost:8899` references in `protocol.md` with `{COORDINATOR_URL}` placeholder
- MCP `boss://protocol` resource now substitutes `s.localURL()` at serve time
- `refreshProtocol()` (SharedContracts init) now substitutes both `{SPACE}` and `{COORDINATOR_URL}`

## Problem
The protocol template was embedded at compile time with hardcoded `localhost:8899`. Three paths served it differently:

| Path | Before | After |
|------|--------|-------|
| MCP `boss://protocol` | Raw template with hardcoded port | Dynamic `s.localURL()` substitution |
| `refreshProtocol()` → SharedContracts | Only `{SPACE}` replaced | `{SPACE}` + `{COORDINATOR_URL}` replaced |
| `buildIgnitionText()` → bootstrap | Already correct (used `s.localURL()`) | No change |

## Test plan
- [x] `go build ./cmd/boss/` compiles
- [x] `go test -race` — all tests pass
- [ ] Manual: start on non-default port, read `boss://protocol` via MCP, verify URLs use actual port
- [ ] Manual: create new space, verify SharedContracts has correct URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)