### PR TITLE
feat(auth): Phase 2 per-agent tokens — SEC-006 closed (TASK-066)

### DIFF
--- a/internal/coordinator/db/models.go
+++ b/internal/coordinator/db/models.go
@@ -90,6 +90,7 @@ type Agent struct {
 	Stale          bool
 	Registration   string    `gorm:"type:text"` // JSON object
 	Config         string    `gorm:"type:text"` // JSON AgentConfig
+	TokenHash      string    `gorm:"type:text"` // SHA-256 hex of per-agent bearer token; empty = no per-agent token
 	LastHeartbeat  time.Time
 	HeartbeatStale bool
 	UpdatedAt      time.Time

--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -95,6 +95,29 @@ func (r *Repository) ListAgents(spaceName string) ([]*Agent, error) {
 	return agents, r.db.Where("space_name = ?", spaceName).Find(&agents).Error
 }
 
+// SaveAgentTokenHash stores the SHA-256 hex of a per-agent bearer token.
+// It upserts only the token_hash column, leaving all other fields unchanged.
+// Agent-name lookup is case-insensitive (LIKE in SQLite behaves case-insensitively
+// for ASCII; for full Unicode safety we also lowercase the input).
+func (r *Repository) SaveAgentTokenHash(spaceName, agentName, tokenHash string) error {
+	return r.db.Model(&Agent{}).
+		Where("space_name = ? AND LOWER(agent_name) = LOWER(?)", spaceName, agentName).
+		Update("token_hash", tokenHash).Error
+}
+
+// GetAgentTokenHash returns the stored SHA-256 hex token hash for an agent, or "" if none.
+// Agent-name lookup is case-insensitive.
+func (r *Repository) GetAgentTokenHash(spaceName, agentName string) (string, error) {
+	var a Agent
+	err := r.db.Select("token_hash").
+		Where("space_name = ? AND LOWER(agent_name) = LOWER(?)", spaceName, agentName).
+		First(&a).Error
+	if err == gorm.ErrRecordNotFound {
+		return "", nil
+	}
+	return a.TokenHash, err
+}
+
 // DeleteAgent removes an agent record.
 func (r *Repository) DeleteAgent(spaceName, agentName string) error {
 	return r.db.Where("space_name = ? AND agent_name = ?", spaceName, agentName).Delete(&Agent{}).Error

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -49,6 +49,14 @@ func (s *Server) handleSpaceAgent(w http.ResponseWriter, r *http.Request, spaceN
 			writeJSONError(w, fmt.Sprintf("agent %q cannot post to %q's channel", callerName, agentName), http.StatusForbidden)
 			return
 		}
+		// Per-agent token enforcement (SEC-006): when auth is enabled and the
+		// caller is not using the workspace operator token, verify the token was
+		// specifically issued for this agent. Prevents one agent from posting to
+		// another agent's channel by presenting a sibling's per-agent token.
+		if !s.verifyAgentToken(r, spaceName, agentName) {
+			writeJSONError(w, "unauthorized: token does not match this agent", http.StatusUnauthorized)
+			return
+		}
 
 		contentType := r.Header.Get("Content-Type")
 		defer r.Body.Close()
@@ -1504,7 +1512,7 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 				Height:               req.Height,
 				MCPServerURL:         s.localURL(),
 				MCPServerName:        s.mcpServerName(),
-				AgentToken:           s.apiToken,
+				AgentToken:           s.generateAgentToken(spaceName, req.Name),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
 		}

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -388,7 +388,7 @@ func (s *Server) spawnAgentService(spaceName, agentName string, req spawnRequest
 				WorkDir:              spawnWorkDir,
 				MCPServerURL:         s.localURL(),
 				MCPServerName:        s.mcpServerName(),
-				AgentToken:           s.apiToken,
+				AgentToken:           s.generateAgentToken(spaceName, agentName),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
 		}
@@ -633,7 +633,7 @@ func (s *Server) restartAgentService(spaceName, agentName string, req spawnReque
 				WorkDir:              restartWorkDir,
 				MCPServerURL:         s.localURL(),
 				MCPServerName:        s.mcpServerName(),
-				AgentToken:           s.apiToken,
+				AgentToken:           s.generateAgentToken(spaceName, canonical),
 				AllowSkipPermissions: s.allowSkipPermissions,
 			},
 		}
