### PR TITLE
docs(garden): TASK-036 — document @mention syntax in protocol and audit checklist

### DIFF
--- a/docs/exec-plans/doc-gardening-agent.md
+++ b/docs/exec-plans/doc-gardening-agent.md
@@ -258,6 +258,24 @@ grep -q "Dev Agent Experience Surface" docs/design-docs/agent-experience-surface
 
 ---
 
+### Check 7 — @mention syntax is documented in protocol.md
+
+After any sprint touching the message system or frontend agent card rendering, verify that `internal/coordinator/protocol.md` documents `@mention` syntax.
+
+```bash
+grep '@agent-name\|@mention\|mention' internal/coordinator/protocol.md
+```
+
+**Pass:** protocol.md explains that agents can use `@agent-name` in `send_message` bodies to pulse the mentioned agent's card in the operator dashboard.
+**Fail:** add a bullet to the `**Communication**` section of protocol.md:
+
+```
+- Use **@agent-name** anywhere in a message body to mention a peer — the operator dashboard
+  will pulse that agent's card for 3 seconds. Example: "@arch2 can you review this before I merge?"
+```
+
+---
+
 ### Drift found → action matrix
 
 | Drift type | Action |
@@ -270,6 +288,7 @@ grep -q "Dev Agent Experience Surface" docs/design-docs/agent-experience-surface
 | Auth var undocumented | Edit CLAUDE.md, verify session backend injects it; open PR |
 | dev-spawn script or target missing | File task (assign to arch); document what exists, note what is planned |
 | dev-spawn documented but script absent | Mark as `_(planned — TASK-NNN)_` in CLAUDE.md; update when merged |
+| @mention not in protocol.md | Add bullet to Communication section in `internal/coordinator/protocol.md`, open PR |
 
 ---
 

--- a/internal/coordinator/protocol.md
+++ b/internal/coordinator/protocol.md
@@ -43,6 +43,7 @@ An HTTP REST API is available at `{COORDINATOR_URL}` for non-MCP clients (webhoo
 - Use `send_message` to coordinate with peers and your manager
 - Use `check_messages` at the start of every work cycle
 - Use `ack_message` on messages you have acted on
+- Use **@agent-name** anywhere in a message body to mention a peer — the operator dashboard will pulse that agent's card for 3 seconds. Example: `"@arch2 can you review the spawn handler before I merge?"`
 
 **Task Discipline**
 - Create the task BEFORE starting work using `create_task`


### PR DESCRIPTION
## Summary

- **protocol.md** — adds `@agent-name` mention syntax to the Communication section: agents can @mention peers in `send_message` bodies, which pulses the mentioned agent's card in the operator dashboard for 3 seconds
- **doc-gardening-agent.md** — adds Check 7 to the Agent Experience Audit: verifies @mention syntax is documented in protocol.md after any sprint touching the message system or frontend; adds a drift-action-matrix row

## Context

Requested by `ux` (per boss directive): agents have no instructions for using @tags. The frontend already parses `@agent-name` and triggers a 3s pulse ring animation on the mentioned agent's card (gamification feature). This PR closes the documentation gap.

## Test plan
- [ ] `go test ./internal/coordinator/ ./internal/domain/...` passes (no code changes)
- [ ] `grep '@agent-name' internal/coordinator/protocol.md` returns the new bullet
- [ ] `grep 'Check 7' docs/exec-plans/doc-gardening-agent.md` returns the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)