### PR TITLE
feat(lint): TASK-013 — mechanical architecture linters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,3 +112,24 @@ Data survives restarts — SQLite DB (`DATA_DIR/boss.db`) is loaded on startup.
 ## Doc Gardening
 
 The `garden` agent keeps the knowledge base current after every sprint. See **[docs/exec-plans/doc-gardening-agent.md](docs/exec-plans/doc-gardening-agent.md)** for the standing instructions — what to check, how to update grades, and how to open the PR.
+## Linting
+
+Run the architectural boundary and taste-invariant linters with:
+
+```bash
+go test ./internal/domain/... ./internal/coordinator/...
+```
+
+These tests fail if any of the following rules are violated:
+
+### Boundary enforcement (`internal/domain/architecture_test.go`)
+- `internal/domain/` must import **only** the Go standard library — no external packages, no coordinator, no adapters.
+- `internal/adapters/` packages (once created) must not import sibling adapter packages.
+- The domain boundary test logs the `internal/coordinator` import baseline for migration tracking.
+
+### Taste invariants (`internal/coordinator/lint_test.go`)
+1. **No `fmt.Print*` in server code** — use the structured logger (`log.Info`, `log.Error`, etc.). `fmt.Sprintf` for string formatting is fine; `fmt.Printf` / `fmt.Println` / `fmt.Fprintf(os.Stderr, ...)` are not.
+2. **File size limit** — no new `.go` file in `internal/coordinator/` may exceed 600 lines. Files that already exceed this limit are grandfathered (see `grandfatheredLargeFiles` in `lint_test.go`) — do not add new files to the grandfather list without a cleanup task.
+3. **Handler naming** — HTTP handler methods on `*Server` must follow `handle{Noun}{Verb}` (e.g. `handleAgentCreate`, `handleTaskGet`). Known legacy violations are grandfathered in `grandfatheredHandlers`. New handlers must conform.
+
+When a linter test fails, the error message includes the rule and an exact remediation instruction.

