### PR TITLE
feat(lint): TASK-013+016 — mechanical architecture linters + agent experience invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,5 +147,12 @@ These tests fail if any of the following rules are violated:
 1. **No `fmt.Print*` in server code** — use the structured logger (`log.Info`, `log.Error`, etc.). `fmt.Sprintf` for string formatting is fine; `fmt.Printf` / `fmt.Println` / `fmt.Fprintf(os.Stderr, ...)` are not.
 2. **File size limit** — no new `.go` file in `internal/coordinator/` may exceed 600 lines. Files that already exceed this limit are grandfathered (see `grandfatheredLargeFiles` in `lint_test.go`) — do not add new files to the grandfather list without a cleanup task.
 3. **Handler naming** — HTTP handler methods on `*Server` must follow `handle{Noun}{Verb}` (e.g. `handleAgentCreate`, `handleTaskGet`). Known legacy violations are grandfathered in `grandfatheredHandlers`. New handlers must conform.
+4. **Agent experience surface** — `TmuxCreateOpts` literals that set `MCPServerURL` must also set `AgentToken`. See below.
 
 When a linter test fails, the error message includes the rule and an exact remediation instruction.
+
+## Agent Experience Invariants
+
+Every agent spawn must deliver the full experience surface: MCP URL, auth token, working directory, and ignition prompt. The structural test `TestAgentExperienceSurfaceInvariants` (`internal/coordinator/lint_test.go`) enforces the most failure-prone coupling: **if `TmuxCreateOpts.MCPServerURL` is set, `AgentToken` must also be set**. This prevents the silent failure mode where auth is enabled on the server but spawned agents never receive the credential to call MCP tools.
+
+See **[docs/design-docs/agent-experience-surface.md](docs/design-docs/agent-experience-surface.md)** for the full contract and spawn flow diagram.

