### PR TITLE
fix(ux): usability sprint 2 — CR-5, H-04, H-11 (TASK-082)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1464,6 +1464,9 @@ onUnmounted(() => {
             <kbd class="px-2 py-0.5 rounded border bg-muted text-muted-foreground font-mono text-xs">i</kbd>
             <span>Switch to inbox tab (space overview)</span>
 
+            <kbd class="px-2 py-0.5 rounded border bg-muted text-muted-foreground font-mono text-xs">d</kbd>
+            <span>Go to Conversations view</span>
+
             <kbd class="px-2 py-0.5 rounded border bg-muted text-muted-foreground font-mono text-xs">[ ]</kbd>
             <span>Switch between spaces</span>
           </div>

--- a/frontend/src/components/ApprovalTray.vue
+++ b/frontend/src/components/ApprovalTray.vue
@@ -80,7 +80,7 @@ function agentToolInfo(name: string): { toolName: string; promptText: string } {
               </p>
               <p
                 v-if="agentToolInfo(agentName).promptText"
-                class="text-xs text-muted-foreground mt-1 line-clamp-2 font-mono bg-muted rounded px-1.5 py-1"
+                class="text-xs text-muted-foreground mt-1 font-mono bg-muted rounded px-1.5 py-1 break-all"
               >
                 {{ agentToolInfo(agentName).promptText }}
               </p>

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -184,6 +184,33 @@ const agentConversations = computed(() =>
   filteredConversations.value.filter(c => !c.participants.includes('boss')),
 )
 
+// Flat ordered list for keyboard navigation: boss conversations first, then agent ones
+const orderedConversations = computed(() => [
+  ...bossConversations.value,
+  ...agentConversations.value,
+])
+
+function handleListboxKeydown(e: KeyboardEvent) {
+  const list = orderedConversations.value
+  if (list.length === 0) return
+  const currentIdx = list.findIndex(c => c.key === selectedKey.value)
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    const next = currentIdx < list.length - 1 ? currentIdx + 1 : 0
+    selectedKey.value = list[next]!.key
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    const prev = currentIdx > 0 ? currentIdx - 1 : list.length - 1
+    selectedKey.value = list[prev]!.key
+  } else if (e.key === 'Home') {
+    e.preventDefault()
+    selectedKey.value = list[0]!.key
+  } else if (e.key === 'End') {
+    e.preventDefault()
+    selectedKey.value = list[list.length - 1]!.key
+  }
+}
+
 // selectedConversation — includes virtual entry for preselectAgent with no history
 const selectedConversation = computed((): Conversation | null => {
   const found = conversations.value.find(c => c.key === selectedKey.value)
@@ -659,7 +686,7 @@ watch(composeRecipient, async (agent) => {
           </button>
         </div>
 
-        <div v-else class="py-1" role="listbox" aria-label="Conversation list">
+        <div v-else class="py-1" role="listbox" aria-label="Conversation list" tabindex="0" @keydown="handleListboxKeydown">
           <!-- With Boss group -->
           <div v-if="bossConversations.length > 0">
             <div class="px-3 pt-2 pb-1 flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

Second usability sprint — three remaining fixes from the consolidated audit:

- **CR-5**: Arrow-key navigation for `role="listbox"` in ConversationsView.vue — the conversation list now accepts keyboard focus (`tabindex=0`) and responds to ↑/↓/Home/End to navigate between conversations, satisfying the WAI-ARIA listbox spec requirement
- **H-04**: Add `d` keyboard shortcut to help overlay — the shortcut existed in code but wasn't documented; now shows "Go to Conversations view" alongside the other shortcuts
- **H-11**: Remove `line-clamp-2` from ApprovalTray prompt text — full tool prompt is now visible without truncation; replaced with `break-all` for long mono strings

## Already resolved (confirmed in current main)

CR-2 (router catch-all ✓), CR-3 (TypeScript clean via `make typecheck` ✓), CR-4 (AlertDialog in TaskDetailPanel ✓), H-01 (KanbanView setInterval ✓), H-02 (dynamic data-active ✓), H-03 (no duplicate badge ✓), H-06 (inline error display ✓), H-10 (ApprovalTray button styles ✓)

## Test plan

- [ ] Open Conversations view — click into the conversation list panel then use ↑/↓ to navigate between threads, Home/End to jump to first/last
- [ ] Press `?` — verify `d` appears in the help overlay with "Go to Conversations view"
- [ ] Press `d` — verify navigates to conversations view
- [ ] Open ApprovalTray when an agent is pending — verify prompt text shows in full (no clamp)
- [ ] `make typecheck` passes clean

Closes TASK-082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)