--- a/internal/coordinator/lint_test.go
+++ b/internal/coordinator/lint_test.go
@@ -1,0 +1,323 @@
+// Package coordinator_test contains taste-invariant linters that enforce
+// code quality conventions for the coordinator package. These tests run as
+// part of `go test ./internal/coordinator/...` and fail loud with remediation
+// instructions so that agents know exactly what to fix.
+//
+// Three invariants are checked:
+//  1. No fmt.Print* in server code — use the structured logger instead.
+//  2. No new .go files in coordinator exceeding 600 lines.
+//  3. HTTP handler functions follow the handle{Noun}{Verb} naming convention.
+package coordinator_test
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// coordinatorDir returns the absolute path to internal/coordinator/.
+func coordinatorDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(thisFile)
+}
+
+// goFiles returns all non-test .go files in dir (non-recursive).
+func goFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") {
+			files = append(files, filepath.Join(dir, name))
+		}
+	}
+	return files
+}
+
+// linesOf counts lines in a file.
+func linesOf(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	count := 0
+	for sc.Scan() {
+		count++
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return count
+}
+
+// TestNoFmtPrintInServerCode verifies that no production coordinator code uses
+// fmt.Print*, fmt.Println*, or fmt.Fprintf to stderr/stdout. All logging must go
+// through the structured logger (log.Info, log.Error, log.Warn, etc.).
+//
+// TO FIX: Replace fmt.Printf("...") with log.Info("...") or log.Error("...").
+// Import "log/slog" and use slog.Default() if the local logger is not available.
+func TestNoFmtPrintInServerCode(t *testing.T) {
+	dir := coordinatorDir(t)
+	files := goFiles(t, dir)
+
+	// Matches fmt.Print*, fmt.Println*, fmt.Printf* — functions that write to stdout.
+	// Does NOT match fmt.Sprintf/Sprint (string formatting) or fmt.Fprintf/Fprint
+	// (writer-based, used legitimately for HTTP responses).
+	// Also catches fmt.Fprintf(os.Stderr/os.Stdout) — explicit stderr/stdout writes.
+	fmtPrintRe := regexp.MustCompile(`\bfmt\.(Print|Println|Printf)\(|\bfmt\.Fprintf\(os\.(Stderr|Stdout)\b`)
+
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			t.Fatalf("open %s: %v", file, err)
+		}
+		sc := bufio.NewScanner(f)
+		lineNum := 0
+		for sc.Scan() {
+			lineNum++
+			line := sc.Text()
+			trimmed := strings.TrimSpace(line)
+			// Skip comment lines
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+			if fmtPrintRe.MatchString(line) {
+				t.Errorf(
+					"LINT FAIL [fmt.Print*]: %s:%d\n"+
+						"  Found: %s\n"+
+						"  Rule: coordinator code must use the structured logger, not fmt.Print*.\n"+
+						"  Fix: Replace with log.Info(\"message\", \"key\", value) or log.Error(\"message\", \"err\", err).\n"+
+						"  Import: \"log/slog\" and use slog.Default() if no local logger is available.",
+					filepath.Base(file), lineNum, strings.TrimSpace(line),
+				)
+			}
+		}
+		f.Close()
+		if err := sc.Err(); err != nil {
+			t.Fatalf("scan %s: %v", file, err)
+		}
+	}
+}
+
+// TestFileSizeLimit verifies that no new .go file in internal/coordinator/
+// exceeds 600 lines. Files grandfathered below are known tech debt.
+//
+// TO FIX: Split the file into focused sub-files. Suggested approach:
+//   - Extract handler functions into handlers_<noun>.go files
+//   - Extract pure helper/util logic into helpers_<topic>.go files
+//   - Each file should own one coherent responsibility
+//
+// When adding a file to the grandfather list, include a comment with:
+//   - The line count at the time of grandfathering
+//   - A TASK reference for the cleanup work
+const fileSizeLimit = 600
+
+// grandfatheredLargeFiles lists files that exceeded 600 lines when this linter
+// was introduced (2026-03). Each entry documents the count at grandfathering time
+// and a reference to the cleanup task. New files must not be added here without
+// a corresponding task in the backlog.
+//
+// To grandfather a file: add it to this map with its current line count and task reference.
+// Do NOT add files here as a shortcut — create a cleanup task first.
+var grandfatheredLargeFiles = map[string]string{
+	// 1680 lines at grandfathering — TASK-013 tech debt, awaiting handler extraction
+	"handlers_agent.go": "1680 lines — handler extraction planned (see TASK-013)",
+	// 1104 lines at grandfathering — TASK-013 tech debt, MCP tools need own package
+	"mcp_tools.go": "1104 lines — MCP tool extraction planned (see TASK-013)",
+	// 887 lines at grandfathering — TASK-013 tech debt, task handler extraction
+	"handlers_task.go": "887 lines — task handler extraction planned (see TASK-013)",
+	// 879 lines at grandfathering — TASK-013 tech debt, lifecycle management
+	"lifecycle.go": "879 lines — lifecycle extraction planned (see TASK-013)",
+	// 802 lines at grandfathering — TASK-013 tech debt, types consolidation
+	"types.go": "802 lines — types consolidation planned (see TASK-013)",
+	// 723 lines at grandfathering — TASK-013 tech debt, tmux backend
+	"tmux.go": "723 lines — tmux backend extraction planned (see TASK-013)",
+}
+
+func TestFileSizeLimit(t *testing.T) {
+	dir := coordinatorDir(t)
+	files := goFiles(t, dir)
+
+	for _, file := range files {
+		base := filepath.Base(file)
+		lines := linesOf(t, file)
+
+		if lines <= fileSizeLimit {
+			continue
+		}
+
+		if note, ok := grandfatheredLargeFiles[base]; ok {
+			t.Logf("LINT WARN [file-size]: %s has %d lines (grandfathered: %s)", base, lines, note)
+			continue
+		}
+
+		t.Errorf(
+			"LINT FAIL [file-size]: %s has %d lines (limit: %d)\n"+
+				"  Rule: No new .go file in internal/coordinator/ may exceed %d lines.\n"+
+				"  Fix: Split into focused files (e.g. handlers_<noun>.go, helpers_<topic>.go).\n"+
+				"  If this is unavoidable tech debt, add it to grandfatheredLargeFiles in lint_test.go\n"+
+				"  with a comment referencing the cleanup task.",
+			base, lines, fileSizeLimit, fileSizeLimit,
+		)
+	}
+}
+
+// TestHandlerNaming verifies that HTTP handler methods on *Server follow the
+// handle{Noun}{Verb} naming convention (e.g. handleAgentGet, handleTaskCreate).
+//
+// Rationale: Consistent naming makes handlers grep-able and self-documenting.
+// The noun says what resource is being operated on; the verb says what operation.
+//
+// TO FIX: Rename the handler to follow handle{Noun}{Verb}:
+//   - handleListSpaces   → handleSpaceList
+//   - handleDeleteSpace  → handleSpaceDelete
+//   - handleApproveAgent → handleAgentApprove
+//   - handleCreateAgents → handleAgentCreate
+//   - handleReplyAgent   → handleAgentReply
+//   - handleDismissQuestion → handleQuestionDismiss
+//
+// Grandfathered handlers below are known naming debt. New handlers added after
+// this linter was introduced (2026-03) MUST follow the convention.
+var grandfatheredHandlers = map[string]string{
+	// Route dispatchers and top-level handlers — no clear noun/verb split
+	"handleRoot":       "top-level SPA fallback — no noun/verb applicable",
+	"handleSSE":        "SSE is a protocol acronym, not a noun/verb pair",
+	"handleSpaceRoute": "route dispatcher — dispatches to sub-handlers",
+	"handleSettings":   "settings has no sub-resources yet — rename to handleSettingsGet when expanded",
+
+	// Verb-first handlers (should be handle{Noun}{Verb}) — TASK-013 naming debt
+	"handleListSpaces":   "should be handleSpaceList — verb-first naming debt (TASK-013)",
+	"handleDeleteSpace":  "should be handleSpaceDelete — verb-first naming debt (TASK-013)",
+	"handleApproveAgent": "should be handleAgentApprove — verb-first naming debt (TASK-013)",
+	"handleReplyAgent":   "should be handleAgentReply — verb-first naming debt (TASK-013)",
+	"handleDismissQuestion":  "should be handleQuestionDismiss — verb-first naming debt (TASK-013)",
+	"handleCreateAgents": "should be handleAgentCreate — verb-first naming debt (TASK-013)",
+
+	// Compound/special-purpose handlers — no simple noun/verb decomposition
+	"handleSpaceAgent":          "route dispatcher for /spaces/:space/agents/:agent — compound route",
+	"handleSpaceJSON":           "should be handleSpaceGet (JSON format) — naming debt (TASK-013)",
+	"handleSpaceHierarchy":      "should be handleSpaceHierarchyGet — naming debt (TASK-013)",
+	"handleSpaceTextField":      "internal sub-handler for text fields — not a top-level HTTP route",
+	"handleSpaceRaw":            "should be handleSpaceRawGet — naming debt (TASK-013)",
+	"handleSpaceContracts":      "should be handleSpaceContractList — naming debt (TASK-013)",
+	"handleSpaceContractsDefault": "should be handleSpaceContractDefault — naming debt (TASK-013)",
+	"handleSpaceAgentsJSON":     "should be handleAgentList — naming debt (TASK-013)",
+	"handleSpaceEventsJSON":     "should be handleEventList — naming debt (TASK-013)",
+	"handleSpaceSessionStatus":  "should be handleSessionStatusGet — naming debt (TASK-013)",
+	"handleSpaceSSE":            "SSE is a protocol acronym — should be handleSpaceStream (TASK-013)",
+	"handleSingleBroadcast":     "should be handleAgentBroadcast — naming debt (TASK-013)",
+	"handleBroadcast":           "should be handleSpaceBroadcast — naming debt (TASK-013)",
+	"handleIgnition":            "should be handleAgentIgnite — naming debt (TASK-013)",
+
+	// Persona handlers — prefix is correct but suffix doesn't follow verb pattern
+	"handlePersonaDetail":           "should be handlePersonaGet — naming debt (TASK-013)",
+	"handlePersonaHistory":          "should be handlePersonaHistoryList — naming debt (TASK-013)",
+	"handlePersonaAgents":           "should be handlePersonaAgentList — naming debt (TASK-013)",
+	"handlePersonaRestartOutdated":  "compound — acceptable for specificity, consider handlePersonaOutdatedRestart",
+
+	// Interrupt handlers — no noun/verb decomposition
+	"handleInterrupts":       "should be handleInterruptList — naming debt (TASK-013)",
+	"handleInterruptMetrics": "should be handleInterruptMetricGet — naming debt (TASK-013)",
+
+	// Task sub-handlers and route dispatchers
+	"handleTaskCreateSubtask": "compound verb — acceptable for specificity; consider handleSubtaskCreate",
+	"handleSpaceTasks":        "should be handleTaskList — verb/noun naming debt (TASK-013)",
+
+	// History handlers — History is a noun, not a verb
+	"handleSpaceHistory": "should be handleSpaceHistoryList — noun suffix not a verb (TASK-013)",
+	"handleAgentHistory": "should be handleAgentHistoryList — noun suffix not a verb (TASK-013)",
+
+	// Lifecycle handlers with non-verb suffixes
+	"handleRestartAll":   "should be handleAgentRestartAll or handleSpaceRestart — verb-first, missing noun (TASK-013)",
+	"handleAgentHeartbeat": "Heartbeat is a noun; should be handleAgentPing or handleAgentHeartbeatPost (TASK-013)",
+	"handleAgentMessages":  "Messages is a plural noun; should be handleAgentMessageList (TASK-013)",
+	"handleAgentSSE":       "SSE is an acronym; should be handleAgentStream (TASK-013)",
+
+	// handlers_agent.go — agent config (Config used as noun not verb)
+	"handleAgentConfig": "Config is ambiguous noun/verb — acceptable; consider handleAgentConfigure (TASK-013)",
+}
+
+// handlerFuncRe matches handler method declarations on *Server.
+var handlerFuncRe = regexp.MustCompile(`^func \(s \*Server\) (handle[A-Z][a-zA-Z]+)\(`)
+
+// handlerNounVerbRe matches the approved handle{Noun}{Verb} pattern.
+// Noun: one or more title-case words (e.g. Task, SpaceAgent)
+// Verb: a known action verb at the end of the name
+var handlerNounVerbRe = regexp.MustCompile(
+	`^handle[A-Z][a-zA-Z]+(Create|List|Get|Update|Delete|Move|Assign|Comment|Ack|Approve|` +
+		`Reply|Dismiss|Duplicate|Archive|View|Revert|Restart|Send|Post|Put|Patch|` +
+		`Config|Stream|Ignite|Broadcast|Export|Import|Publish|Subscribe|` +
+		`Lock|Unlock|Enable|Disable|Reset|Flush|Sync|Poll|Ping|` +
+		`Spawn|Stop|Interrupt|Introspect|Register|Message|Document|` +
+		`Activate|Deactivate|Start|Cancel|Retry|Attach|Detach|Check|Submit|Execute)$`,
+)
+
+func TestHandlerNaming(t *testing.T) {
+	dir := coordinatorDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		filePath := filepath.Join(dir, e.Name())
+		f, err := os.Open(filePath)
+		if err != nil {
+			t.Fatalf("open %s: %v", filePath, err)
+		}
+
+		sc := bufio.NewScanner(f)
+		lineNum := 0
+		for sc.Scan() {
+			lineNum++
+			line := sc.Text()
+			m := handlerFuncRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			name := m[1]
+
+			if note, ok := grandfatheredHandlers[name]; ok {
+				t.Logf("LINT WARN [handler-naming]: %s:%d — %s (grandfathered: %s)",
+					e.Name(), lineNum, name, note)
+				continue
+			}
+
+			if !handlerNounVerbRe.MatchString(name) {
+				t.Errorf(
+					"LINT FAIL [handler-naming]: %s:%d — %s\n"+
+						"  Rule: HTTP handlers must follow handle{Noun}{Verb} (e.g. handleAgentCreate, handleTaskGet).\n"+
+						"  Fix: Rename to handle{Resource}{Action}, where Resource is the noun (Agent, Task, Space)\n"+
+						"       and Action is a CRUD verb (Create, List, Get, Update, Delete, Move, Ack, etc.).\n"+
+						"  Note: If this is unavoidable, add to grandfatheredHandlers in lint_test.go with a reason.",
+					e.Name(), lineNum, name,
+				)
+			}
+		}
+		f.Close()
+		if err := sc.Err(); err != nil {
+			t.Fatalf("scan %s: %v", filePath, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the \"enforce invariants mechanically\" principle for agent-boss with two categories of automated linters, runnable as standard Go tests.

## Changes

### Part A: Boundary enforcement (`internal/domain/architecture_test.go`)
From the `feat/hexagonal-architecture` base — three tests:
- `TestDomainImportsOnlyStdlib`: domain layer must only import stdlib (zero external deps)
- `TestCoordinatorImportBaseline`: documents coordinator's current import profile for migration tracking
- `TestAdapterIsolationBaseline`: validates adapter-to-adapter isolation (activates in Phase 2)

### Part B: Taste invariants (`internal/coordinator/lint_test.go`) — **new file**
Three mechanical checks:
1. **`TestNoFmtPrintInServerCode`** — no `fmt.Print*` / `fmt.Println*` / `fmt.Printf()` in production coordinator code; all output via structured logger
2. **`TestFileSizeLimit`** — no new `.go` file may exceed 600 lines; 6 oversized legacy files grandfathered with TASK references and rename suggestions
3. **`TestHandlerNaming`** — `*Server` HTTP handlers must follow `handle{Noun}{Verb}` (e.g. `handleAgentCreate`, `handleTaskGet`); known legacy violations grandfathered with rename suggestions

Each failure emits: the rule, the offending line, and exact remediation steps so that agents get actionable context.

### Part C: `CLAUDE.md` "## Linting" section
Documents `go test ./internal/domain/... ./internal/coordinator/...` as the linting command and explains all three invariants.

## Test plan

- [x] `go test -race ./internal/domain/... ./internal/coordinator/...` passes (42s with race detector)
- [x] All three taste-invariant tests pass on current codebase
- [x] Known violations are grandfathered (logged as WARN, not FAIL)
- [x] New violations will FAIL with clear remediation messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)