@@ -858,7 +858,7 @@ func (s *Server) handleRestartAll(w http.ResponseWriter, r *http.Request, spaceN
 					WorkDir:              workDir,
 					MCPServerURL:         s.localURL(),
 					MCPServerName:        s.mcpServerName(),
-					AgentToken:           s.apiToken,
+					AgentToken:           s.generateAgentToken(spaceName, t.name),
 					AllowSkipPermissions: s.allowSkipPermissions,
 				},
 			}

--- a/internal/coordinator/mcp_server.go
+++ b/internal/coordinator/mcp_server.go
@@ -156,7 +156,7 @@ func (s *Server) buildMCPHandler() http.Handler {
 	// Wrap with CORS headers so browser-based and cross-origin MCP clients can connect.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		setCORSOriginHeader(w, r)
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
 		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 		if r.Method == http.MethodOptions {

--- a/internal/coordinator/middleware.go
+++ b/internal/coordinator/middleware.go
@@ -2,6 +2,10 @@ package coordinator
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -58,6 +62,11 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 // authMiddleware wraps an http.Handler, requiring a Bearer token on mutating
 // requests (POST, PATCH, DELETE, PUT). If s.apiToken is empty, the middleware
 // is a no-op (open mode — backward compatible for local development).
+//
+// Two token classes are accepted:
+//  1. Workspace token (s.apiToken / BOSS_API_TOKEN) — full access to all endpoints.
+//  2. Per-agent token — valid only on agent-channel endpoints; the handler verifies
+//     the token belongs to the specific agent being posted to.
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if s.apiToken == "" {
@@ -75,10 +84,100 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		token := auth[7:] // strip "Bearer " (7 chars) preserving original case
-		if !hmac.Equal([]byte(token), []byte(s.apiToken)) {
-			writeJSONError(w, "unauthorized", http.StatusUnauthorized)
+
+		// Workspace token: full access to all endpoints.
+		if hmac.Equal([]byte(token), []byte(s.apiToken)) {
+			next.ServeHTTP(w, r)
 			return
 		}
-		next.ServeHTTP(w, r)
+
+		// Per-agent token: only permitted on agent-channel POST endpoints.
+		// The handler is responsible for verifying the token matches the
+		// specific agent (enforcing SEC-006 — agent channel isolation).
+		if s.repo != nil && isAgentChannelPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		writeJSONError(w, "unauthorized", http.StatusUnauthorized)
 	})
+}
+
+// isAgentChannelPath returns true when the path is an agent status-post endpoint:
+//
+//	/spaces/{space}/agent/{name}   (multi-space)
+//	/agent/{name}                  (legacy default-space)
+func isAgentChannelPath(path string) bool {
+	// /spaces/.../agent/...
+	if strings.Contains(path, "/agent/") {
+		return true
+	}
+	// /agent/{name} (legacy)
+	if strings.HasPrefix(path, "/agent/") {
+		return true
+	}
+	return false
+}
+
+// generateAgentToken creates a cryptographically random UUID-style token for
+// a specific agent, stores its SHA-256 hash in the DB, and returns the plain
+// token for injection into the agent's tmux session. Safe to call on every
+// spawn/restart — a new token replaces any previous one.
+func (s *Server) generateAgentToken(spaceName, agentName string) string {
+	if s.apiToken == "" || s.repo == nil {
+		// Open mode or no DB: fall back to shared workspace token (Phase 1 behaviour).
+		return s.apiToken
+	}
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		// Fallback to shared token on RNG failure (extremely unlikely).
+		return s.apiToken
+	}
+	token := hex.EncodeToString(raw) // 64-char hex string
+	sum := sha256.Sum256([]byte(token))
+	hash := hex.EncodeToString(sum[:])
+	if err := s.repo.SaveAgentTokenHash(spaceName, agentName, hash); err != nil {
+		// Non-fatal: fall back to shared token if DB write fails.
+		return s.apiToken
+	}
+	return token
+}
+
+// verifyAgentToken checks that the Bearer token presented in r matches the
+// stored per-agent token hash for (spaceName, agentName). Returns true when:
+//   - Auth is disabled (s.apiToken == ""), or
+//   - The presented token is the workspace token (operator access), or
+//   - The SHA-256 hash of the presented token matches the stored hash.
+func (s *Server) verifyAgentToken(r *http.Request, spaceName, agentName string) bool {
+	if s.apiToken == "" {
+		return true // open mode
+	}
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		return false
+	}
+	token := auth[7:]
+
+	// Workspace token always grants access.
+	if hmac.Equal([]byte(token), []byte(s.apiToken)) {
+		return true
+	}
+
+	// Per-agent token: verify hash against DB.
+	if s.repo == nil {
+		return false
+	}
+	storedHash, err := s.repo.GetAgentTokenHash(spaceName, agentName)
+	if err != nil || storedHash == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(token))
+	presented := hex.EncodeToString(sum[:])
+	return hmac.Equal([]byte(presented), []byte(storedHash))
+}
+
+// tokenErrorf formats and returns an error string for auth failures.
+// Kept here to avoid scattering auth messaging across multiple files.
+func tokenErrorf(format string, args ...any) string {
+	return fmt.Sprintf(format, args...)
 }

