### PR TITLE
feat(personas): migrate storage from JSON file to SQLite (TASK-074)

### DIFF
--- a/internal/coordinator/db/db.go
+++ b/internal/coordinator/db/db.go
@@ -89,6 +89,8 @@ func migrate(db *gorm.DB) error {
 		&Setting{},
 		&SpaceEventLog{},
 		&InterruptRecord{},
+		&PersonaRow{},
+		&PersonaVersionRow{},
 	); err != nil {
 		return err
 	}

--- a/internal/coordinator/db/migrate_from_json.go
+++ b/internal/coordinator/db/migrate_from_json.go
@@ -280,6 +280,76 @@ func (r *Repository) importAgent(spaceName, agentName string, ja *jsonAgent) err
 	return nil
 }
 
+// ImportPersonasFromJSON reads DATA_DIR/personas.json (if present) and imports any
+// personas that do not yet exist in the database. Safe to call on every startup.
+func (r *Repository) ImportPersonasFromJSON(dataDir string) error {
+	path := filepath.Join(dataDir, "personas.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to migrate
+		}
+		return fmt.Errorf("read personas.json: %w", err)
+	}
+
+	type jsonPersonaVersion struct {
+		Version   int       `json:"version"`
+		Prompt    string    `json:"prompt"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+	type jsonPersona struct {
+		ID          string               `json:"id"`
+		Name        string               `json:"name"`
+		Description string               `json:"description"`
+		Prompt      string               `json:"prompt"`
+		Version     int                  `json:"version"`
+		History     []jsonPersonaVersion `json:"history"`
+		CreatedAt   time.Time            `json:"created_at"`
+		UpdatedAt   time.Time            `json:"updated_at"`
+	}
+
+	var personas []jsonPersona
+	if err := json.Unmarshal(data, &personas); err != nil {
+		return fmt.Errorf("parse personas.json: %w", err)
+	}
+
+	for _, jp := range personas {
+		exists, err := r.PersonaExists(jp.ID)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue // already imported
+		}
+		row := &PersonaRow{
+			ID:          jp.ID,
+			Name:        jp.Name,
+			Description: jp.Description,
+			Prompt:      jp.Prompt,
+			Version:     jp.Version,
+			CreatedAt:   jp.CreatedAt,
+			UpdatedAt:   jp.UpdatedAt,
+		}
+		if row.Version == 0 {
+			row.Version = 1
+		}
+		if err := r.CreatePersona(row); err != nil {
+			return fmt.Errorf("import persona %q: %w", jp.ID, err)
+		}
+		for _, h := range jp.History {
+			if err := r.SavePersonaVersion(&PersonaVersionRow{
+				PersonaID: jp.ID,
+				Version:   h.Version,
+				Prompt:    h.Prompt,
+				UpdatedAt: h.UpdatedAt,
+			}); err != nil {
+				return fmt.Errorf("import persona %q version %d: %w", jp.ID, h.Version, err)
+			}
+		}
+	}
+	return nil
+}
+
 func (r *Repository) importTask(spaceName string, jt *jsonTask) error {
 	var dueAt sql.NullTime
 	if jt.DueAt != nil {

--- a/internal/coordinator/db/models.go
+++ b/internal/coordinator/db/models.go
@@ -214,6 +214,31 @@ type SpaceEventLog struct {
 
 func (SpaceEventLog) TableName() string { return "space_event_log" }
 
+// PersonaRow is a global, reusable prompt fragment that can be assigned to agents.
+// Replaces the legacy DATA_DIR/personas.json file.
+type PersonaRow struct {
+	ID          string    `gorm:"primarykey;not null"`
+	Name        string    `gorm:"not null"`
+	Description string    `gorm:"type:text"`
+	Prompt      string    `gorm:"type:text"`
+	Version     int       `gorm:"default:1"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+func (PersonaRow) TableName() string { return "personas" }
+
+// PersonaVersionRow records a historical snapshot of a persona's prompt.
+type PersonaVersionRow struct {
+	ID        uint      `gorm:"primarykey;autoIncrement"`
+	PersonaID string    `gorm:"index;not null"`
+	Version   int       `gorm:"not null"`
+	Prompt    string    `gorm:"type:text"`
+	UpdatedAt time.Time
+}
+
+func (PersonaVersionRow) TableName() string { return "persona_versions" }
+
 // InterruptRecord stores an agent interrupt (approval request, decision, etc.)
 // Replaces the legacy {space}.interrupts.jsonl files.
 type InterruptRecord struct {

--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -448,3 +448,59 @@ func (r *Repository) ResolveInterrupt(spaceName, id, resolvedBy, answer string) 
 func (r *Repository) DeleteInterrupts(spaceName string) error {
 	return r.db.Where("space_name = ?", spaceName).Delete(&InterruptRecord{}).Error
 }
+
+// ---- Persona operations ----
+
+// ListPersonas returns all personas ordered by name.
+func (r *Repository) ListPersonas() ([]*PersonaRow, error) {
+	var personas []*PersonaRow
+	return personas, r.db.Order("name ASC").Find(&personas).Error
+}
+
+// GetPersona returns a persona by ID, or (nil, nil) if not found.
+func (r *Repository) GetPersona(id string) (*PersonaRow, error) {
+	var p PersonaRow
+	err := r.db.Where("id = ?", id).First(&p).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return &p, err
+}
+
+// CreatePersona inserts a new persona; returns an error if the ID already exists.
+func (r *Repository) CreatePersona(p *PersonaRow) error {
+	return r.db.Create(p).Error
+}
+
+// SavePersona updates an existing persona record.
+func (r *Repository) SavePersona(p *PersonaRow) error {
+	return r.db.Save(p).Error
+}
+
+// DeletePersona removes a persona and all its version history.
+func (r *Repository) DeletePersona(id string) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("persona_id = ?", id).Delete(&PersonaVersionRow{}).Error; err != nil {
+			return err
+		}
+		return tx.Where("id = ?", id).Delete(&PersonaRow{}).Error
+	})
+}
+
+// GetPersonaVersions returns historical versions for a persona, oldest first.
+func (r *Repository) GetPersonaVersions(personaID string) ([]*PersonaVersionRow, error) {
+	var versions []*PersonaVersionRow
+	return versions, r.db.Where("persona_id = ?", personaID).Order("version ASC").Find(&versions).Error
+}
+
+// SavePersonaVersion persists a persona version snapshot.
+func (r *Repository) SavePersonaVersion(v *PersonaVersionRow) error {
+	return r.db.Create(v).Error
+}
+
+// PersonaExists returns true if a persona with the given ID exists.
+func (r *Repository) PersonaExists(id string) (bool, error) {
+	var count int64
+	err := r.db.Model(&PersonaRow{}).Where("id = ?", id).Count(&count).Error
+	return count > 0, err
+}

