### PR TITLE
docs(garden): TASK-047 — unread message field semantics in protocol.md

### DIFF
--- a/docs/exec-plans/doc-gardening-agent.md
+++ b/docs/exec-plans/doc-gardening-agent.md
@@ -289,6 +289,22 @@ grep '@agent-name\|@mention\|mention' internal/coordinator/protocol.md
 | dev-spawn script or target missing | File task (assign to arch); document what exists, note what is planned |
 | dev-spawn documented but script absent | Mark as `_(planned — TASK-NNN)_` in CLAUDE.md; update when merged |
 | @mention not in protocol.md | Add bullet to Communication section in `internal/coordinator/protocol.md`, open PR |
+| Unread message field semantics missing | Add unread/read field table to Message Polling section of `internal/coordinator/protocol.md`, open PR |
+
+---
+
+### Check 8 — Unread message field semantics are documented in protocol.md
+
+After any sprint touching the message system or `check_messages` tool, verify that `internal/coordinator/protocol.md` correctly documents how agents distinguish unread from read messages.
+
+```bash
+grep -A3 'Unread\|read.*false\|field does not exist' internal/coordinator/protocol.md
+```
+
+**Pass:** protocol.md explains that unread messages omit the `"read"` field entirely, and warns agents never to grep for `"read": false`.
+**Fail:** add the unread/read field table to the Message Polling section. This is a critical correctness issue — agents who miss this will silently drop directives.
+
+The correct guidance: call `check_messages` and act on every message in the returned array that has not yet been `ack_message`d. Do not filter by `"read"` field value.
 
 ---
 

--- a/internal/coordinator/protocol.md
+++ b/internal/coordinator/protocol.md
@@ -69,6 +69,17 @@ Use `check_messages` with the `since` cursor for efficient polling:
 2. Subsequent calls: `check_messages(space, agent, since: cursor)` — returns only new messages
 3. Empty `messages` array = no new messages
 
+**Unread vs read message fields — critical:**
+
+| State | `"read"` field | `"read_at"` field |
+|-------|---------------|-------------------|
+| **Unread** | **absent** (field does not exist in the object) | absent |
+| **Read** | `true` | RFC3339 timestamp string |
+
+> **Never grep for `"read": false`** — that string never appears in any response. Unread messages simply omit the `"read"` field entirely. Any attempt to filter by `"read": false` will silently match nothing and cause you to miss messages.
+
+The correct approach: call `check_messages` and act on every message in the returned array that you have not yet `ack_message`d. Do not try to filter the JSON file on disk — use the tool response directly.
+
 ### JSON Format Reference
 
 ```json


### PR DESCRIPTION
## Summary

- **`internal/coordinator/protocol.md`** — adds an unread/read field table to the Message Polling section explaining that unread messages have NO `"read"` field (it is absent, not `false`). Adds a warning: never grep for `"read": false`.
- **`docs/exec-plans/doc-gardening-agent.md`** — adds Check 8 to the Agent Experience Audit checklist and a drift action matrix row for this case.

## Root cause

Agents were grepping for `"read": false` to detect unread messages from `check_messages`. This string never appears in any response — unread messages simply omit the `"read"` field entirely. As a result, agents missed directives for multiple check-in cycles.

## Correct pattern

Call `check_messages` and act on every message in the returned array that has not yet been `ack_message`d. No field filtering needed.

## Test plan
- [ ] `go test ./internal/coordinator/ ./internal/domain/...` passes (no code changes)
- [ ] `grep -A3 'Unread' internal/coordinator/protocol.md` shows the new table
- [ ] `grep 'Check 8' docs/exec-plans/doc-gardening-agent.md` returns the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)