### PR TITLE
fix(sse): eliminate spurious disconnect banner on space navigation (TASK-067)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1308,7 +1308,7 @@ onUnmounted(() => {
           leave-to-class="opacity-0 -translate-y-1"
         >
           <div
-            v-if="!sse.connected.value"
+            v-if="sse.error.value"
             class="flex items-center justify-center gap-2 bg-amber-500/10 border-b border-amber-500/30 px-4 py-1.5 text-xs text-amber-600 dark:text-amber-400 shrink-0"
             role="alert"
             aria-live="assertive"

--- a/internal/coordinator/handlers_sse.go
+++ b/internal/coordinator/handlers_sse.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -81,10 +82,16 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, space string) 
 		case <-ctx.Done():
 			return
 		case msg := <-client.ch:
-			w.Write(msg)
+			if _, err := w.Write(msg); err != nil {
+				slog.Warn("sse: write error, client likely disconnected", "space", space, "err", err)
+				return
+			}
 			flusher.Flush()
 		case t := <-keepalive.C:
-			fmt.Fprintf(w, ": keepalive %s\n\n", t.UTC().Format(time.RFC3339))
+			if _, err := fmt.Fprintf(w, ": keepalive %s\n\n", t.UTC().Format(time.RFC3339)); err != nil {
+				slog.Warn("sse: keepalive write error, client likely disconnected", "space", space, "err", err)
+				return
+			}
 			flusher.Flush()
 		}
 	}


### PR DESCRIPTION
## Root Cause

The \"Live connection lost\" banner used `v-if=\"!sse.connected.value\"` which fires on **every space navigation**, not just actual disconnects.

When navigating between spaces, `sse.connect(newSpace)` is called, which internally calls `disconnect()` → sets `connected.value = false` → banner appears. Then the new `EventSource.onopen` fires → `connected.value = true` → banner disappears. This flash happens on every route change. If the boss navigates frequently, the banner appears constantly.

## Fixes

### Frontend — banner condition (App.vue)

**Before:** `v-if=\"!sse.connected.value\"` — true during intentional navigation reconnects AND error backoff  
**After:** `v-if=\"sse.error.value\"` — only true during error-based disconnects

The `error` ref in `useSSE` is only set in the `onerror` handler (unexpected disconnect → backoff retry). On `disconnect()` (intentional), `error` is explicitly cleared to `null`. This means the banner only shows when there's a real connection problem requiring user attention.

The toolbar dot indicator still uses `sse.connected.value` (small, expected to flicker during navigation — not intrusive).

### Backend — SSE write error handling (handlers_sse.go)

Previously `w.Write(msg)` and `fmt.Fprintf(w, keepalive)` ignored return errors. Added error checking with `slog.Warn` logging and early return on write failure. This surfaces broken connections in server logs for diagnostics and avoids continuing to write to dead connections.

### PR #197 impact

`ConversationsView` (hotfix PR #197) only re-fetches messages on `space.name` change (navigation), not on every SSE event. No SSE polling pressure added.

## Test plan

- [x] `go test -race ./internal/coordinator/` passes
- [x] Frontend builds clean
- [ ] Navigate between spaces — disconnect banner should NOT flash
- [ ] Kill the boss server — banner should appear after reconnect timeout
- [ ] Restart server — banner should disappear when reconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)