### PR TITLE
perf(ci): cache Playwright browser binaries between CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,20 @@ jobs:
         run: npm ci
         working-directory: e2e
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install chromium --with-deps
+          fi
         working-directory: e2e
 
       - name: Build frontend


### PR DESCRIPTION
## Summary

Adds `actions/cache@v4` for `~/.cache/ms-playwright` in the e2e CI job to avoid re-downloading ~100 MB of browser binaries and Ubuntu fonts on every run.

- Cache key: `playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json') }}` — invalidates only when e2e deps change
- **Cache hit**: runs `npx playwright install-deps chromium` (system libs only, no download)
- **Cache miss**: runs `npx playwright install chromium --with-deps` as before

Closes TASK-027.

## Test plan

- [ ] CI passes on first run (cache miss path: full install)
- [ ] CI is faster on subsequent runs (cache hit path: system deps only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)