### PR TITLE
fix(tmux): use paste-buffer for large SendInput payloads (TASK-135)

### DIFF
--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -143,7 +143,15 @@ func (b *TmuxSessionBackend) CheckApproval(sessionID string) ApprovalInfo {
 	return tmuxCheckApproval(sessionID)
 }
 
+// tmuxSendKeysLimit is the safe upper bound for tmux send-keys.
+// Beyond ~16 KB tmux returns "command too long" (exit status 1).
+// Using 8 KB gives comfortable headroom below the hard limit.
+const tmuxSendKeysLimit = 8192
+
 func (b *TmuxSessionBackend) SendInput(sessionID string, text string) error {
+	if len(text) > tmuxSendKeysLimit {
+		return tmuxPasteInput(sessionID, text)
+	}
 	return tmuxSendKeys(sessionID, text)
 }
 

--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -383,6 +383,45 @@ func tmuxSendKeys(session, text string) error {
 	return nil
 }
 
+// tmuxPasteInput sends text to a tmux session using load-buffer + paste-buffer.
+// This is necessary for text larger than tmux's send-keys hard limit (~16 KB):
+// beyond that threshold send-keys returns exit status 1 with "command too long".
+// Named buffers (one per session) prevent concurrent calls from interfering.
+func tmuxPasteInput(session, text string) error {
+	bufName := "ignite-" + session
+
+	// Load text into a named paste buffer via stdin.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", "load-buffer", "-b", bufName, "-")
+	cmd.Stdin = strings.NewReader(text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("load-buffer: %w", err)
+	}
+
+	// Paste buffer into the target session at the current cursor position.
+	// -p suppresses an extra newline so we can send Enter ourselves below.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), tmuxCmdTimeout)
+	defer cancel2()
+	if err := exec.CommandContext(ctx2, "tmux", "paste-buffer", "-b", bufName, "-t", session, "-p").Run(); err != nil {
+		exec.Command("tmux", "delete-buffer", "-b", bufName).Run() //nolint:errcheck
+		return fmt.Errorf("paste-buffer: %w", err)
+	}
+	time.Sleep(tmuxSendDelay)
+
+	// Clean up the named buffer.
+	exec.Command("tmux", "delete-buffer", "-b", bufName).Run() //nolint:errcheck
+
+	// Submit with Enter.
+	ctx3, cancel3 := context.WithTimeout(context.Background(), tmuxCmdTimeout)
+	defer cancel3()
+	if err := exec.CommandContext(ctx3, "tmux", "send-keys", "-t", session, "C-m").Run(); err != nil {
+		return fmt.Errorf("send Enter: %w", err)
+	}
+	time.Sleep(tmuxSendDelay)
+	return nil
+}
+
 func waitForIdle(session string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
## Root Cause

`tmux send-keys` has a hard internal limit of ~16 KB. Beyond that it returns exit status 1 with \"command too long\". The ignition prompt sent to newly spawned agents is 28,576 bytes — it **always** exceeded this limit.

This explains why every spawn and restart failed with `create: ignite send failed: exit status 1` at exactly the grace period mark: `waitForIdle` returned, `SendInput` called `tmuxSendKeys`, which immediately failed.

## Fix

Added `tmuxPasteInput(session, text string)` in `tmux.go`:
- Pipes text into `tmux load-buffer -b <bufname> -` via stdin (no size limit)
- Calls `tmux paste-buffer -b <bufname> -t <session> -p` (paste at cursor, no extra newline)
- Sends `C-m` via `send-keys` to submit
- Cleans up the named buffer

`SendInput` in `TmuxSessionBackend` now routes text > 8 KB (well below the 16 KB limit) through `tmuxPasteInput`. Named buffers (`ignite-<session>`) prevent concurrent spawns from overwriting each other's paste buffer.

## Verification

Reproduced: `tmux send-keys -t <session> $(cat 28KB-file)` → "command too long", exit 1
Fixed: `cat 28KB-file | tmux load-buffer -b name - && tmux paste-buffer -b name -t <session> -p` → exit 0

All existing tests pass: `go test -race ./internal/coordinator/`

## Closes

TASK-135

🤖 Generated with [Claude Code](https://claude.com/claude-code)