### PR TITLE
fix(ui): TASK-107 approve buttons not firing in notification tray

### DIFF
--- a/frontend/src/components/ApprovalTray.vue
+++ b/frontend/src/components/ApprovalTray.vue
@@ -7,7 +7,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ShieldCheck } from 'lucide-vue-next'
 
@@ -95,21 +94,20 @@ function agentToolInfo(name: string): { toolName: string; promptText: string } {
             </div>
           </div>
           <div class="flex gap-2">
-            <Button
-              size="sm"
-              class="flex-1 h-7 text-xs bg-destructive hover:bg-destructive/90 text-destructive-foreground"
-              @click="emit('approve', agentName, false)"
+            <button
+              type="button"
+              class="flex-1 h-7 text-xs inline-flex items-center justify-center rounded-md font-medium transition-colors bg-destructive hover:bg-destructive/90 text-destructive-foreground px-3"
+              @click.stop="emit('approve', agentName, false)"
             >
               Approve once
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              class="flex-1 h-7 text-xs"
-              @click="emit('approve', agentName, true)"
+            </button>
+            <button
+              type="button"
+              class="flex-1 h-7 text-xs inline-flex items-center justify-center rounded-md font-medium transition-colors border bg-background hover:bg-accent hover:text-accent-foreground px-3"
+              @click.stop="emit('approve', agentName, true)"
             >
               Always allow
-            </Button>
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fixes bug where clicking "Approve once" / "Always allow" in the approval notification tray did nothing
- Root cause: `Button` (shadcn/reka-ui `Primitive` wrapper) components inside `DropdownMenuContent` can have click events intercepted or dropped by Reka UI's MenuContent context management
- Fix: replace `Button` components with native `<button>` elements using equivalent Tailwind classes + add `@click.stop` to prevent dropdown dismiss layer from consuming the event before `emit` fires
- Binary rebuilt and server restarted with the fix live

## Test plan
- [ ] Open dashboard with an agent pending approval (needs_approval=true)
- [ ] Click the shield badge in the top-right header → tray opens
- [ ] Click "Approve once" → agent is approved, tray updates
- [ ] Click "Always allow" → agent is always-allowed, tray updates
- [ ] Clicking agent name still navigates to agent view

🤖 Generated with [Claude Code](https://claude.com/claude-code)