### PR TITLE
fix(kanban): remove unused dueSortKey — TS6133 build error

### DIFF
--- a/frontend/src/components/KanbanView.vue
+++ b/frontend/src/components/KanbanView.vue
@@ -57,11 +57,6 @@ function isTaskOverdue(task: Task): boolean {
   return new Date(task.due_at) < now.value
 }
 
-function dueSortKey(task: Task): number {
-  if (!task.due_at) return Infinity
-  return new Date(task.due_at).getTime()
-}
-
 const filteredTasks = computed(() => {
   const search = filterSearch.value.trim().toLowerCase()
   return tasks.value.filter(t => {


### PR DESCRIPTION
## Summary
- Removes `dueSortKey()` function introduced in TASK-076 (PR #206) that was declared but never called
- `statusChangedSortKey()` handles all column sorting; `dueSortKey` was a leftover
- Fixes `TS6133: 'dueSortKey' is declared but its value is never read` blocking the build

## Test plan
- [ ] `vue-tsc -b --noEmit` passes clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)