### PR TITLE
fix(conversations): add /spaces/:space/messages endpoint (TASK-065)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -150,6 +150,10 @@ class ApiClient {
     return this.request(url)
   }
 
+  fetchSpaceMessages(space: string): Promise<Record<string, { messages: import('@/types').AgentMessage[] }>> {
+    return this.request(`/spaces/${encodeURIComponent(space)}/messages`)
+  }
+
   ackMessage(space: string, agent: string, messageId: string, agentName: string): Promise<void> {
     return this.requestVoid(
       `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/message/${encodeURIComponent(messageId)}/ack`,

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -43,12 +43,28 @@ interface Conversation {
   lastMessageAt: string
 }
 
+// Messages fetched from /spaces/:space/messages — decoupled from the space JSON
+// (which no longer embeds message histories after the perf fix in PR #195).
+const spaceMessages = ref<Record<string, { messages: import('@/types').AgentMessage[] }>>({})
+
+async function loadSpaceMessages() {
+  try {
+    spaceMessages.value = await api.fetchSpaceMessages(props.space.name)
+  } catch {
+    // non-fatal: falls back to agentData.messages (empty after PR #195)
+  }
+}
+
+onMounted(loadSpaceMessages)
+watch(() => props.space.name, loadSpaceMessages)
+
 // Reconstruct pairwise conversation threads from all agents' message inboxes.
 const conversations = computed((): Conversation[] => {
   const convMap = new Map<string, Conversation>()
 
   for (const [agentName, agentData] of Object.entries(props.space.agents)) {
-    for (const msg of agentData.messages ?? []) {
+    const msgs = spaceMessages.value[agentName]?.messages ?? agentData.messages ?? []
+    for (const msg of msgs) {
       const sorted = [agentName, msg.sender].sort()
       const participants = sorted as [string, string]
       const key = participants.join('\u2194')
@@ -353,7 +369,7 @@ async function replyToDecision(msgId: string, agentName: string) {
     setTimeout(() => { delete decisionFeedback.value[msgId] }, 3000)
     // Optimistically mark the decision resolved in the local reactive state so the embed
     // immediately flips to "Resolved" without waiting for a full space reload.
-    const bossMessages = props.space.agents['boss']?.messages
+    const bossMessages = spaceMessages.value['boss']?.messages
     if (bossMessages) {
       const msg = bossMessages.find(m => m.id === msgId)
       if (msg) {

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -194,6 +194,8 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 		} else {
 			http.NotFound(w, r)
 		}
+	case "messages":
+		s.handleSpaceMessageList(w, r, spaceName)
 	case "tasks":
 		rest := ""
 		if len(parts) >= 3 {
@@ -538,4 +540,40 @@ func (s *Server) handleSpaceArchive(w http.ResponseWriter, r *http.Request, spac
 		logLabel:    "archive",
 		journalType: EventArchiveUpdated,
 	})
+}
+
+// handleSpaceMessageList serves GET /spaces/{space}/messages.
+// Returns all messages for every agent in the space, indexed by agent name.
+// ConversationsView uses this to reconstruct pairwise conversation threads
+// without needing message histories embedded in the space JSON response.
+func (s *Server) handleSpaceMessageList(w http.ResponseWriter, r *http.Request, spaceName string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, fmt.Sprintf("space %q not found", spaceName), http.StatusNotFound)
+		return
+	}
+
+	s.mu.RLock()
+	type agentMsgs struct {
+		Messages []AgentMessage `json:"messages"`
+	}
+	result := make(map[string]agentMsgs, len(ks.Agents))
+	for name, ag := range ks.Agents {
+		if ag.Status == nil {
+			result[name] = agentMsgs{Messages: []AgentMessage{}}
+			continue
+		}
+		msgs := make([]AgentMessage, len(ag.Status.Messages))
+		copy(msgs, ag.Status.Messages)
+		result[name] = agentMsgs{Messages: msgs}
+	}
+	s.mu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
 }


### PR DESCRIPTION
## Summary

ConversationsView went blank after PR #195 merged the perf fix. The view was reading `space.agents[name].messages` inline from the space JSON, but #195 stripped message histories from that response (738KB → ~35KB win).

This hotfix adds a dedicated endpoint and updates the frontend to use it.

## Changes

**Backend — `GET /spaces/{space}/messages`**
- New route `case "messages":` in `handleSpaceRoute`
- Handler `handleSpaceMessageList`: aggregates messages for all agents under an RLock, returns `{ agentName: { messages: [...] } }`
- Read-only, no side effects, no lock held during encode

**Frontend — `ConversationsView.vue`**
- Adds `spaceMessages` ref populated from `api.fetchSpaceMessages(space.name)`
- Fetches on `onMounted` and whenever `space.name` changes
- `conversations` computed uses `spaceMessages.value[agentName]?.messages` with fallback to `agentData.messages`
- Optimistic resolve in `replyToDecision` updated to mutate `spaceMessages` ref (not the now-empty space prop)

**API client — `client.ts`**
- `fetchSpaceMessages(space)` → `GET /spaces/:space/messages`

## Test plan

- [x] `go test -race ./internal/coordinator/` passes
- [ ] Restart boss and verify ConversationsView renders message threads
- [ ] Verify sending a message and replying to a decision still works
- [ ] Verify space JSON payload stays small (no regression on perf fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)