### PR TITLE
fix: restart agent honors cwd, command, and initial_prompt from AgentConfig

### DIFF
--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -459,10 +459,6 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 			return
 		}
 	}
-	command := req.Command
-	if command == "" {
-		command = "claude --dangerously-skip-permissions"
-	}
 
 	ks, ok := s.getSpace(spaceName)
 	if !ok {
@@ -477,7 +473,22 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 	if exists {
 		oldSession = agent.SessionID
 	}
+	// Load AgentConfig to restore cwd, command, and initial_prompt on restart.
+	var restartWorkDir string
+	var restartInitialPrompt string
+	if cfg := ks.agentConfig(canonical); cfg != nil {
+		restartWorkDir = cfg.WorkDir
+		restartInitialPrompt = cfg.InitialPrompt
+		if req.Command == "" && cfg.Command != "" {
+			req.Command = cfg.Command
+		}
+	}
 	s.mu.RUnlock()
+
+	command := req.Command
+	if command == "" {
+		command = "claude --dangerously-skip-permissions"
+	}
 
 	if !exists {
 		http.Error(w, fmt.Sprintf("agent %q not found", agentName), http.StatusNotFound)
@@ -531,6 +542,7 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 			SessionID: newSession,
 			Command:   command,
 			BackendOpts: TmuxCreateOpts{
+				WorkDir:              restartWorkDir,
 				MCPServerURL:         s.localURL(),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
@@ -584,6 +596,9 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 		if err := backend.SendInput(sessionID, igniteText); err != nil {
 			s.emit(DomainEvent{Level: LevelWarn, EventType: EventAgentRestarted, Space: spaceName, Agent: canonical,
 				Msg: fmt.Sprintf("restart: ignite send failed: %v", err)})
+		}
+		if restartInitialPrompt != "" {
+			s.deliverInternalMessage(spaceName, canonical, "boss", restartInitialPrompt)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- `handleRestart` was creating a new tmux session without reading `AgentConfig`, so `work_dir`, a custom `command`, and `initial_prompt` were all silently dropped on restart
- Added config lookup after canonical resolution to restore these fields with parity to the spawn path

## Changes

- Read `AgentConfig` at the start of the restart handler
- Apply `cfg.WorkDir` to `TmuxCreateOpts` (restores configured working directory)
- Fall back to `cfg.Command` if no command provided in restart request
- Deliver `cfg.InitialPrompt` as an internal message after ignition (same as spawn path)

## Test plan
- Configure agent with `work_dir=/some/path` → restart → new session starts in `/some/path`
- Configure agent with custom `command` → restart → new session uses that command
- Configure agent with `initial_prompt` → restart → prompt re-delivered after ignition
- `go test -race ./internal/coordinator/` passes

Fixes TASK-116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)