### PR TITLE
fix: namespace MCP server name by host/port

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -726,7 +726,7 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 	b.WriteString("**You are running autonomously. There is no human at this terminal.**\n\n")
 	b.WriteString("- You do NOT have a conversational partner. Do not ask questions or wait for confirmation.\n")
 	b.WriteString("- Messages from other agents or the boss are **instructions to act on immediately**.\n")
-	b.WriteString("- You interact with the coordinator using your **boss-mcp tools** (described below).\n")
+	b.WriteString(fmt.Sprintf("- You interact with the coordinator using your **%s tools** (described below).\n", s.mcpServerName()))
 	b.WriteString("- When you receive a new task via messages, **start working on it immediately**.\n")
 	b.WriteString("- If you need a decision, use `send_message` to your manager and continue working on what you can.\n")
 	b.WriteString("- When your task is done, use `post_status` with status `\"done\"` and await new messages.\n")
@@ -740,8 +740,9 @@ func (s *Server) buildIgnitionText(spaceName, agentName, sessionID string) strin
 	}
 	b.WriteString("\n")
 
-	b.WriteString("## MCP Tools (boss-mcp)\n\n")
-	b.WriteString("You have **boss-mcp** tools available. Use these for ALL coordinator interactions:\n\n")
+	mcpName := s.mcpServerName()
+	b.WriteString(fmt.Sprintf("## MCP Tools (%s)\n\n", mcpName))
+	b.WriteString(fmt.Sprintf("You have **%s** tools available. Use these for ALL coordinator interactions:\n\n", mcpName))
 	b.WriteString("| Tool | Purpose |\n")
 	b.WriteString("| ---- | ------- |\n")
 	b.WriteString("| `post_status` | Report your current status, branch, PR, progress |\n")
@@ -1402,6 +1403,7 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 				Width:                req.Width,
 				Height:               req.Height,
 				MCPServerURL:         s.localURL(),
+				MCPServerName:        s.mcpServerName(),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
 		}

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -425,6 +425,7 @@ func (s *Server) handleSpaceContractsDefault(w http.ResponseWriter, r *http.Requ
 	}
 	defaultContracts := strings.ReplaceAll(protocolTemplate, "{SPACE}", spaceName)
 	defaultContracts = strings.ReplaceAll(defaultContracts, "{COORDINATOR_URL}", s.localURL())
+	defaultContracts = strings.ReplaceAll(defaultContracts, "{MCP_NAME}", s.mcpServerName())
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	fmt.Fprint(w, defaultContracts)
 }

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -374,6 +374,7 @@ func (s *Server) spawnAgentService(spaceName, agentName string, req spawnRequest
 				Height:               req.Height,
 				WorkDir:              spawnWorkDir,
 				MCPServerURL:         s.localURL(),
+				MCPServerName:        s.mcpServerName(),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
 		}
