### PR TITLE
feat(dx): git pre-commit hook for local TS typecheck enforcement (TASK-077)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run TypeScript typecheck if any frontend files are staged.
+# Install via: make install-hooks  (or git config core.hooksPath .githooks)
+
+set -euo pipefail
+
+# Check if any frontend TypeScript/Vue files are staged
+if git diff --cached --name-only | grep -qE '^frontend/'; then
+  echo "pre-commit: frontend files changed — running TypeScript typecheck..."
+  (cd "$(git rev-parse --show-toplevel)/frontend" && npx vue-tsc -b)
+  echo "pre-commit: TypeScript typecheck passed."
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,24 @@ Data survives restarts — SQLite DB (`DATA_DIR/boss.db`) is loaded on startup.
 The `garden` agent keeps the knowledge base current after every sprint. See **[docs/exec-plans/doc-gardening-agent.md](docs/exec-plans/doc-gardening-agent.md)** for the standing instructions — what to check, how to update grades, and how to open the PR.
 ## Linting
 
+### TypeScript typechecking
+
+Run the TypeScript typecheck locally before pushing:
+
+```bash
+make typecheck
+```
+
+To enforce this automatically on every commit, install the pre-commit hook:
+
+```bash
+make install-hooks
+```
+
+The hook runs `vue-tsc -b` in `frontend/` only when `.ts` or `.vue` files are staged. The same check runs as a standalone CI job (`typecheck`) on every PR in parallel with Go tests.
+
+### Go architecture + taste-invariant linters
+
 Run the architectural boundary and taste-invariant linters with:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,15 @@ REGISTRY      := default-route-openshift-image-registry.apps.okd1.timslab
 IMAGE_TAG     := latest
 IMAGE         := $(REGISTRY)/$(NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-.PHONY: build install build-image push-image deploy rollout dev-build dev-start dev-stop dev-restart dev-status dev-spawn e2e e2e-ui e2e-report e2e-dev e2e-screenshots typecheck
+.PHONY: build install build-image push-image deploy rollout dev-build dev-start dev-stop dev-restart dev-status dev-spawn e2e e2e-ui e2e-report e2e-dev e2e-screenshots typecheck install-hooks
 
 
 typecheck:
 	cd frontend && npx vue-tsc -b
+
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "Git hooks installed. Pre-commit hook will typecheck frontend on staged .ts/.vue files."
 
 build:
 	cd frontend && npm install && npm run build


### PR DESCRIPTION
## Summary

Follow-up to #209 (CI typecheck job) — adds local enforcement via a committable git hook.

- **`.githooks/pre-commit`**: runs `vue-tsc -b` in `frontend/` when `.ts`/`.vue` files are staged; no-op otherwise
- **`make install-hooks`**: one-time setup that runs `git config core.hooksPath .githooks` to activate the hook
- **CLAUDE.md**: documents both `make typecheck` (manual) and `make install-hooks` (automatic) workflows

## Why committable hooks (`.githooks/`) over `.git/hooks/`

`.git/hooks/` is not tracked by git — hooks installed there disappear on fresh clones. By storing hooks in `.githooks/` and activating via `git config core.hooksPath`, the hook is versioned with the repo and opt-in via a single `make install-hooks` call.

## Test plan

- [ ] Run `make install-hooks` → git config shows `core.hooksPath = .githooks`
- [ ] Stage a `.vue` or `.ts` file → pre-commit hook runs `vue-tsc -b`
- [ ] Introduce an unused local → commit blocked with typecheck failure
- [ ] Stage only Go/non-frontend files → hook skips typecheck entirely

Closes TASK-077 (git hook feedback from boss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)