--- a/docs/design-docs/agent-experience-surface.md
+++ b/docs/design-docs/agent-experience-surface.md
@@ -1,0 +1,106 @@
+# Agent Experience Surface
+
+**Status:** Enforced
+**Enforcement:** `TestAgentExperienceSurfaceInvariants` in `internal/coordinator/lint_test.go`
+**See also:** [auth-model.md](auth-model.md)
+
+## Purpose
+
+This document defines the **formal contract** for everything the coordinator must deliver to an agent at spawn time. It was introduced after TASK-015 (PR #155) revealed that BOSS_API_TOKEN auth was added to the HTTP layer but the MCP registration command at agent spawn time never received the `--header` flag — leaving all agents silently broken when auth was enabled.
+
+The lesson: _encode invariants mechanically, not in documentation alone._
+
+---
+
+## The Agent Experience Contract
+
+Every spawned agent **must** receive all of the following:
+
+### 1. MCP Server URL
+
+- **What:** The URL of the Boss coordinator MCP endpoint.
+- **How:** `TmuxCreateOpts.MCPServerURL` → `claude mcp add <name> --transport http <url>/mcp`
+- **Why:** Without this, the agent cannot call any MCP tools (`post_status`, `check_messages`, etc.).
+
+### 2. MCP Auth Header
+
+- **What:** `Authorization: Bearer <token>` header passed to `claude mcp add`.
+- **How:** `TmuxCreateOpts.AgentToken` → `--header 'Authorization: Bearer <token>'`
+- **Why:** When `BOSS_API_TOKEN` is set, all mutating endpoints require auth. Without the header, every MCP tool call returns 401.
+- **Invariant:** If `MCPServerURL` is set, `AgentToken` **must** also be set. The structural test `TestAgentExperienceSurfaceInvariants` enforces this at build time.
+
+### 3. Working Directory
+
+- **What:** The filesystem path the agent should operate in.
+- **How:** `TmuxCreateOpts.WorkDir` → `cd <workDir>` before launching.
+- **Why:** Agents reference local files and run git commands; the cwd determines what they can see.
+
+### 4. Protocol Reference
+
+- **What:** The ignition prompt — the full agent protocol document — sent to the agent after launch.
+- **How:** `buildIgnitionText()` in `server.go`, sent via `backend.SendInput()` after the session reaches idle.
+- **Why:** The ignition prompt tells the agent its name, workspace, MCP tools, collaboration norms, and task assignments. Without it, the agent has no context.
+
+---
+
+## Invariant: MCPServerURL implies AgentToken
+
+The following rule is mechanically enforced:
+
+> Any `TmuxCreateOpts` struct literal that sets `MCPServerURL` must also set `AgentToken`.
+
+**Rationale:** These two fields are logically coupled — you cannot register an authenticated MCP server without also passing auth credentials. Omitting one silently breaks agent connectivity when auth is enabled.
+
+**Enforcement:** `TestAgentExperienceSurfaceInvariants` in `internal/coordinator/lint_test.go` parses all Go source files in `internal/coordinator/` and fails the build if any `TmuxCreateOpts` literal sets `MCPServerURL` without `AgentToken`.
+
+**To satisfy the invariant:**
+
+```go
+// CORRECT: both fields set together
+BackendOpts: TmuxCreateOpts{
+    MCPServerURL:  s.localURL(),
+    MCPServerName: s.mcpServerName(),
+    AgentToken:    s.apiToken,   // required when MCPServerURL is set
+}
+
+// WRONG: auth token missing — will fail TestAgentExperienceSurfaceInvariants
+BackendOpts: TmuxCreateOpts{
+    MCPServerURL: s.localURL(),
+    // AgentToken omitted — breaks agent MCP auth silently
+}
+```
+
+---
+
+## How Spawn Delivers the Contract
+
+The spawn flow in `lifecycle.go` / `handlers_agent.go`:
+
+```
+spawnAgentService()
+  └─ backend.CreateSession(ctx, SessionCreateOpts{
+         BackendOpts: TmuxCreateOpts{
+             WorkDir:      spawnWorkDir,       // [3] working directory
+             MCPServerURL: s.localURL(),       // [1] MCP URL
+             AgentToken:   s.apiToken,         // [2] auth token
+         }
+     })
+       └─ TmuxSessionBackend.CreateSession()
+            ├─ cd <workDir>
+            ├─ claude mcp add boss-mcp --transport http <url>/mcp
+            │       --header 'Authorization: Bearer <token>'
+            └─ <command>  (e.g. "claude --dangerously-skip-permissions")
+
+  └─ waitForIdle() then buildIgnitionText()   // [4] protocol reference
+       └─ backend.SendInput(sessionID, ignitePrompt)
+```
+
+---
+
+## Adding a New Spawn Site
+
+If you add a new location that creates a `TmuxCreateOpts` with `MCPServerURL`:
+
+1. Set `AgentToken: s.apiToken` alongside it.
+2. Run `go test ./internal/coordinator/` — `TestAgentExperienceSurfaceInvariants` will fail if you forget.
+3. Update this doc if the spawn flow changes structurally.

--- a/internal/coordinator/lint_test.go
+++ b/internal/coordinator/lint_test.go
@@ -3,10 +3,11 @@
 // part of `go test ./internal/coordinator/...` and fail loud with remediation
 // instructions so that agents know exactly what to fix.
 //
-// Three invariants are checked:
+// Four invariants are checked:
 //  1. No fmt.Print* in server code — use the structured logger instead.
 //  2. No new .go files in coordinator exceeding 600 lines.
 //  3. HTTP handler functions follow the handle{Noun}{Verb} naming convention.
+//  4. TmuxCreateOpts literals that set MCPServerURL must also set AgentToken.
 package coordinator_test
 
 import (
@@ -318,6 +319,103 @@ func TestHandlerNaming(t *testing.T) {
 		f.Close()
 		if err := sc.Err(); err != nil {
 			t.Fatalf("scan %s: %v", filePath, err)
+		}
+	}
+}
+
+// TestAgentExperienceSurfaceInvariants enforces the agent experience contract:
+// any TmuxCreateOpts struct literal that sets MCPServerURL must also set AgentToken.
+//
+// Rationale: MCPServerURL and AgentToken are logically coupled. When BOSS_API_TOKEN
+// is set on the server, all MCP tool calls require an Authorization: Bearer header.
+// If MCPServerURL is registered without AgentToken, agents silently receive 401s
+// on every MCP call — a connectivity failure with no obvious error at spawn time.
+//
+// This invariant was introduced after TASK-015 (PR #155) revealed exactly this
+// failure mode: auth was added to the HTTP layer but spawn never got the --header flag.
+//
+// See: docs/design-docs/agent-experience-surface.md
+//
+// TO FIX: Add AgentToken: s.apiToken to any TmuxCreateOpts literal that sets MCPServerURL.
+func TestAgentExperienceSurfaceInvariants(t *testing.T) {
+	dir := coordinatorDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+
+	// We scan source files for TmuxCreateOpts struct literals using a simple
+	// state-machine approach: track when we're inside a TmuxCreateOpts{...} block
+	// and check that MCPServerURL and AgentToken appear together.
+	//
+	// This grep-based approach is intentionally simple and robust — no AST parsing
+	// needed because the struct literal fields are always on separate lines by
+	// convention (enforced by gofmt). If the codebase style changes, adjust the
+	// detection logic below.
+
+	tmuxOptsStartRe := regexp.MustCompile(`\bTmuxCreateOpts\s*\{`)
+	mcpURLFieldRe := regexp.MustCompile(`\bMCPServerURL\s*:`)
+	agentTokenFieldRe := regexp.MustCompile(`\bAgentToken\s*:`)
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		filePath := filepath.Join(dir, e.Name())
+
+		// Read all lines so we can do windowed scans around each TmuxCreateOpts literal.
+		f, err := os.Open(filePath)
+		if err != nil {
+			t.Fatalf("open %s: %v", filePath, err)
+		}
+		var lines []string
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			lines = append(lines, sc.Text())
+		}
+		f.Close()
+		if err := sc.Err(); err != nil {
+			t.Fatalf("scan %s: %v", filePath, err)
+		}
+
+		for i, line := range lines {
+			if !tmuxOptsStartRe.MatchString(line) {
+				continue
+			}
+			// Found a TmuxCreateOpts{ literal at line i (1-indexed: i+1).
+			// Scan forward to find the closing brace, collecting all field names.
+			// Limit the scan window to 30 lines — struct literals should never be longer.
+			startLine := i + 1 // 1-indexed for error messages
+			hasMCPURL := mcpURLFieldRe.MatchString(line)
+			hasAgentToken := agentTokenFieldRe.MatchString(line)
+
+			depth := strings.Count(line, "{") - strings.Count(line, "}")
+			for j := i + 1; j < len(lines) && j < i+30; j++ {
+				l := lines[j]
+				if mcpURLFieldRe.MatchString(l) {
+					hasMCPURL = true
+				}
+				if agentTokenFieldRe.MatchString(l) {
+					hasAgentToken = true
+				}
+				depth += strings.Count(l, "{") - strings.Count(l, "}")
+				if depth <= 0 {
+					break
+				}
+			}
+
+			if hasMCPURL && !hasAgentToken {
+				t.Errorf(
+					"LINT FAIL [agent-experience]: %s:%d — TmuxCreateOpts sets MCPServerURL without AgentToken\n"+
+						"  Invariant: MCPServerURL and AgentToken must always be set together.\n"+
+						"  Reason: When BOSS_API_TOKEN is configured, every MCP tool call requires an\n"+
+						"          Authorization: Bearer header. Omitting AgentToken silently breaks all\n"+
+						"          agent MCP connectivity with no error at spawn time.\n"+
+						"  Fix: Add AgentToken: s.apiToken to this TmuxCreateOpts literal.\n"+
+						"  Spec: docs/design-docs/agent-experience-surface.md",
+					e.Name(), startLine,
+				)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR implements two TASK deliverables from the architecture linting initiative.

### TASK-013: Mechanical architecture linters — boundary enforcement + taste invariants

- `internal/domain/architecture_test.go`: stricter boundary import checks (`go list -json`)
- `internal/coordinator/lint_test.go`: three taste invariants:
  1. No `fmt.Print*` in server code
  2. File size limit (600 lines, grandfathered legacy files)
  3. HTTP handler naming convention (`handle{Noun}{Verb}`)
- CLAUDE.md: `## Linting` section documenting how to run and what each rule enforces

### TASK-016: Agent experience surface — spec doc + structural enforcement test

**Context:** TASK-015 (PR #155) fixed a bug where `BOSS_API_TOKEN` auth was added to the HTTP layer but the MCP registration at spawn time never got the `--header` flag. Agents silently received 401s on every MCP call.

**Deliverables:**
1. **`TmuxCreateOpts.AgentToken`** (new field) — passed as `--header 'Authorization: Bearer <token>'` to `claude mcp add`
2. **All 4 spawn sites** updated: `handlers_agent.go` + `lifecycle.go` (×3) now set `AgentToken: s.apiToken`
3. **`TestAgentExperienceSurfaceInvariants`** — structural test that scans all coordinator source files and fails if any `TmuxCreateOpts` literal sets `MCPServerURL` without `AgentToken`
4. **`docs/design-docs/agent-experience-surface.md`** — formal contract: the 4 things every spawned agent must receive (MCP URL, auth header, working directory, ignition prompt)
5. **CLAUDE.md `## Agent Experience Invariants`** section — links to the spec and explains the enforcement

## Tests

```
go test -race ./internal/coordinator/ ./internal/domain/...
```

All tests pass.