--- a/internal/coordinator/server_test.go
+++ b/internal/coordinator/server_test.go
@@ -4396,3 +4396,105 @@ func TestCORSAllowlistNarrowsWildcard(t *testing.T) {
 		}
 	})
 }
+
+// TestPerAgentTokenIsolation verifies SEC-006: per-agent tokens allow an agent
+// to post only to its own channel, not to a sibling agent's channel.
+func TestPerAgentTokenIsolation(t *testing.T) {
+	const wsToken = "workspace-secret"
+	srv, cleanup := mustStartServerWithToken(t, wsToken)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	// Seed both agents via the workspace token so they exist in the DB.
+	for _, name := range []string{"alice", "bob"} {
+		resp := postJSONWithToken(t, base+"/spaces/sec006/agent/"+name, wsToken, map[string]any{
+			"status": "active", "summary": name + ": online",
+		})
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+			t.Fatalf("seed %s: expected 200/202, got %d", name, resp.StatusCode)
+		}
+	}
+
+	// Generate per-agent tokens for alice and bob.
+	aliceToken := srv.generateAgentToken("sec006", "alice")
+	bobToken := srv.generateAgentToken("sec006", "bob")
+
+	if aliceToken == wsToken || bobToken == wsToken {
+		t.Fatal("generateAgentToken should return a distinct per-agent token, not the workspace token")
+	}
+	if aliceToken == bobToken {
+		t.Fatal("generateAgentToken must produce distinct tokens for different agents")
+	}
+
+	postAs := func(token, channel, caller string) int {
+		data, _ := json.Marshal(map[string]any{"status": "active", "summary": caller + ": posting"})
+		req, _ := http.NewRequest(http.MethodPost, base+"/spaces/sec006/agent/"+channel, strings.NewReader(string(data)))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Agent-Name", caller)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	ok := func(code int) bool { return code == http.StatusOK || code == http.StatusAccepted }
+
+	// alice's token → alice's channel: allowed.
+	if code := postAs(aliceToken, "alice", "alice"); !ok(code) {
+		t.Errorf("alice→alice: expected 200/202, got %d", code)
+	}
+
+	// bob's token → bob's channel: allowed.
+	if code := postAs(bobToken, "bob", "bob"); !ok(code) {
+		t.Errorf("bob→bob: expected 200/202, got %d", code)
+	}
+
+	// alice's token → bob's channel: SEC-006 — must be rejected.
+	if code := postAs(aliceToken, "bob", "bob"); ok(code) {
+		t.Errorf("alice token → bob channel: should be rejected (SEC-006), got %d", code)
+	}
+
+	// bob's token → alice's channel: SEC-006 — must be rejected.
+	if code := postAs(bobToken, "alice", "alice"); ok(code) {
+		t.Errorf("bob token → alice channel: should be rejected (SEC-006), got %d", code)
+	}
+
+	// Workspace token → either channel: always allowed (operator access).
+	if code := postAs(wsToken, "alice", "alice"); !ok(code) {
+		t.Errorf("workspace token → alice: expected 200/202, got %d", code)
+	}
+	if code := postAs(wsToken, "bob", "bob"); !ok(code) {
+		t.Errorf("workspace token → bob: expected 200/202, got %d", code)
+	}
+}
+
+// TestMCPCORSAllowsAuthorizationHeader verifies that the /mcp CORS preflight
+// includes Authorization in Access-Control-Allow-Headers, enabling browser-based
+// MCP clients that need to pass Bearer tokens.
+func TestMCPCORSAllowsAuthorizationHeader(t *testing.T) {
+	srv, cleanup := mustStartServer(t)
+	defer cleanup()
+	base := serverBaseURL(srv)
+
+	req, err := http.NewRequest(http.MethodOptions, base+"/mcp", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "http://localhost:8899")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "Authorization")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("OPTIONS /mcp: %v", err)
+	}
+	defer resp.Body.Close()
+
+	allowed := resp.Header.Get("Access-Control-Allow-Headers")
+	if !strings.Contains(strings.ToLower(allowed), "authorization") {
+		t.Errorf("CORS preflight: Authorization not in Access-Control-Allow-Headers: %q", allowed)
+	}
+}


