### PR TITLE
feat(personas): version history, outdated detection, re-pin on restart

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -922,9 +922,40 @@ func (s *Server) handleSpaceAgentsJSON(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	// Enrich agent records with persona_outdated info.
+	type agentWithPersonaStatus struct {
+		*AgentRecord
+		PersonaOutdated  bool                        `json:"persona_outdated,omitempty"`
+		PersonaVersions  map[string]personaVersionInfo `json:"persona_versions,omitempty"`
+	}
+	result := make(map[string]agentWithPersonaStatus, len(ks.Agents))
+	for name, rec := range ks.Agents {
+		entry := agentWithPersonaStatus{AgentRecord: rec}
+		if rec != nil && rec.Config != nil && s.personas != nil {
+			for _, ref := range rec.Config.Personas {
+				cur := s.personas.currentVersion(ref.ID)
+				if ref.PinnedVersion < cur {
+					entry.PersonaOutdated = true
+					if entry.PersonaVersions == nil {
+						entry.PersonaVersions = make(map[string]personaVersionInfo)
+					}
+					entry.PersonaVersions[ref.ID] = personaVersionInfo{
+						Pinned:  ref.PinnedVersion,
+						Current: cur,
+					}
+				}
+			}
+		}
+		result[name] = entry
+	}
+	s.mu.RUnlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(ks.Agents)
+	json.NewEncoder(w).Encode(result)
+}
+
+type personaVersionInfo struct {
+	Pinned  int `json:"pinned"`
+	Current int `json:"current"`
 }
 
 func (s *Server) handleSpaceEventsJSON(w http.ResponseWriter, r *http.Request) {

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -557,6 +557,10 @@ func (s *Server) handleAgentRestart(w http.ResponseWriter, r *http.Request, spac
 	agent.Status = StatusIdle
 	agent.Summary = fmt.Sprintf("%s: restarted", canonical)
 	agent.UpdatedAt = time.Now().UTC()
+	// Re-pin persona versions so the agent gets the latest prompts.
+	if cfg := ks.agentConfig(canonical); cfg != nil && len(cfg.Personas) > 0 {
+		cfg.Personas = s.resolvePersonaRefs(cfg.Personas)
+	}
 	s.saveSpace(ks)
 	s.mu.Unlock()
 

--- a/internal/coordinator/personas.go
+++ b/internal/coordinator/personas.go
@@ -1,6 +1,7 @@
 package coordinator
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -115,6 +116,12 @@ func (ps *PersonaStore) update(id string, fn func(*Persona)) (*Persona, error) {
 	if p == nil {
 		return nil, fmt.Errorf("persona %q not found", id)
 	}
+	// Save current state to history before applying changes.
+	p.History = append(p.History, PersonaVersion{
+		Version:   p.Version,
+		Prompt:    p.Prompt,
+		UpdatedAt: p.UpdatedAt,
+	})
 	fn(p)
 	p.Version++
 	p.UpdatedAt = time.Now().UTC()
@@ -123,6 +130,62 @@ func (ps *PersonaStore) update(id string, fn func(*Persona)) (*Persona, error) {
 	}
 	copy := *p
 	return &copy, nil
+}
+
+// history returns the version history for a persona.
+func (ps *PersonaStore) history(id string) ([]PersonaVersion, error) {
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	p := ps.data[id]
+	if p == nil {
+		return nil, fmt.Errorf("persona %q not found", id)
+	}
+	// Return history + current version.
+	all := make([]PersonaVersion, len(p.History), len(p.History)+1)
+	copy(all, p.History)
+	all = append(all, PersonaVersion{
+		Version:   p.Version,
+		Prompt:    p.Prompt,
+		UpdatedAt: p.UpdatedAt,
+	})
+	return all, nil
+}
+
+// revert restores a persona to a previous version's prompt, creating a new version.
+func (ps *PersonaStore) revert(id string, targetVersion int) (*Persona, error) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	p := ps.data[id]
+	if p == nil {
+		return nil, fmt.Errorf("persona %q not found", id)
+	}
+	// Find the target version in history.
+	var targetPrompt string
+	found := false
+	for _, h := range p.History {
+		if h.Version == targetVersion {
+			targetPrompt = h.Prompt
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("version %d not found in history", targetVersion)
+	}
+	// Save current to history, then apply the old prompt.
+	p.History = append(p.History, PersonaVersion{
+		Version:   p.Version,
+		Prompt:    p.Prompt,
+		UpdatedAt: p.UpdatedAt,
+	})
+	p.Prompt = targetPrompt
+	p.Version++
+	p.UpdatedAt = time.Now().UTC()
+	if err := ps.save(); err != nil {
+		return nil, err
+	}
+	cp := *p
+	return &cp, nil
 }
 
 func (ps *PersonaStore) delete(id string) error {
@@ -329,6 +392,178 @@ func (s *Server) handlePersonaDetail(w http.ResponseWriter, r *http.Request, per
 	default:
 		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// handlePersonaHistory handles GET /personas/{id}/history.
+func (s *Server) handlePersonaHistory(w http.ResponseWriter, r *http.Request, personaID string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	versions, err := s.personas.history(personaID)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(versions)
+}
+
+// handlePersonaRevert handles POST /personas/{id}/revert.
+func (s *Server) handlePersonaRevert(w http.ResponseWriter, r *http.Request, personaID string) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Version int `json:"version"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, "invalid json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	updated, err := s.personas.revert(personaID, req.Version)
+	if err != nil {
+		writeJSONError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(updated)
+}
+
+// personaAgentInfo describes an agent using a persona, with outdated status.
+type personaAgentInfo struct {
+	Space          string `json:"space"`
+	Agent          string `json:"agent"`
+	PinnedVersion  int    `json:"pinned_version"`
+	CurrentVersion int    `json:"current_version"`
+	Outdated       bool   `json:"outdated"`
+	SessionID      string `json:"session_id,omitempty"`
+}
+
+// handlePersonaAgents handles GET /personas/{id}/agents.
+func (s *Server) handlePersonaAgents(w http.ResponseWriter, r *http.Request, personaID string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	p := s.personas.get(personaID)
+	if p == nil {
+		writeJSONError(w, fmt.Sprintf("persona %q not found", personaID), http.StatusNotFound)
+		return
+	}
+
+	var agents []personaAgentInfo
+	s.mu.RLock()
+	for spaceName, ks := range s.spaces {
+		for agentName, rec := range ks.Agents {
+			if rec == nil || rec.Config == nil {
+				continue
+			}
+			for _, ref := range rec.Config.Personas {
+				if ref.ID == personaID {
+					agents = append(agents, personaAgentInfo{
+						Space:          spaceName,
+						Agent:          agentName,
+						PinnedVersion:  ref.PinnedVersion,
+						CurrentVersion: p.Version,
+						Outdated:       ref.PinnedVersion < p.Version,
+						SessionID:      rec.Status.SessionID,
+					})
+					break
+				}
+			}
+		}
+	}
+	s.mu.RUnlock()
+
+	if agents == nil {
+		agents = []personaAgentInfo{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(agents)
+}
+
+// handlePersonaRestartOutdated handles POST /personas/{id}/restart-outdated.
+func (s *Server) handlePersonaRestartOutdated(w http.ResponseWriter, r *http.Request, personaID string) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	p := s.personas.get(personaID)
+	if p == nil {
+		writeJSONError(w, fmt.Sprintf("persona %q not found", personaID), http.StatusNotFound)
+		return
+	}
+
+	type restartTarget struct {
+		Space     string
+		Agent     string
+		SessionID string
+		Backend   string
+	}
+	var targets []restartTarget
+
+	s.mu.RLock()
+	for spaceName, ks := range s.spaces {
+		for agentName, rec := range ks.Agents {
+			if rec == nil || rec.Config == nil || rec.Status == nil {
+				continue
+			}
+			for _, ref := range rec.Config.Personas {
+				if ref.ID == personaID && ref.PinnedVersion < p.Version {
+					targets = append(targets, restartTarget{
+						Space:     spaceName,
+						Agent:     agentName,
+						SessionID: rec.Status.SessionID,
+						Backend:   rec.Status.BackendType,
+					})
+					break
+				}
+			}
+		}
+	}
+	s.mu.RUnlock()
+
+	var restarted []string
+	var errors []string
+	for _, t := range targets {
+		if t.SessionID == "" {
+			errors = append(errors, fmt.Sprintf("%s/%s: no session", t.Space, t.Agent))
+			continue
+		}
+		backend := s.backendByName(t.Backend)
+		if backend == nil {
+			errors = append(errors, fmt.Sprintf("%s/%s: backend not available", t.Space, t.Agent))
+			continue
+		}
+		// Re-pin persona versions before restart.
+		s.mu.Lock()
+		if ks, ok := s.spaces[t.Space]; ok {
+			if rec, ok := ks.Agents[t.Agent]; ok && rec.Config != nil {
+				rec.Config.Personas = s.resolvePersonaRefs(rec.Config.Personas)
+				s.saveSpace(ks)
+			}
+		}
+		s.mu.Unlock()
+
+		// Trigger restart via the lifecycle handler logic.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := backend.KillSession(ctx, t.SessionID); err != nil {
+			errors = append(errors, fmt.Sprintf("%s/%s: kill failed: %v", t.Space, t.Agent, err))
+			cancel()
+			continue
+		}
+		cancel()
+		restarted = append(restarted, t.Space+"/"+t.Agent)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"restarted": restarted,
+		"errors":    errors,
+		"total":     len(targets),
+	})
 }
 
 // dedup removes duplicate strings from a slice.

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -248,9 +248,27 @@ func (s *Server) Start() error {
 	})
 	mux.HandleFunc("/personas", s.handlePersonaList)
 	mux.HandleFunc("/personas/", func(w http.ResponseWriter, r *http.Request) {
-		id := strings.TrimPrefix(r.URL.Path, "/personas/")
-		id = strings.TrimRight(id, "/")
-		s.handlePersonaDetail(w, r, id)
+		rest := strings.TrimPrefix(r.URL.Path, "/personas/")
+		rest = strings.TrimRight(rest, "/")
+		// Sub-routes: /personas/{id}/history, /personas/{id}/agents, etc.
+		if idx := strings.Index(rest, "/"); idx >= 0 {
+			id := rest[:idx]
+			sub := rest[idx+1:]
+			switch sub {
+			case "history":
+				s.handlePersonaHistory(w, r, id)
+			case "revert":
+				s.handlePersonaRevert(w, r, id)
+			case "agents":
+				s.handlePersonaAgents(w, r, id)
+			case "restart-outdated":
+				s.handlePersonaRestartOutdated(w, r, id)
+			default:
+				writeJSONError(w, "not found", http.StatusNotFound)
+			}
+			return
+		}
+		s.handlePersonaDetail(w, r, rest)
 	})
 	mux.HandleFunc("/settings", s.handleSettings)
 	mcpHandler := s.buildMCPHandler()

--- a/internal/coordinator/types.go
+++ b/internal/coordinator/types.go
@@ -773,11 +773,19 @@ type PersonaRef struct {
 // Persona is a global, reusable prompt fragment that can be assigned to agents.
 // Personas are stored in DATA_DIR/personas.json and are independent of spaces.
 type Persona struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description"`
-	Prompt      string    `json:"prompt"`
-	Version     int       `json:"version"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          string           `json:"id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Prompt      string           `json:"prompt"`
+	Version     int              `json:"version"`
+	History     []PersonaVersion `json:"history,omitempty"`
+	CreatedAt   time.Time        `json:"created_at"`
+	UpdatedAt   time.Time        `json:"updated_at"`
+}
+
+// PersonaVersion is a snapshot of a persona at a specific version.
+type PersonaVersion struct {
+	Version   int       `json:"version"`
+	Prompt    string    `json:"prompt"`
+	UpdatedAt time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary
Backend foundation for persona version management (TASK-118, TASK-119, TASK-120).

### Version History (TASK-118)
- `PersonaVersion` type stores version number, prompt text, and timestamp
- On every persona update, current state is appended to `History` before changes apply
- `GET /personas/{id}/history` — returns full version timeline (all versions including current)
- `POST /personas/{id}/revert` — reverts to a previous version's prompt (creates a new version, doesn't destroy history)

### Outdated Detection (TASK-119)
- `GET /personas/{id}/agents` — lists all agents using a persona, each with `outdated` flag comparing `pinned_version` vs `current_version`
- `/api/agents` response now includes `persona_outdated: true` and `persona_versions: {"persona-id": {"pinned": 2, "current": 4}}` when applicable
- `POST /personas/{id}/restart-outdated` — bulk-restarts all agents with stale persona pins, re-pins versions

### Re-pin on Restart (TASK-120)
- Agent restart flow now calls `resolvePersonaRefs()` to update `PinnedVersion` to current
- Previously, restarting an agent did NOT update the persona pin, so agents appeared outdated even after restart

## New API Endpoints

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/personas/{id}/history` | GET | Full version history |
| `/personas/{id}/revert` | POST | Revert to version N |
| `/personas/{id}/agents` | GET | Agents using this persona with outdated status |
| `/personas/{id}/restart-outdated` | POST | Bulk restart outdated agents |

## Test plan
- [x] `go build ./cmd/boss/` compiles
- [x] `go test -race` — all tests pass
- [ ] Manual: update a persona, verify history grows
- [ ] Manual: verify `/personas/{id}/agents` shows outdated agents
- [ ] Manual: restart agent, verify pinned_version updates
- [ ] Manual: revert persona, verify new version created with old prompt

## Follow-up
Frontend work (TASK-123, TASK-124, TASK-125) depends on these APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)