@@ -606,6 +607,7 @@ func (s *Server) restartAgentService(spaceName, agentName string, req spawnReque
 			BackendOpts: TmuxCreateOpts{
 				WorkDir:              restartWorkDir,
 				MCPServerURL:         s.localURL(),
+				MCPServerName:        s.mcpServerName(),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
 		}
@@ -826,6 +828,7 @@ func (s *Server) handleRestartAll(w http.ResponseWriter, r *http.Request, spaceN
 				BackendOpts: TmuxCreateOpts{
 					WorkDir:              workDir,
 					MCPServerURL:         s.localURL(),
+					MCPServerName:        s.mcpServerName(),
 					AllowSkipPermissions: s.allowSkipPermissions,
 				},
 			}

--- a/internal/coordinator/mcp_server.go
+++ b/internal/coordinator/mcp_server.go
@@ -97,6 +97,7 @@ func (s *Server) buildMCPHandler() http.Handler {
 		MIMEType:    "text/markdown",
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
 		text := strings.ReplaceAll(protocolTemplate, "{COORDINATOR_URL}", s.localURL())
+		text = strings.ReplaceAll(text, "{MCP_NAME}", s.mcpServerName())
 		return &mcp.ReadResourceResult{
 			Contents: []*mcp.ResourceContents{
 				{

--- a/internal/coordinator/protocol.md
+++ b/internal/coordinator/protocol.md
@@ -4,9 +4,9 @@
 
 Space: `{SPACE}`
 
-### MCP Tools (boss-mcp)
+### MCP Tools ({MCP_NAME})
 
-All coordinator interactions use **boss-mcp** tools. These are automatically available when your MCP server is registered.
+All coordinator interactions use **{MCP_NAME}** tools. These are automatically available when your MCP server is registered.
 
 | Tool | Purpose | Key Parameters |
 | ---- | ------- | -------------- |
@@ -22,7 +22,7 @@ All coordinator interactions use **boss-mcp** tools. These are automatically ava
 
 ### HTTP API
 
-An HTTP REST API is available at `{COORDINATOR_URL}` for non-MCP clients (webhooks, CI pipelines, external tools). MCP is the primary interface for agents — use the boss-mcp tools above.
+An HTTP REST API is available at `{COORDINATOR_URL}` for non-MCP clients (webhooks, CI pipelines, external tools). MCP is the primary interface for agents — use the {MCP_NAME} tools above.
 
 ### Rules
 
@@ -81,7 +81,7 @@ Use `check_messages` with the `since` cursor for efficient polling:
 }
 ```
 
-### MCP Resources (available via boss-mcp)
+### MCP Resources (available via {MCP_NAME})
 
 | Resource | URI |
 |----------|-----|

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -317,6 +317,22 @@ func (s *Server) localURL() string {
 	return "http://" + s.host + ":" + port
 }
 
+// mcpServerName returns a unique MCP server name for this instance.
+// Default (localhost:8899) → "boss-mcp" (unchanged for backwards compat).
+// Non-default port on localhost → "boss-mcp-{port}".
+// Non-localhost host → "boss-mcp-{host}-{port}".
+func (s *Server) mcpServerName() string {
+	port := strings.TrimPrefix(s.port, ":")
+	isDefaultHost := s.host == "localhost" || s.host == "127.0.0.1" || s.host == ""
+	if isDefaultHost && port == "8899" {
+		return "boss-mcp"
+	}
+	if isDefaultHost {
+		return "boss-mcp-" + port
+	}
+	return "boss-mcp-" + s.host + "-" + port
+}
+
 func (s *Server) Stop() error {
 	s.runMu.Lock()
 	defer s.runMu.Unlock()

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -539,8 +539,11 @@ func TestProtocolInjectedOnNewSpace(t *testing.T) {
 	if !strings.Contains(md, "Space: `local-reconciler`") {
 		t.Error("{SPACE} not substituted in protocol")
 	}
-	if !strings.Contains(md, "boss-mcp") {
+	if !strings.Contains(md, "MCP Tools (boss-mcp") {
 		t.Error("MCP tools section missing from protocol")
+	}
+	if strings.Contains(md, "{MCP_NAME}") {
+		t.Error("raw {MCP_NAME} placeholder still present in rendered output")
 	}
 	if strings.Contains(md, "{SPACE}") {
 		t.Error("raw {SPACE} placeholder still present in rendered output")

--- a/internal/coordinator/session_backend.go
+++ b/internal/coordinator/session_backend.go
@@ -116,7 +116,8 @@ type TmuxCreateOpts struct {
 	WorkDir              string // working directory to cd into before launching
 	Width                int    // terminal width (default 220)
 	Height               int    // terminal height (default 50)
-	MCPServerURL         string // if set, run "claude mcp add boss-mcp" before launching
+	MCPServerURL         string // if set, run "claude mcp add" before launching
+	MCPServerName        string // MCP server name (e.g. "boss-mcp", "boss-mcp-8889"); defaults to "boss-mcp"
 	AllowSkipPermissions bool   // if true, append --dangerously-skip-permissions to command
 }
 

--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -46,6 +46,7 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 	height := 50
 	var workDir string
 	var mcpServerURL string
+	var mcpServerName string
 	var allowSkipPermissions bool
 
 	if tmuxOpts, ok := opts.BackendOpts.(TmuxCreateOpts); ok {
@@ -57,7 +58,11 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 		}
 		workDir = tmuxOpts.WorkDir
 		mcpServerURL = tmuxOpts.MCPServerURL
+		mcpServerName = tmuxOpts.MCPServerName
 		allowSkipPermissions = tmuxOpts.AllowSkipPermissions
+	}
+	if mcpServerName == "" {
+		mcpServerName = "boss-mcp"
 	}
 
 	// Append --dangerously-skip-permissions when global toggle is on.
@@ -87,7 +92,7 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 
 	// Register boss MCP server with Claude before launching (idempotent).
 	if mcpServerURL != "" {
-		mcpCmd := fmt.Sprintf("claude mcp add boss-mcp --transport http %s/mcp 2>/dev/null || true", mcpServerURL)
+		mcpCmd := fmt.Sprintf("claude mcp add %s --transport http %s/mcp 2>/dev/null || true", mcpServerName, mcpServerURL)
 		if err := tmuxSendKeys(sessionID, mcpCmd); err != nil {
 			// Non-fatal: log but continue — agent can still function without MCP.
 			_ = err

--- a/internal/coordinator/storage.go
+++ b/internal/coordinator/storage.go
@@ -156,6 +156,7 @@ func (s *Server) refreshProtocol(ks *KnowledgeSpace) {
 	if ks.SharedContracts == "" {
 		p := strings.ReplaceAll(protocolTemplate, "{SPACE}", ks.Name)
 		p = strings.ReplaceAll(p, "{COORDINATOR_URL}", s.localURL())
+		p = strings.ReplaceAll(p, "{MCP_NAME}", s.mcpServerName())
 		ks.SharedContracts = p
 	}
 }

--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -478,12 +478,12 @@ func (s *Server) runAgentCheckIn(spaceName, canonical, sessionID string, backend
 
 	// Send a plain-text check-in prompt using MCP tools.
 	checkInPrompt := fmt.Sprintf(
-		"Check in now. Use your boss-mcp tools: "+
+		"Check in now. Use your %s tools: "+
 			"1) check_messages(space: %q, agent: %q) to read pending messages. "+
 			"2) post_status(space: %q, agent: %q, status: \"active\", summary: \"%s: checking in\") to report your current state. "+
 			"3) Act on any message directives immediately. "+
 			"If you have lost context about the collaboration protocol, read the boss://protocol MCP resource.",
-		spaceName, canonical, spaceName, canonical, canonical,
+		s.mcpServerName(), spaceName, canonical, spaceName, canonical, canonical,
 	)
 	progress("sending check-in prompt")
 	if err := backend.SendInput(sessionID, checkInPrompt); err != nil {


### PR DESCRIPTION
## Summary

- When running multiple boss instances on the same machine, `claude mcp add boss-mcp` is global — whichever server spawned an agent last would overwrite the MCP endpoint for **all** agents, causing cross-server data leakage (spaces and agent updates appearing on the wrong server's frontend)
- Added `Server.mcpServerName()` that derives a unique name from host/port: `boss-mcp` (default localhost:8899), `boss-mcp-{port}` (non-default port), `boss-mcp-{host}-{port}` (non-localhost)
- Threaded the name through `TmuxCreateOpts`, `claude mcp add` command, ignition text, check-in prompts, and all protocol template substitution sites (`protocol.md` now uses `{MCP_NAME}` placeholder)

## Files changed

| File | Change |
|------|--------|
| `server.go` | Added `mcpServerName()` method |
| `session_backend.go` | Added `MCPServerName` field to `TmuxCreateOpts` |
| `session_backend_tmux.go` | Use dynamic name in `claude mcp add` command |
| `protocol.md` | `boss-mcp` → `{MCP_NAME}` placeholder |
| `storage.go`, `handlers_space.go`, `mcp_server.go` | Substitute `{MCP_NAME}` in protocol template |
| `handlers_agent.go` | Use dynamic name in ignition text + pass to TmuxCreateOpts |
| `lifecycle.go` | Pass `MCPServerName` in all 3 TmuxCreateOpts sites |
| `tmux.go` | Use dynamic name in check-in prompt |
| `server_test.go` | Updated protocol test to handle dynamic name + check `{MCP_NAME}` substitution |

## Test plan

- [x] `go test -race ./internal/coordinator/` — all tests pass
- [ ] Run two boss instances on different ports, verify agents register distinct MCP server names
- [ ] Verify default port (8899) still uses `boss-mcp` for backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)