### PR DESCRIPTION
## Summary

- Generates a cryptographically unique token per agent at spawn/restart time
- Stores SHA-256 hash in `agents.token_hash` DB column (AutoMigrate, no manual migration)
- Injects plain token via `--mcp-config` JSON Authorization header so MCP calls authenticate as the correct agent
- Enforces token-to-agent binding in the POST handler: an agent's token cannot post to another agent's channel (closes SEC-006)
- Fixes MCP CORS: adds `Authorization` to `Access-Control-Allow-Headers` for browser MCP clients

**Auth tiers** (all backward compatible):
1. Open mode (`BOSS_API_TOKEN` unset) — no change, all requests pass
2. Workspace token (`BOSS_API_TOKEN`) — full operator access to any channel
3. Per-agent token — new; channel-scoped, generated at spawn, injected via MCP config

## Files changed

| File | Change |
|------|--------|
| `db/models.go` | `TokenHash` field on `Agent` |
| `db/repository.go` | `SaveAgentTokenHash` + `GetAgentTokenHash` (case-insensitive) |
| `middleware.go` | `generateAgentToken()`, `verifyAgentToken()`, `isAgentChannelPath()`, updated `authMiddleware` |
| `handlers_agent.go` | `verifyAgentToken()` check after X-Agent-Name validation |
| `lifecycle.go` (3 sites) | `generateAgentToken()` replaces `s.apiToken` in `TmuxCreateOpts.AgentToken` |
| `handlers_agent.go` (spawn) | same |
| `mcp_server.go` | `Authorization` in CORS Allow-Headers |
| `server_test.go` | `TestPerAgentTokenIsolation`, `TestMCPCORSAllowsAuthorizationHeader` |

## Test plan

- [x] go test -race ./internal/coordinator/ — all pass
- [x] TestPerAgentTokenIsolation — alice token rejected on bob channel (SEC-006)
- [x] TestMCPCORSAllowsAuthorizationHeader — Authorization in preflight
- [x] All existing auth tests pass

Note: based on feat/auth-phase1-rebased (Phase 1 auth prerequisite).

🤖 Generated with Claude Code