--- a/internal/coordinator/personas.go
+++ b/internal/coordinator/personas.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
+
+	bossdb "github.com/ambient/platform/components/boss/internal/coordinator/db"
 )
 
 // slugRe matches any character that is not a letter, digit, or hyphen.
@@ -23,148 +22,113 @@ func slugify(name string) string {
 	return strings.Trim(s, "-")
 }
 
-// personasFile is the filename for global persona storage in DATA_DIR.
-const personasFile = "personas.json"
-
-// PersonaStore manages global personas persisted to DATA_DIR/personas.json.
+// PersonaStore manages global personas persisted to SQLite.
 type PersonaStore struct {
-	mu      sync.RWMutex
-	dataDir string
-	data    map[string]*Persona // keyed by persona ID
+	repo *bossdb.Repository
 }
 
-func newPersonaStore(dataDir string) *PersonaStore {
-	ps := &PersonaStore{
-		dataDir: dataDir,
-		data:    make(map[string]*Persona),
-	}
-	_ = ps.load()
-	return ps
-}
-
-func (ps *PersonaStore) path() string {
-	return filepath.Join(ps.dataDir, personasFile)
-}
-
-func (ps *PersonaStore) load() error {
-	data, err := os.ReadFile(ps.path())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // first run, no file yet
-		}
-		return err
-	}
-	var personas []*Persona
-	if err := json.Unmarshal(data, &personas); err != nil {
-		return err
-	}
-	ps.data = make(map[string]*Persona, len(personas))
-	for _, p := range personas {
-		ps.data[p.ID] = p
-	}
-	return nil
-}
-
-func (ps *PersonaStore) save() error {
-	personas := make([]*Persona, 0, len(ps.data))
-	for _, p := range ps.data {
-		personas = append(personas, p)
-	}
-	data, err := json.MarshalIndent(personas, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(ps.path(), data, 0644)
+func newPersonaStore(repo *bossdb.Repository) *PersonaStore {
+	return &PersonaStore{repo: repo}
 }
 
 func (ps *PersonaStore) list() []*Persona {
-	ps.mu.RLock()
-	defer ps.mu.RUnlock()
-	out := make([]*Persona, 0, len(ps.data))
-	for _, p := range ps.data {
-		copy := *p
-		out = append(out, &copy)
+	rows, err := ps.repo.ListPersonas()
+	if err != nil {
+		return nil
+	}
+	out := make([]*Persona, len(rows))
+	for i, r := range rows {
+		out[i] = personaFromRow(r)
 	}
 	return out
 }
 
 func (ps *PersonaStore) get(id string) *Persona {
-	ps.mu.RLock()
-	defer ps.mu.RUnlock()
-	p := ps.data[id]
-	if p == nil {
+	row, err := ps.repo.GetPersona(id)
+	if err != nil || row == nil {
 		return nil
 	}
-	copy := *p
-	return &copy
+	return personaFromRow(row)
 }
 
 func (ps *PersonaStore) create(p *Persona) error {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-	if _, exists := ps.data[p.ID]; exists {
+	exists, err := ps.repo.PersonaExists(p.ID)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return fmt.Errorf("persona %q already exists", p.ID)
 	}
-	ps.data[p.ID] = p
-	return ps.save()
+	return ps.repo.CreatePersona(personaToRow(p))
 }
 
 func (ps *PersonaStore) update(id string, fn func(*Persona)) (*Persona, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-	p := ps.data[id]
-	if p == nil {
-		return nil, fmt.Errorf("persona %q not found", id)
-	}
-	// Save current state to history before applying changes.
-	p.History = append(p.History, PersonaVersion{
-		Version:   p.Version,
-		Prompt:    p.Prompt,
-		UpdatedAt: p.UpdatedAt,
-	})
-	fn(p)
-	p.Version++
-	p.UpdatedAt = time.Now().UTC()
-	if err := ps.save(); err != nil {
+	row, err := ps.repo.GetPersona(id)
+	if err != nil {
 		return nil, err
 	}
-	copy := *p
-	return &copy, nil
-}
-
-// history returns the version history for a persona.
-func (ps *PersonaStore) history(id string) ([]PersonaVersion, error) {
-	ps.mu.RLock()
-	defer ps.mu.RUnlock()
-	p := ps.data[id]
-	if p == nil {
+	if row == nil {
 		return nil, fmt.Errorf("persona %q not found", id)
 	}
-	// Return history + current version.
-	all := make([]PersonaVersion, len(p.History), len(p.History)+1)
-	copy(all, p.History)
-	all = append(all, PersonaVersion{
-		Version:   p.Version,
-		Prompt:    p.Prompt,
-		UpdatedAt: p.UpdatedAt,
-	})
+	// Save current state as a version snapshot before applying changes.
+	if err := ps.repo.SavePersonaVersion(&bossdb.PersonaVersionRow{
+		PersonaID: id,
+		Version:   row.Version,
+		Prompt:    row.Prompt,
+		UpdatedAt: row.UpdatedAt,
+	}); err != nil {
+		return nil, err
+	}
+	p := personaFromRow(row)
+	fn(p)
+	p.Version = row.Version + 1
+	p.UpdatedAt = time.Now().UTC()
+	if err := ps.repo.SavePersona(personaToRow(p)); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// history returns the version history for a persona (past versions + current).
+func (ps *PersonaStore) history(id string) ([]PersonaVersion, error) {
+	row, err := ps.repo.GetPersona(id)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, fmt.Errorf("persona %q not found", id)
+	}
+	vrows, err := ps.repo.GetPersonaVersions(id)
+	if err != nil {
+		return nil, err
+	}
+	all := make([]PersonaVersion, 0, len(vrows)+1)
+	for _, v := range vrows {
+		all = append(all, PersonaVersion{Version: v.Version, Prompt: v.Prompt, UpdatedAt: v.UpdatedAt})
+	}
+	// Append current version.
+	all = append(all, PersonaVersion{Version: row.Version, Prompt: row.Prompt, UpdatedAt: row.UpdatedAt})
 	return all, nil
 }
 
 // revert restores a persona to a previous version's prompt, creating a new version.
 func (ps *PersonaStore) revert(id string, targetVersion int) (*Persona, error) {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-	p := ps.data[id]
-	if p == nil {
+	row, err := ps.repo.GetPersona(id)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
 		return nil, fmt.Errorf("persona %q not found", id)
 	}
-	// Find the target version in history.
+	vrows, err := ps.repo.GetPersonaVersions(id)
+	if err != nil {
+		return nil, err
+	}
 	var targetPrompt string
 	found := false
-	for _, h := range p.History {
-		if h.Version == targetVersion {
-			targetPrompt = h.Prompt
+	for _, v := range vrows {
+		if v.Version == targetVersion {
+			targetPrompt = v.Prompt
 			found = true
 			break
 		}
@@ -172,40 +136,68 @@ func (ps *PersonaStore) revert(id string, targetVersion int) (*Persona, error) {
 	if !found {
 		return nil, fmt.Errorf("version %d not found in history", targetVersion)
 	}
-	// Save current to history, then apply the old prompt.
-	p.History = append(p.History, PersonaVersion{
-		Version:   p.Version,
-		Prompt:    p.Prompt,
-		UpdatedAt: p.UpdatedAt,
-	})
-	p.Prompt = targetPrompt
-	p.Version++
-	p.UpdatedAt = time.Now().UTC()
-	if err := ps.save(); err != nil {
+	// Snapshot current before reverting.
+	if err := ps.repo.SavePersonaVersion(&bossdb.PersonaVersionRow{
+		PersonaID: id,
+		Version:   row.Version,
+		Prompt:    row.Prompt,
+		UpdatedAt: row.UpdatedAt,
+	}); err != nil {
 		return nil, err
 	}
-	cp := *p
-	return &cp, nil
+	row.Prompt = targetPrompt
+	row.Version++
+	row.UpdatedAt = time.Now().UTC()
+	if err := ps.repo.SavePersona(row); err != nil {
+		return nil, err
+	}
+	return personaFromRow(row), nil
 }
 
 func (ps *PersonaStore) delete(id string) error {
-	ps.mu.Lock()
-	defer ps.mu.Unlock()
-	if _, exists := ps.data[id]; !exists {
+	exists, err := ps.repo.PersonaExists(id)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		return fmt.Errorf("persona %q not found", id)
 	}
-	delete(ps.data, id)
-	return ps.save()
+	return ps.repo.DeletePersona(id)
 }
 
 // currentVersion returns the current version of persona id, or 0 if not found.
 func (ps *PersonaStore) currentVersion(id string) int {
-	ps.mu.RLock()
-	defer ps.mu.RUnlock()
-	if p := ps.data[id]; p != nil {
-		return p.Version
+	row, err := ps.repo.GetPersona(id)
+	if err != nil || row == nil {
+		return 0
 	}
-	return 0
+	return row.Version
+}
+
+// personaFromRow converts a DB row to a coordinator Persona.
+func personaFromRow(r *bossdb.PersonaRow) *Persona {
+	return &Persona{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		Prompt:      r.Prompt,
+		Version:     r.Version,
+		CreatedAt:   r.CreatedAt,
+		UpdatedAt:   r.UpdatedAt,
+	}
+}
+
+// personaToRow converts a coordinator Persona to a DB row.
+func personaToRow(p *Persona) *bossdb.PersonaRow {
+	return &bossdb.PersonaRow{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		Prompt:      p.Prompt,
+		Version:     p.Version,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
 }
 
 // assemblePersonaPrompt builds the combined persona prompt text for a set of PersonaRefs.

--- a/internal/coordinator/server.go
+++ b/internal/coordinator/server.go
@@ -124,7 +124,7 @@ func NewServer(port, dataDir string) *Server {
 		defaultBackend:       "tmux",
 		logger:               NewLogger(os.Stdout),
 		allowSkipPermissions: os.Getenv("BOSS_ALLOW_SKIP_PERMISSIONS") == "true",
-		personas:             newPersonaStore(dataDir),
+		personas:             nil, // initialized in Start() after DB is ready
 		apiToken:             os.Getenv("BOSS_API_TOKEN"),
 	}
 
@@ -209,6 +209,11 @@ func (s *Server) Start() error {
 		return fmt.Errorf("open db: %w", err)
 	}
 	s.repo = bossdb.New(gdb)
+	// Migrate personas from JSON file to SQLite on first run.
+	if err := s.repo.ImportPersonasFromJSON(s.dataDir); err != nil {
+		return fmt.Errorf("migrate personas: %w", err)
+	}
+	s.personas = newPersonaStore(s.repo)
 	// Wire the domain StoragePort adapter over the GORM repository.
 	s.storage = sqliteadapter.New(s.repo)
 	// With SQLite as the primary store, switch the event journal to in-memory

--- a/internal/coordinator/types.go
+++ b/internal/coordinator/types.go
@@ -783,7 +783,7 @@ type PersonaRef struct {
 }
 
 // Persona is a global, reusable prompt fragment that can be assigned to agents.
-// Personas are stored in DATA_DIR/personas.json and are independent of spaces.
+// Personas are stored in SQLite (personas table) and are independent of spaces.
 type Persona struct {
 	ID          string           `json:"id"`
 	Name        string           `json:"name"`


### PR DESCRIPTION
## Summary

- Personas were stored in `DATA_DIR/personas.json`, outside SQLite — inconsistent with every other entity in the system
- Adds `personas` and `persona_versions` tables to `boss.db` via GORM AutoMigrate
- Rewrites `PersonaStore` to use the DB repository instead of in-memory map + file I/O
- On first startup after upgrade, existing `personas.json` data is imported into SQLite automatically (idempotent — skips existing rows)
- `PersonaVersion` history rows are stored in a separate `persona_versions` table (normalized)

## Test plan
- [x] `go build ./internal/coordinator/...` — clean build
- [x] `go test -race ./internal/coordinator/` — all tests pass
- [x] `go test -race ./internal/domain/...` — boundary tests pass
- [x] `personas.go` stays under 600-line limit (572 lines)
- [x] Pre-commit hook passes

Closes TASK-074

🤖 Generated with [Claude Code](https://claude.com/claude-code)