### PR TITLE
feat(ui): TASK-113/114 — Shared Contracts viewer/editor with Protocol tab

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -460,6 +460,26 @@ class ApiClient {
 
 
 
+  // --------------- Contracts ---------------
+
+  fetchContracts(space: string): Promise<string> {
+    return fetch(`${this.baseUrl}/spaces/${encodeURIComponent(space)}/contracts`)
+      .then(r => r.text())
+  }
+
+  saveContracts(space: string, content: string): Promise<void> {
+    return this.requestVoid(`/spaces/${encodeURIComponent(space)}/contracts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: content,
+    })
+  }
+
+  fetchDefaultContracts(space: string): Promise<string> {
+    return fetch(`${this.baseUrl}/spaces/${encodeURIComponent(space)}/contracts/default`)
+      .then(r => r.text())
+  }
+
   // --------------- Personas ---------------
 
   fetchPersonas(): Promise<Persona[]> {

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -45,6 +45,11 @@ import {
   Search,
   Plus,
   RotateCcw,
+  FileText,
+  Pencil,
+  X,
+  Save,
+  Loader2,
 } from 'lucide-vue-next'
 import StatusBadge from './StatusBadge.vue'
 import InterruptTracker from './InterruptTracker.vue'
@@ -54,6 +59,7 @@ import GanttTimeline from './GanttTimeline.vue'
 import HierarchyView from './HierarchyView.vue'
 import AgentCreateDialog from './AgentCreateDialog.vue'
 import { prLink } from '@/lib/utils'
+import { renderMarkdown } from '@/lib/markdown'
 import api from '@/api/client'
 
 const props = defineProps<{
@@ -112,6 +118,84 @@ onMounted(loadPersonaVersions)
 const agentSearch = ref('')
 const activeTab = ref('agents')
 const agentCreateDialogOpen = ref(false)
+
+// Protocol tab state
+const contractsEditing = ref(false)
+const contractsText = ref('')
+const contractsDefault = ref('')
+const contractsSaving = ref(false)
+const contractsError = ref('')
+const contractsSuccess = ref(false)
+const contractsResetConfirmOpen = ref(false)
+const contractsLoading = ref(false)
+
+const contractsIsCustomized = computed(() =>
+  contractsDefault.value !== '' && contractsText.value.trim() !== contractsDefault.value.trim()
+)
+
+async function loadContractsDefault() {
+  if (contractsDefault.value) return
+  try {
+    contractsDefault.value = await api.fetchDefaultContracts(props.space.name)
+  } catch {
+    // ignore — reset button just won't show accurate state
+  }
+}
+
+async function onProtocolTabActivated() {
+  contractsText.value = props.space.shared_contracts ?? ''
+  contractsEditing.value = false
+  contractsError.value = ''
+  contractsSuccess.value = false
+  contractsLoading.value = true
+  try {
+    // Re-fetch live value from server (space prop may be stale)
+    const live = await api.fetchContracts(props.space.name)
+    contractsText.value = live
+  } catch {
+    // fall back to prop value
+  } finally {
+    contractsLoading.value = false
+  }
+  loadContractsDefault()
+}
+
+async function saveContracts() {
+  contractsSaving.value = true
+  contractsError.value = ''
+  contractsSuccess.value = false
+  try {
+    await api.saveContracts(props.space.name, contractsText.value)
+    contractsEditing.value = false
+    contractsSuccess.value = true
+    setTimeout(() => { contractsSuccess.value = false }, 3000)
+  } catch (e) {
+    contractsError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    contractsSaving.value = false
+  }
+}
+
+async function resetContractsToDefault() {
+  contractsResetConfirmOpen.value = false
+  contractsSaving.value = true
+  contractsError.value = ''
+  try {
+    await api.saveContracts(props.space.name, contractsDefault.value)
+    contractsText.value = contractsDefault.value
+    contractsEditing.value = false
+    contractsSuccess.value = true
+    setTimeout(() => { contractsSuccess.value = false }, 3000)
+  } catch (e) {
+    contractsError.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    contractsSaving.value = false
+  }
+}
+
+watch(activeTab, (tab) => {
+  if (tab === 'protocol') onProtocolTabActivated()
+})
 const deleteDialogOpen = ref(false)
 const deleteDialogAgent = ref<string | null>(null)
 const deleteSpaceDialogOpen = ref(false)
@@ -538,6 +622,11 @@ const activeSections = computed(() => [
           </TabsTrigger>
           <TabsTrigger value="timeline">Timeline</TabsTrigger>
           <TabsTrigger value="hierarchy">Hierarchy</TabsTrigger>
+          <TabsTrigger value="protocol" class="gap-1.5">
+            <FileText class="size-3.5" />
+            Protocol
+            <Badge v-if="contractsIsCustomized" variant="secondary" class="text-[9px] px-1 py-0 h-3.5 leading-none">custom</Badge>
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="agents">
@@ -974,7 +1063,106 @@ const activeSections = computed(() => [
             @select-agent="emit('select-agent', $event)"
           />
         </TabsContent>
+
+        <!-- Protocol / Shared Contracts tab -->
+        <TabsContent value="protocol">
+          <div class="p-4 space-y-3 max-w-3xl">
+            <!-- Header row -->
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <h2 class="text-sm font-semibold">Shared Contracts</h2>
+                <p class="text-xs text-muted-foreground mt-0.5">Communication protocol and rules your agents follow in this space.</p>
+              </div>
+              <div class="flex items-center gap-2">
+                <Badge v-if="contractsIsCustomized" variant="outline" class="text-[10px] px-2 py-0.5 border-amber-500/50 text-amber-600 dark:text-amber-400">
+                  Customized
+                </Badge>
+                <Button v-if="!contractsEditing" variant="ghost" size="sm" class="h-7 gap-1 text-xs" @click="contractsEditing = true; contractsError = ''">
+                  <Pencil class="size-3.5" /> Edit
+                </Button>
+                <Button
+                  v-if="contractsIsCustomized && !contractsEditing"
+                  variant="ghost"
+                  size="sm"
+                  class="h-7 gap-1 text-xs text-muted-foreground hover:text-foreground"
+                  title="Reset to default protocol template"
+                  @click="contractsResetConfirmOpen = true"
+                >
+                  <RotateCcw class="size-3.5" /> Reset
+                </Button>
+              </div>
+            </div>
+
+            <!-- Success toast -->
+            <div v-if="contractsSuccess" class="flex items-center gap-2 px-3 py-2 rounded-md bg-green-500/10 border border-green-500/20 text-xs text-green-700 dark:text-green-400">
+              Contracts saved successfully.
+            </div>
+
+            <!-- Loading -->
+            <div v-if="contractsLoading" class="flex items-center gap-2 text-xs text-muted-foreground py-4">
+              <Loader2 class="size-3.5 animate-spin" /> Loading…
+            </div>
+
+            <!-- View mode -->
+            <div v-else-if="!contractsEditing">
+              <div
+                v-if="contractsText"
+                class="prose prose-sm dark:prose-invert max-w-none md-content border rounded-md p-4 bg-muted/30 text-sm leading-relaxed overflow-y-auto max-h-[60vh]"
+                v-html="renderMarkdown(contractsText)"
+              />
+              <div v-else class="flex flex-col items-center gap-3 py-8 text-muted-foreground">
+                <FileText class="size-8 opacity-30" />
+                <p class="text-sm">No protocol defined for this space yet.</p>
+                <Button size="sm" variant="outline" @click="contractsEditing = true">
+                  <Pencil class="size-3.5 mr-1.5" /> Define Protocol
+                </Button>
+              </div>
+            </div>
+
+            <!-- Edit mode -->
+            <div v-else class="space-y-2">
+              <Textarea
+                v-model="contractsText"
+                rows="24"
+                class="font-mono text-xs leading-relaxed resize-y"
+                placeholder="# Protocol&#10;&#10;Define the communication rules your agents follow..."
+              />
+              <p v-if="contractsError" class="text-xs text-destructive">{{ contractsError }}</p>
+              <div class="flex items-center gap-2">
+                <Button size="sm" class="h-7 gap-1 text-xs" :disabled="contractsSaving" @click="saveContracts">
+                  <Loader2 v-if="contractsSaving" class="size-3 animate-spin" />
+                  <Save v-else class="size-3" />
+                  Save
+                </Button>
+                <Button size="sm" variant="ghost" class="h-7 text-xs" :disabled="contractsSaving" @click="contractsEditing = false; contractsError = ''">
+                  <X class="size-3 mr-1" /> Cancel
+                </Button>
+              </div>
+            </div>
+          </div>
+        </TabsContent>
       </Tabs>
+
+      <!-- Reset contracts confirmation -->
+      <AlertDialog v-model:open="contractsResetConfirmOpen">
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset to default protocol?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will replace the current shared contracts with the default protocol template. Your customizations will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              @click.prevent="resetContractsToDefault"
+            >
+              <RotateCcw class="size-4 mr-1" /> Reset to Default
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <!-- Clear done/idle agents confirmation dialog -->
       <AlertDialog v-model:open="clearDoneDialogOpen">

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -112,6 +112,10 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 	case "raw":
 		s.handleSpaceRaw(w, r, spaceName)
 	case "contracts":
+		if len(parts) >= 3 && strings.TrimRight(parts[2], "/") == "default" {
+			s.handleSpaceContractsDefault(w, r, spaceName)
+			return
+		}
 		s.handleSpaceContracts(w, r, spaceName)
 	case "archive":
 		s.handleSpaceArchive(w, r, spaceName)
@@ -401,6 +405,23 @@ func (s *Server) handleSpaceContracts(w http.ResponseWriter, r *http.Request, sp
 		logLabel:    "contracts",
 		journalType: EventContractsUpdated,
 	})
+}
+
+// handleSpaceContractsDefault serves GET /spaces/{space}/contracts/default —
+// returns the embedded protocol.md template with {SPACE} substituted.
+// This lets the frontend compare current contracts to the default and offer a reset.
+func (s *Server) handleSpaceContractsDefault(w http.ResponseWriter, r *http.Request, spaceName string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if protocolTemplate == "" {
+		writeJSONError(w, "protocol template not available", http.StatusInternalServerError)
+		return
+	}
+	defaultContracts := strings.ReplaceAll(protocolTemplate, "{SPACE}", spaceName)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprint(w, defaultContracts)
 }
 
 func (s *Server) handleSpaceArchive(w http.ResponseWriter, r *http.Request, spaceName string) {


### PR DESCRIPTION
## Summary

- Adds **Protocol** tab to the Space overview with full shared-contracts viewer and editor
- Backend: `GET /spaces/{space}/contracts/default` — returns the embedded `protocol.md` template with `{SPACE}` substituted, enabling frontend to detect customization and offer a reset
- API client: `fetchContracts`, `saveContracts`, `fetchDefaultContracts` methods
- SpaceOverview Protocol tab:
  - Rendered markdown view of the space's shared contracts
  - **Edit** button switches to a monospace textarea for full editing
  - **Save** via `POST /spaces/{space}/contracts` with success toast and inline error
  - **Customized** amber badge when the current contracts differ from the default template (TASK-114)
  - **Reset to default** button with confirmation dialog — restores `protocol.md` (TASK-114)
  - Lazy-loads the live contract text from the server on tab activation

## Test plan

- [ ] `go test -race ./internal/coordinator/` — all tests pass
- [ ] `npm run build` in `frontend/` — clean build, no type errors
- [ ] Manual: open any space → click Protocol tab → see rendered contracts
- [ ] Manual: click Edit → modify text → Save → success toast shown
- [ ] Manual: contracts differ from default → "Customized" badge appears + Reset button visible
- [ ] Manual: Reset → confirmation dialog → confirm → contracts restored to default

Closes TASK-113, TASK-114

🤖 Generated with [Claude Code](https://claude.com/claude-code)