### PR TITLE
fix(protocol): remove curl examples from shared contracts — MCP is primary (TASK-127)

### DIFF
--- a/internal/coordinator/protocol.md
+++ b/internal/coordinator/protocol.md
@@ -19,30 +19,9 @@ All coordinator interactions use **boss-mcp** tools. These are automatically ava
 | `move_task` | Change task status | `space`, `agent`, `task_id`, `status`, `reason` |
 | `update_task` | Update task fields | `space`, `agent`, `task_id`, `title`, `linked_pr`, `assigned_to` |
 
-### HTTP API (alternative for non-MCP clients)
+### HTTP API
 
-The HTTP API remains available at `{COORDINATOR_URL}` for clients that do not support MCP.
-
-#### Core Endpoints
-
-| Action | Command |
-|--------|---------|
-| Post status (JSON) | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name} -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"status":"...","summary":"...","items":[...]}'` |
-| Send message to agent | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{target}/message -H 'Content-Type: application/json' -H 'X-Agent-Name: {sender}' -d '{"message":"..."}'` |
-| Read my section | `curl -s {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}` |
-| Read full blackboard | `curl -s {COORDINATOR_URL}/spaces/{SPACE}/raw` |
-| Poll my messages | `curl -s "{COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/messages?since=<cursor>"` |
-| ACK a message | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/agent/{name}/messages/{id}/ack -H 'X-Agent-Name: {name}'` |
-| Dashboard | `{COORDINATOR_URL}/spaces/{SPACE}/` |
-
-#### Task Management
-
-| Action | Command |
-|--------|---------|
-| Create task | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/tasks -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"title":"...","assigned_to":"...","priority":"high"}'` |
-| List tasks | `curl -s "{COORDINATOR_URL}/spaces/{SPACE}/tasks?assigned_to={name}&status=in_progress"` |
-| Move task status | `curl -s -X POST {COORDINATOR_URL}/spaces/{SPACE}/tasks/{id}/move -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"status":"done"}'` |
-| Update task (PR link) | `curl -s -X PUT {COORDINATOR_URL}/spaces/{SPACE}/tasks/{id} -H 'Content-Type: application/json' -H 'X-Agent-Name: {name}' -d '{"linked_pr":"#123"}'` |
+An HTTP REST API is available at `{COORDINATOR_URL}` for non-MCP clients (webhooks, CI pipelines, external tools). MCP is the primary interface for agents — use the boss-mcp tools above.
 
 ### Rules
 

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -537,8 +537,8 @@ func TestProtocolInjectedOnNewSpace(t *testing.T) {
 	if !strings.Contains(md, "Space: `local-reconciler`") {
 		t.Error("{SPACE} not substituted in protocol")
 	}
-	if !strings.Contains(md, "local-reconciler/agent/{name}") {
-		t.Error("{SPACE} not substituted in endpoint URLs")
+	if !strings.Contains(md, "boss-mcp") {
+		t.Error("MCP tools section missing from protocol")
 	}
 	if strings.Contains(md, "{SPACE}") {
 		t.Error("raw {SPACE} placeholder still present in rendered output")


### PR DESCRIPTION
## Summary

- Removes the entire HTTP API curl section from `internal/coordinator/protocol.md` (the shared contracts template injected into every space)
- Replaces it with a single note: HTTP REST exists for non-MCP clients (webhooks, CI pipelines, external tools)
- Keeps the MCP Tools table, Rules, Collaboration Norms, and all other content untouched
- Updates `TestProtocolInjectedOnNewSpace` to check for `boss-mcp` section presence instead of the removed curl URL patterns

**Before:** protocol.md had two parallel sections — MCP Tools (primary) and HTTP API (24 lines of curl examples)  
**After:** protocol.md has one primary interface (MCP Tools) and a one-line note about HTTP for non-MCP clients

## Test plan

- [x] `go test -race ./internal/coordinator/` — all tests pass
- [x] `TestProtocolInjectedOnNewSpace` updated and passing

Closes TASK-127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)