### PR TITLE
fix(TASK-051): decision embed resolves on reply

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -270,7 +270,10 @@ class ApiClient {
     agent: string,
     message: string,
     sender: string,
+    replyToDecisionId?: string,
   ): Promise<void> {
+    const body: Record<string, string> = { message }
+    if (replyToDecisionId) body.reply_to_decision_id = replyToDecisionId
     return this.requestVoid(
       `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/message`,
       {
@@ -279,7 +282,7 @@ class ApiClient {
           'Content-Type': 'application/json',
           'X-Agent-Name': sender,
         },
-        body: JSON.stringify({ message }),
+        body: JSON.stringify(body),
       },
     )
   }

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -346,11 +346,21 @@ async function replyToDecision(msgId: string, agentName: string) {
   decisionReplying.value[msgId] = true
   decisionFeedback.value[msgId] = { ok: true, msg: '' }
   try {
-    // Send the reply as a regular message to the agent
-    await api.sendMessage(props.space.name, agentName, text, 'boss')
+    // Send the reply to the agent, passing the decision ID so the backend marks it resolved.
+    await api.sendMessage(props.space.name, agentName, text, 'boss', msgId)
     decisionReplyTexts.value[msgId] = ''
     decisionFeedback.value[msgId] = { ok: true, msg: 'Reply sent' }
     setTimeout(() => { delete decisionFeedback.value[msgId] }, 3000)
+    // Optimistically mark the decision resolved in the local reactive state so the embed
+    // immediately flips to "Resolved" without waiting for a full space reload.
+    const bossMessages = props.space.agents['boss']?.messages
+    if (bossMessages) {
+      const msg = bossMessages.find(m => m.id === msgId)
+      if (msg) {
+        msg.resolved = true
+        msg.resolution = text
+      }
+    }
   } catch (err) {
     decisionFeedback.value[msgId] = { ok: false, msg: err instanceof Error ? err.message : 'Failed' }
     setTimeout(() => { delete decisionFeedback.value[msgId] }, 3000)

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -295,11 +295,17 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, spac
 		agentName = sender.Parent
 	}
 
-	var messageReq AgentMessage
-	if err := json.NewDecoder(r.Body).Decode(&messageReq); err != nil {
+	// sendMessageBody extends AgentMessage with an optional field to resolve a pending decision.
+	var sendBody struct {
+		AgentMessage
+		ReplyToDecisionID string `json:"reply_to_decision_id,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&sendBody); err != nil {
 		writeJSONError(w, fmt.Sprintf("decode: %v", err), http.StatusBadRequest)
 		return
 	}
+	messageReq := sendBody.AgentMessage
+	replyToDecisionID := sendBody.ReplyToDecisionID
 
 	// Validate required fields
 	if strings.TrimSpace(messageReq.Message) == "" {
@@ -406,6 +412,23 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, spac
 				filtered = append(filtered, m)
 			}
 			ag.Messages = filtered
+		}
+	}
+
+	// If the sender provided a decision message ID to resolve, mark it Resolved in the sender's
+	// own message list. Decision messages live in the sender's inbox (e.g. boss's messages when
+	// an agent calls request_decision), so we look in the canonical sender's messages.
+	if replyToDecisionID != "" {
+		senderRecord := ks.agentStatus(strings.ToLower(senderName))
+		if senderRecord != nil {
+			for i := range senderRecord.Messages {
+				if senderRecord.Messages[i].ID == replyToDecisionID &&
+					senderRecord.Messages[i].Type == "decision" {
+					senderRecord.Messages[i].Resolved = true
+					senderRecord.Messages[i].Resolution = messageReq.Message
+					break
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Bug Fix: Decision Embed Cards Don't Resolve on Reply

### Problem
When a boss replies to a `request_decision` embed card in Conversations, the card stays amber/unresolved. Clicking send appears to work (message is delivered to the agent) but the embed never flips to "Decision — Resolved".

**Root cause**: `AgentMessage.Resolved` and `AgentMessage.Resolution` existed in the type definition but were **never set by any code path**. The backend had the fields, the frontend rendered based on them, but nothing ever populated them.

### Fix

**Backend** (`handlers_agent.go`):
- `handleAgentMessage` decodes an optional `reply_to_decision_id` field from the POST body
- When present and sender is `'boss'`, finds the matching decision message in boss's messages list and marks `Resolved = true` + `Resolution = message text`
- Runs inside the same mutex lock as message delivery — save is atomic

**Frontend** (`api/client.ts`):
- `sendMessage()` accepts an optional `replyToDecisionId` param, includes it in the request body if provided

**Frontend** (`ConversationsView.vue`):
- `replyToDecision()` passes `msgId` as `reply_to_decision_id`
- After successful send, **optimistically mutates** `props.space.agents['boss'].messages` to mark `msg.resolved = true` so the embed immediately flips to "Decision — Resolved" without waiting for a space reload
- On next space reload (SSE-triggered), the backend-persisted resolved state is loaded

### Before / After
- **Before**: Embed stays amber forever after replying
- **After**: Embed immediately shows gray "Decision — Resolved" with the reply text shown below