### PR TITLE
feat(ux): TASK-005 — Frontend UX overhaul

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,6 +19,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import AppSidebar from '@/components/AppSidebar.vue'
 import SpaceOverview from '@/components/SpaceOverview.vue'
 import AgentDetail from '@/components/AgentDetail.vue'
@@ -59,6 +65,10 @@ let pollTimer: ReturnType<typeof setInterval> | null = null
 // ── Component refs ──────────────────────────────────────────────────
 const sidebarRef = ref<InstanceType<typeof AppSidebar> | null>(null)
 
+// ── Global overlay drawers (Personas / Settings) ────────────────────
+const personasDrawerOpen = ref(false)
+const settingsDrawerOpen = ref(false)
+
 // ── Keyboard shortcut state ────────────────────────────────────────
 const showHelpOverlay = ref(false)
 const showMessageDialog = ref(false)
@@ -95,8 +105,10 @@ const showConversations = computed(() =>
 )
 
 const showKanban = computed(() => route.name === 'kanban')
-const showPersonas = computed(() => route.name === 'personas')
-const showSettings = computed(() => route.name === 'settings')
+// These are now drawer-based — the route handler below opens the drawer
+// and redirects back, so these computed values stay false in the main content
+const showPersonas = computed(() => false)
+const showSettings = computed(() => false)
 
 // Pending decision count across all agents in current space
 const pendingDecisionCount = computed(() => {
@@ -259,12 +271,42 @@ async function loadSessionStatus(space: string) {
 
 // ── Selection handlers (via router) ────────────────────────────────
 function handleSelectSpace(name: string) {
-  router.push('/' + name + '/kanban')
+  // Day 0: no agents → show overview with empty state CTAs
+  // Day 2: has agents → default to kanban
+  const spaceSummary = spaces.value.find(s => s.name === name)
+  const hasAgents = (spaceSummary?.agent_count ?? 0) > 0
+  router.push(hasAgents ? '/' + name + '/kanban' : '/' + name)
 }
 
 function handleSelectAgent(name: string) {
   router.push('/' + selectedSpace.value + '/' + name)
 }
+
+// ── Intercept /personas and /settings routes → open drawer overlay ──
+// The routes still exist in the router for back-compat, but instead of
+// rendering a full page, we open the global settings drawer and navigate back.
+watch(
+  () => route.name,
+  (name) => {
+    if (name === 'personas') {
+      personasDrawerOpen.value = true
+      // Navigate back to space (or home) so the space view stays visible behind the drawer
+      if (selectedSpace.value) {
+        router.replace('/' + selectedSpace.value)
+      } else {
+        router.replace('/')
+      }
+    } else if (name === 'settings') {
+      settingsDrawerOpen.value = true
+      if (selectedSpace.value) {
+        router.replace('/' + selectedSpace.value)
+      } else {
+        router.replace('/')
+      }
+    }
+  },
+  { immediate: true },
+)
 
 // ── Watch route params for data loading & SSE ──────────────────────
 watch(
@@ -888,6 +930,8 @@ onUnmounted(() => {
         @delete-space="handleDeleteSpace"
         @create-space="handleCreateSpace"
         @archive-space="handleArchiveSpace"
+        @open-personas="personasDrawerOpen = true"
+        @open-settings="settingsDrawerOpen = true"
       />
       <SidebarInset class="flex flex-col h-dvh">
         <!-- Header -->
@@ -1090,12 +1134,6 @@ onUnmounted(() => {
             @select-agent="handleSelectAgent"
           />
 
-          <!-- Personas management view -->
-          <PersonasView v-else-if="showPersonas" />
-
-          <!-- Settings view -->
-          <SettingsView v-else-if="showSettings" />
-
           <!-- Space overview -->
           <SpaceOverview
             v-else-if="currentSpace"
@@ -1113,6 +1151,7 @@ onUnmounted(() => {
             @delete-space="handleDeleteSpace(selectedSpace)"
             @archive-space="handleArchiveSpace(selectedSpace)"
             @clear-done-agents="handleClearDoneAgents"
+            @open-personas="personasDrawerOpen = true"
           />
 
           <!-- Empty state -->
@@ -1222,5 +1261,29 @@ onUnmounted(() => {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    <!-- Personas global overlay drawer -->
+    <Sheet v-model:open="personasDrawerOpen">
+      <SheetContent side="right" class="w-full sm:max-w-2xl p-0 flex flex-col">
+        <SheetHeader class="px-6 pt-6 pb-0 shrink-0">
+          <SheetTitle>Personas</SheetTitle>
+        </SheetHeader>
+        <div class="flex-1 min-h-0 overflow-hidden">
+          <PersonasView />
+        </div>
+      </SheetContent>
+    </Sheet>
+
+    <!-- Settings global overlay drawer -->
+    <Sheet v-model:open="settingsDrawerOpen">
+      <SheetContent side="right" class="w-full sm:max-w-lg p-0 flex flex-col">
+        <SheetHeader class="px-6 pt-6 pb-0 shrink-0">
+          <SheetTitle>Settings</SheetTitle>
+        </SheetHeader>
+        <div class="flex-1 min-h-0 overflow-y-auto">
+          <SettingsView />
+        </div>
+      </SheetContent>
+    </Sheet>
   </TooltipProvider>
 </template>

--- a/frontend/src/components/AgentCreateDialog.vue
+++ b/frontend/src/components/AgentCreateDialog.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:open': [value: boolean]
   created: [agentName: string]
+  'open-personas': []
 }>()
 
 const agentName = ref('')
@@ -235,12 +236,22 @@ async function submit() {
           </p>
         </div>
 
-        <!-- Persona selector (shown only when personas exist) -->
-        <div v-if="personas.length > 0" class="flex flex-col gap-1.5">
-          <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-            Personas (optional)
-          </label>
-          <div class="flex flex-wrap gap-1.5">
+        <!-- Persona selector — shown when personas exist; quick-link shown when none -->
+        <div class="flex flex-col gap-1.5">
+          <div class="flex items-center justify-between">
+            <label class="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Personas (optional)
+            </label>
+            <button
+              v-if="personas.length === 0"
+              type="button"
+              class="text-xs text-primary hover:underline"
+              @click="emit('open-personas')"
+            >
+              + Create persona
+            </button>
+          </div>
+          <div v-if="personas.length > 0" class="flex flex-wrap gap-1.5">
             <button
               v-for="persona in personas"
               :key="persona.id"
@@ -256,8 +267,9 @@ async function submit() {
             >
               {{ persona.name }}
             </button>
+            <p class="text-xs text-muted-foreground w-full">Prompt fragments injected into the agent on spawn.</p>
           </div>
-          <p class="text-xs text-muted-foreground">Prompt fragments injected into the agent on spawn.</p>
+          <p v-else class="text-xs text-muted-foreground">No personas yet. Create one to inject reusable prompts into agents.</p>
         </div>
 
         <p v-if="errorMsg" class="text-xs text-destructive">{{ errorMsg }}</p>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -67,6 +67,8 @@ const emit = defineEmits<{
   'delete-space': [name: string]
   'create-space': [name: string]
   'archive-space': [name: string]
+  'open-personas': []
+  'open-settings': []
 }>()
 
 const router = useRouter()
@@ -443,26 +445,6 @@ defineExpose({ openNewSpaceDialog })
         </SidebarGroupContent>
       </SidebarGroup>
 
-      <!-- Global nav — always visible -->
-      <SidebarGroup>
-        <SidebarGroupContent>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton @click="router.push('/personas')">
-                <User class="size-4" />
-                <span>Personas</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton @click="router.push('/settings')">
-                <Settings class="size-4" />
-                <span>Settings</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarGroupContent>
-      </SidebarGroup>
-
       <SidebarSeparator v-if="currentSpace" />
 
       <!-- Space nav: Tasks board + Conversations -->
@@ -699,8 +681,8 @@ defineExpose({ openNewSpaceDialog })
       </SidebarGroup>
     </SidebarContent>
 
-    <SidebarFooter v-if="currentSpace" class="p-3">
-      <Tooltip>
+    <SidebarFooter class="p-3 gap-2">
+      <Tooltip v-if="currentSpace">
         <TooltipTrigger as-child>
           <Button
             variant="outline"
@@ -716,6 +698,37 @@ defineExpose({ openNewSpaceDialog })
           Nudge all agents with the latest space state
         </TooltipContent>
       </Tooltip>
+      <!-- Global settings row — always at bottom of sidebar -->
+      <div class="flex items-center justify-end gap-1 pt-1 border-t border-border/50">
+        <Tooltip>
+          <TooltipTrigger as-child>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+              aria-label="Personas"
+              @click="emit('open-personas')"
+            >
+              <User class="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">Personas</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger as-child>
+            <Button
+              variant="ghost"
+              size="sm"
+              class="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+              aria-label="Settings"
+              @click="emit('open-settings')"
+            >
+              <Settings class="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">Settings</TooltipContent>
+        </Tooltip>
+      </div>
     </SidebarFooter>
   </Sidebar>
 

--- a/frontend/src/components/EventLog.vue
+++ b/frontend/src/components/EventLog.vue
@@ -104,6 +104,11 @@ let tickTimer: ReturnType<typeof setInterval> | null = null
 // Track which server-side log messages we've already seen (to avoid duplicates)
 const seenServerMessages = new Set<string>()
 
+// Per-space event cache: keeps events when switching spaces so returning shows history
+const spaceEventCache = new Map<string, { entries: EventLogEntry[]; seen: Set<string> }>()
+// Whether we're showing cached events (true briefly when switching spaces before fresh load)
+const showingCached = ref(false)
+
 // Format a Date as a human-readable relative string ("2s ago", "5m ago", etc.)
 function formatRelative(date: Date, _tick: number): string {
   const diffMs = Date.now() - date.getTime()
@@ -259,6 +264,7 @@ async function loadEvents() {
         for (const r of raw) {
           seenServerMessages.add(r)
         }
+        showingCached.value = false
         if (isOpen.value) {
           nextTick(scrollToBottom)
         }
@@ -273,6 +279,8 @@ async function loadEvents() {
             added = true
           }
         }
+        // Fresh data loaded — clear the cached banner
+        showingCached.value = false
         if (added) {
           if (!isOpen.value) {
             unreadCount.value++
@@ -448,14 +456,34 @@ function startResize(e: MouseEvent | TouchEvent) {
   document.addEventListener('touchend', onEnd)
 }
 
-// Reload events when space changes
-watch(() => props.spaceName, () => {
-  entries.value = []
+// Reload events when space changes — save current to cache, restore from cache if available
+watch(() => props.spaceName, (newSpace, oldSpace) => {
+  // Save current space events to cache before switching
+  if (oldSpace && entries.value.length > 0) {
+    spaceEventCache.set(oldSpace, {
+      entries: [...entries.value],
+      seen: new Set(seenServerMessages),
+    })
+  }
+
+  // Reset per-space state
   seenServerMessages.clear()
-  nextId = 0
   activeTypes.value = new Set()
   searchQuery.value = ''
   unreadCount.value = 0
+
+  // Restore from cache if available (avoids blank log on space switch)
+  const cached = newSpace ? spaceEventCache.get(newSpace) : undefined
+  if (cached && cached.entries.length > 0) {
+    entries.value = cached.entries
+    for (const msg of cached.seen) seenServerMessages.add(msg)
+    showingCached.value = true
+    if (isOpen.value) nextTick(scrollToBottom)
+  } else {
+    entries.value = []
+    showingCached.value = false
+  }
+
   loadEvents()
 })
 
@@ -563,6 +591,14 @@ defineExpose({ pushSSEEvent, clearLog })
           <path d="m18 15-6-6-6 6" />
         </svg>
       </div>
+    </div>
+
+    <!-- Cached events banner — shown briefly when space just switched -->
+    <div
+      v-if="isOpen && showingCached"
+      class="px-4 py-1 text-[10px] text-amber-600 dark:text-amber-400 bg-amber-500/10 border-b border-amber-500/20 shrink-0"
+    >
+      Showing cached events — reconnecting…
     </div>
 
     <!-- Search + filter toolbar (shown when open and there are events) -->

--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -79,6 +79,7 @@ const emit = defineEmits<{
   'delete-space': []
   'archive-space': []
   'clear-done-agents': [names: string[]]
+  'open-personas': []
 }>()
 
 // Persona version tracking for outdated badge
@@ -1240,6 +1241,7 @@ const activeSections = computed(() => [
         v-model:open="agentCreateDialogOpen"
         :space="space.name"
         @created="() => {}"
+        @open-personas="emit('open-personas')"
       />
     </div>
   </ScrollArea>


### PR DESCRIPTION
## Summary

Implements all 6 design changes from TASK-005:

1. **Settings/Personas as bottom-of-sidebar drawer** — removed from mid-sidebar, moved to compact icon buttons in SidebarFooter. Clicking opens a slide-over Sheet drawer (not a page route), keeping space context visible behind the overlay.

2. **Day 0 vs Day 2 default view** — selecting a space with agents defaults to Kanban; selecting an empty space defaults to Overview with empty state CTAs.

3. **Persona quick-link in AgentCreateDialog** — when no personas exist, a "+ Create persona" link is shown inline in the dialog. Clicking opens the Personas drawer without requiring navigation away.

4. **Per-space event caching in EventLog** — previous space events are cached in a `Map<spaceName, entries>`. On space switch, cached events are shown immediately with a subtle "Showing cached events — reconnecting…" banner until fresh SSE events arrive.

5. **Sidebar structure cleanup** — removed the "Global nav" group (Personas/Settings buttons) from the middle of the sidebar. They now live as compact icon buttons at the bottom footer, always visible.

6. **Route cleanup** — `/personas` and `/settings` routes now intercept via a `watch(route.name)` and open the Sheet drawer instead of rendering inline views. The space context stays visible behind the overlay.

## Test plan
- [ ] Click Personas (User icon) in sidebar footer → drawer slides in over current space
- [ ] Click Settings (gear icon) in sidebar footer → drawer slides in over current space
- [ ] Navigate to `/personas` URL directly → drawer opens, URL redirects back to space
- [ ] Select a space with agents → lands on Kanban
- [ ] Select a space with no agents → lands on Overview with empty state
- [ ] Open Add Agent dialog with no personas → see "+ Create persona" link
- [ ] Switch spaces in EventLog → brief "cached events" banner, then fresh events replace
- [ ] `npm run build` completes with no TypeScript errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)