### PR TITLE
fix(tmux): TASK-024 — detect claude code exit in tmuxIsIdle

### DIFF
--- a/internal/coordinator/tmux.go
+++ b/internal/coordinator/tmux.go
@@ -244,6 +244,16 @@ func tmuxIsIdle(session string) bool {
 		return false
 	}
 
+	// Detect claude code exit: if the pane contains "Resume this session with:",
+	// claude has exited to the shell. The session is NOT in a usable idle state —
+	// returning false prevents check-in text from being sent to bash (where it
+	// would produce syntax errors). The restart loop will relaunch claude shortly.
+	for _, line := range lines {
+		if strings.Contains(line, "Resume this session with:") {
+			return false
+		}
+	}
+
 	// Check each of the last N non-empty lines for idle indicators.
 	for _, line := range lines {
 		if lineIsIdleIndicator(line) {


### PR DESCRIPTION
## Summary

When claude code exits unexpectedly, the tmux session drops to a bash shell. Previously `isShellPrompt()` returned `true` for the bash `$` prompt, so `tmuxIsIdle()` = `true` and check-in text was delivered to bash → syntax errors (`"Check: command not found"`).

**Fix:** Scan pane lines for `"Resume this session with:"` before checking idle indicators. If found, claude has exited — return `false` (not idle) to prevent check-ins from reaching bash. The restart loop (TASK-022, PR #156) will relaunch claude automatically.

This is a **detection/containment fix**. The root cause of why claude exits in the first place is still under investigation (TASK-024).

## Test plan
- [ ] `go test -race ./internal/coordinator/` passes
- [ ] Spawn agent, simulate claude exit in tmux, verify no check-in is sent to bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)