### PR TITLE
fix: tighten 'ready' idle heuristic to prevent false approval suppression

### DIFF
--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -308,11 +308,18 @@ func lineIsIdleIndicator(line string) bool {
 	}
 
 	// ── OpenCode / Claude Code status bar keywords ──
+	// Be specific: these must match exact status-bar phrases, not arbitrary
+	// content lines that happen to contain common words like "ready".
 	lower := strings.ToLower(trimmed)
 	if strings.Contains(lower, "waiting for input") ||
-		strings.Contains(lower, "ready") ||
 		strings.Contains(lower, "type a message") ||
 		strings.Contains(lower, "press enter") {
+		return true
+	}
+	// "ready" alone or as a full status-bar token (e.g. "Model ready", "claude ready")
+	// but NOT embedded in arbitrary sentence content like "online and ready for tasks".
+	// Match only when "ready" is the last meaningful word on the line.
+	if strings.HasSuffix(lower, "ready") || strings.HasSuffix(lower, "ready.") {
 		return true
 	}
 


### PR DESCRIPTION
## Summary

- `lineIsIdleIndicator` had a broad `strings.Contains(lower, "ready")` check
- This matched arbitrary agent output lines like `"Post status update - online and ready for tasks"`, causing `tmuxIsIdle` to return `true`
- When `tmuxIsIdle` returns `true`, `tmuxCheckApproval` short-circuits and returns no approval — so the 'potential obfuscation' dialog (TASK-115) was silently dropped

## Fix

Changed `ready` detection from `Contains` to `HasSuffix` — only matches lines where `ready` is the last word (actual Claude Code status bar output like `"Model ready"`), not mid-sentence occurrences in agent content.

## Test plan
- `go test -race ./internal/coordinator/` passes
- Agent posting `"online and ready for tasks"` in a status line no longer suppresses approval detection
- Standard Claude Code idle state (`"Model ready"`) still correctly triggers idle

Fixes TASK-115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)