### PR TITLE
feat(db): migrate InterruptLedger from JSONL files to SQLite (TASK-117)

### DIFF
--- a/internal/coordinator/db/db.go
+++ b/internal/coordinator/db/db.go
@@ -88,6 +88,7 @@ func migrate(db *gorm.DB) error {
 		&StatusSnapshot{},
 		&Setting{},
 		&SpaceEventLog{},
+		&InterruptRecord{},
 	); err != nil {
 		return err
 	}

--- a/internal/coordinator/db/models.go
+++ b/internal/coordinator/db/models.go
@@ -211,3 +211,21 @@ type SpaceEventLog struct {
 }
 
 func (SpaceEventLog) TableName() string { return "space_event_log" }
+
+// InterruptRecord stores an agent interrupt (approval request, decision, etc.)
+// Replaces the legacy {space}.interrupts.jsonl files.
+type InterruptRecord struct {
+	ID          string       `gorm:"primarykey;not null"`
+	SpaceName   string       `gorm:"index;not null"`
+	Agent       string       `gorm:"not null"`
+	Type        string       `gorm:"not null"`
+	Question    string       `gorm:"type:text;not null"`
+	Context     string       `gorm:"type:text"` // JSON map[string]string
+	ResolvedBy  string
+	Answer      string       `gorm:"type:text"`
+	ResolvedAt  sql.NullTime
+	WaitSeconds float64
+	CreatedAt   time.Time    `gorm:"index"`
+}
+
+func (InterruptRecord) TableName() string { return "interrupts" }

--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -285,6 +285,9 @@ func (r *Repository) DeleteSpace(name string) error {
 		if err := tx.Where("space_name = ?", name).Delete(&SpaceEventLog{}).Error; err != nil {
 			return err
 		}
+		if err := tx.Where("space_name = ?", name).Delete(&InterruptRecord{}).Error; err != nil {
+			return err
+		}
 		if err := tx.Where("space_name = ?", name).Delete(&Agent{}).Error; err != nil {
 			return err
 		}
@@ -377,4 +380,48 @@ func (r *Repository) NextTaskSeqForSpace(spaceName string) (int, error) {
 		return 0, err
 	}
 	return next, nil
+}
+
+// ---- InterruptRecord operations ----
+
+// SaveInterrupt upserts an interrupt record.
+func (r *Repository) SaveInterrupt(rec *InterruptRecord) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"resolved_by", "answer", "resolved_at", "wait_seconds"}),
+	}).Create(rec).Error
+}
+
+// LoadInterrupts returns all interrupt records for a space, ordered by creation time.
+func (r *Repository) LoadInterrupts(spaceName string) ([]*InterruptRecord, error) {
+	var recs []*InterruptRecord
+	return recs, r.db.Where("space_name = ?", spaceName).Order("created_at ASC").Find(&recs).Error
+}
+
+// ResolveInterrupt marks the interrupt with the given ID as resolved.
+// Returns an error if the record is not found or already resolved.
+func (r *Repository) ResolveInterrupt(spaceName, id, resolvedBy, answer string) error {
+	now := time.Now().UTC()
+	var rec InterruptRecord
+	if err := r.db.Where("id = ? AND space_name = ?", id, spaceName).First(&rec).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("interrupt %q not found", id)
+		}
+		return err
+	}
+	if rec.ResolvedAt.Valid {
+		return fmt.Errorf("interrupt %q already resolved", id)
+	}
+	waitSecs := now.Sub(rec.CreatedAt).Seconds()
+	return r.db.Model(&rec).Updates(map[string]any{
+		"resolved_by":  resolvedBy,
+		"answer":       answer,
+		"resolved_at":  now,
+		"wait_seconds": waitSecs,
+	}).Error
+}
+
+// DeleteInterrupts removes all interrupt records for a space.
+func (r *Repository) DeleteInterrupts(spaceName string) error {
+	return r.db.Where("space_name = ?", spaceName).Delete(&InterruptRecord{}).Error
 }

--- a/internal/coordinator/interrupts.go
+++ b/internal/coordinator/interrupts.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"bufio"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	bossdb "github.com/ambient/platform/components/boss/internal/coordinator/db"
 )
 
 type InterruptType string
@@ -54,12 +57,19 @@ type InterruptLedger struct {
 	dataDir string
 	mu      sync.Mutex
 	seq     atomic.Int64
+	repo    *bossdb.Repository // nil until SetRepo is called; enables SQLite persistence
 }
 
 func NewInterruptLedger(dataDir string) *InterruptLedger {
 	l := &InterruptLedger{dataDir: dataDir}
 	l.seq.Store(time.Now().UnixMilli())
 	return l
+}
+
+// SetRepo injects the SQLite repository. Once set, all operations use SQLite
+// instead of the JSONL file. Must be called before any concurrent use.
+func (l *InterruptLedger) SetRepo(repo *bossdb.Repository) {
+	l.repo = repo
 }
 
 func (l *InterruptLedger) nextID() string {
@@ -81,7 +91,7 @@ func (l *InterruptLedger) Record(space, agent string, itype InterruptType, quest
 		Context:   ctx,
 		CreatedAt: time.Now().UTC(),
 	}
-	l.append(intr)
+	l.save(intr)
 	return intr
 }
 
@@ -101,11 +111,41 @@ func (l *InterruptLedger) RecordResolved(space, agent string, itype InterruptTyp
 		},
 		CreatedAt: now,
 	}
-	l.append(intr)
+	l.save(intr)
 	return intr
 }
 
