### PR TITLE
feat(ui): TASK-128 — exclude approval-type interrupts from inbox

### DIFF
--- a/frontend/src/components/InterruptTracker.vue
+++ b/frontend/src/components/InterruptTracker.vue
@@ -60,16 +60,19 @@ async function fetchData() {
 }
 
 // Expose pending count and refresh for parent (SSE-triggered refresh)
+// Approval-type interrupts are handled exclusively by the ApprovalTray — exclude them here.
 const pendingCount = computed(() => {
-  return interrupts.value.filter(i => !i.resolution).length
+  return interrupts.value.filter(i => !i.resolution && i.type !== 'approval').length
 })
 
 defineExpose({ pendingCount, refresh: fetchData })
 
-const totalCount = computed(() => interrupts.value.length)
+const totalCount = computed(() => interrupts.value.filter(i => i.type !== 'approval').length)
 
 const filteredInterrupts = computed(() => {
-  const sorted = [...interrupts.value].sort((a, b) => {
+  // Approval-type interrupts are handled by the ApprovalTray — exclude from inbox.
+  const nonApproval = interrupts.value.filter(i => i.type !== 'approval')
+  const sorted = [...nonApproval].sort((a, b) => {
     // Pending first
     const aPending = !a.resolution
     const bPending = !b.resolution
@@ -257,15 +260,11 @@ async function confirmMarkAllResolved() {
   markAllDialogOpen.value = false
   markingAll.value = true
   try {
-    const pending = interrupts.value.filter(i => !i.resolution)
-    await Promise.allSettled([
-      ...pending
-        .filter(item => item.type === 'approval')
-        .map(item => api.approveAgent(props.spaceName, item.agent)),
-      ...pending
-        .filter(item => item.type !== 'approval')
-        .map(item => api.resolveInterrupt(props.spaceName, item.id, 'Bulk resolved')),
-    ])
+    // Only non-approval pending items shown in inbox — resolve them all.
+    const pending = interrupts.value.filter(i => !i.resolution && i.type !== 'approval')
+    await Promise.allSettled(
+      pending.map(item => api.resolveInterrupt(props.spaceName, item.id, 'Bulk resolved')),
+    )
     // Optimistically mark all pending items as resolved locally
     const resolvedAt = new Date().toISOString()
     interrupts.value = interrupts.value.map(i => {
@@ -612,7 +611,6 @@ onUnmounted(stopPolling)
         <DialogTitle>Mark all resolved?</DialogTitle>
         <DialogDescription>
           This will resolve all {{ pendingCount }} pending item{{ pendingCount === 1 ? '' : 's' }}.
-          Approval-type items will send an approval signal to the agent.
           This action cannot be undone.
         </DialogDescription>
       </DialogHeader>


### PR DESCRIPTION
## Summary

Implements **Option B** (per Cto recommendation): filter `type=approval` interrupts out of `InterruptTracker` (Inbox tab) so there is one clear place for each concern:

- **ApprovalTray** (header): all live tmux tool-use approvals
- **Inbox tab**: decisions, questions, staleness, review, sequencing — everything except approvals

Previously both showed pending approvals, but acting on one did not update the other.

## Changes

- `filteredInterrupts`: filters out `type=approval` before display
- `pendingCount`: excludes approvals so inbox badge doesn't count them
- `totalCount`: excludes approvals
- `confirmMarkAllResolved`: removes approval-sending branch (no longer needed)
- "Mark all" dialog: removes obsolete approval mention

## Test plan

- [ ] `npm run build` — clean
- [ ] Manual: pending approval in inbox → gone (only shown in tray)
- [ ] Manual: decision/question interrupts still appear in inbox
- [ ] Manual: inbox badge count reflects only non-approval pending items
- [ ] Manual: "Mark all resolved" resolves only decision/question types

Closes TASK-128

🤖 Generated with [Claude Code](https://claude.com/claude-code)