-func (l *InterruptLedger) append(intr *Interrupt) {
+// save persists an interrupt to SQLite (when repo is set) or appends to JSONL file.
+func (l *InterruptLedger) save(intr *Interrupt) {
+	if l.repo != nil {
+		ctxJSON := ""
+		if intr.Context != nil {
+			if b, err := json.Marshal(intr.Context); err == nil {
+				ctxJSON = string(b)
+			}
+		}
+		rec := &bossdb.InterruptRecord{
+			ID:        intr.ID,
+			SpaceName: intr.Space,
+			Agent:     intr.Agent,
+			Type:      string(intr.Type),
+			Question:  intr.Question,
+			Context:   ctxJSON,
+			CreatedAt: intr.CreatedAt,
+		}
+		if intr.Resolution != nil {
+			rec.ResolvedBy = intr.Resolution.ResolvedBy
+			rec.Answer = intr.Resolution.Answer
+			rec.ResolvedAt = sql.NullTime{Time: intr.Resolution.ResolvedAt, Valid: true}
+			rec.WaitSeconds = intr.Resolution.WaitDuration
+		}
+		l.repo.SaveInterrupt(rec)
+		return
+	}
+	l.appendFile(intr)
+}
+
+func (l *InterruptLedger) appendFile(intr *Interrupt) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -124,6 +164,21 @@ func (l *InterruptLedger) append(intr *Interrupt) {
 }
 
 func (l *InterruptLedger) LoadAll(space string) []Interrupt {
+	if l.repo != nil {
+		recs, err := l.repo.LoadInterrupts(space)
+		if err != nil {
+			return nil
+		}
+		result := make([]Interrupt, 0, len(recs))
+		for _, rec := range recs {
+			result = append(result, dbRecordToInterrupt(rec))
+		}
+		return result
+	}
+	return l.loadAllFromFile(space)
+}
+
+func (l *InterruptLedger) loadAllFromFile(space string) []Interrupt {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -150,8 +205,15 @@ func (l *InterruptLedger) LoadAll(space string) []Interrupt {
 	return interrupts
 }
 
-// Resolve marks a pending interrupt as resolved by rewriting the ledger file.
+// Resolve marks a pending interrupt as resolved.
 func (l *InterruptLedger) Resolve(space, id, resolvedBy, answer string) error {
+	if l.repo != nil {
+		return l.repo.ResolveInterrupt(space, id, resolvedBy, answer)
+	}
+	return l.resolveInFile(space, id, resolvedBy, answer)
+}
+
+func (l *InterruptLedger) resolveInFile(space, id, resolvedBy, answer string) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -207,6 +269,33 @@ func (l *InterruptLedger) Resolve(space, id, resolvedBy, answer string) error {
 	}
 	out.Close()
 	return os.Rename(tmp, path)
+}
+
+// dbRecordToInterrupt converts a db.InterruptRecord to the coordinator Interrupt type.
+func dbRecordToInterrupt(rec *bossdb.InterruptRecord) Interrupt {
+	intr := Interrupt{
+		ID:        rec.ID,
+		Space:     rec.SpaceName,
+		Agent:     rec.Agent,
+		Type:      InterruptType(rec.Type),
+		Question:  rec.Question,
+		CreatedAt: rec.CreatedAt,
+	}
+	if rec.Context != "" {
+		var ctx map[string]string
+		if json.Unmarshal([]byte(rec.Context), &ctx) == nil {
+			intr.Context = ctx
+		}
+	}
+	if rec.ResolvedAt.Valid {
+		intr.Resolution = &InterruptResolution{
+			ResolvedBy:   rec.ResolvedBy,
+			Answer:       rec.Answer,
+			ResolvedAt:   rec.ResolvedAt.Time,
+			WaitDuration: rec.WaitSeconds,
+		}
+	}
+	return intr
 }
 
 func (l *InterruptLedger) Metrics(space string) InterruptMetrics {

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -209,6 +209,8 @@ func (s *Server) Start() error {
 		})
 	})
 
+	// Route InterruptLedger operations to SQLite.
+	s.interrupts.SetRepo(s.repo)
 	s.loadSettings() // load persisted settings before spaces
 
 	if err := s.loadAllSpaces(); err != nil {


### PR DESCRIPTION
## Summary

Completes the JSON file elimination by migrating `InterruptLedger` from `{space}.interrupts.jsonl` files to a SQLite `interrupts` table.

**Changes:**
- Add `InterruptRecord` model (`interrupts` table) to db package with all interrupt fields including nullable resolution columns
- Register in `AutoMigrate` and `DeleteSpace` cascade transaction
- Add `SaveInterrupt`, `LoadInterrupts`, `ResolveInterrupt`, `DeleteInterrupts` to `Repository`
- Refactor `InterruptLedger`: add `SetRepo(repo)` injection. When set (always at runtime): `Record`/`RecordResolved` → `SaveInterrupt`, `LoadAll` → `LoadInterrupts`, `Resolve` → `ResolveInterrupt`
- Wire `SetRepo` in `Server.Start()` after repo init — no `{space}.interrupts.jsonl` files written when SQLite active
- File-based fallback paths retained for no-DB deployments

**After this PR, the only remaining file writes are:**
- `personas.json` (intentional — global config, not space data)
- Agent document `.md` files (intentional feature)

## Test plan
- [x] All 179+ tests pass with `-race`
- [x] InterruptLedger.Record → SQLite row via SaveInterrupt
- [x] InterruptLedger.Resolve → SQLite update via ResolveInterrupt
- [x] DeleteSpace cascades to interrupts table

🤖 Generated with [Claude Code](https://claude.com/claude-code)