### PR TITLE
fix(ux): usability sprint 3 — H-09, H-18, M-02, M-03 (TASK-084)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,6 +20,16 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
   Sheet,
   SheetContent,
   SheetHeader,
@@ -85,6 +95,7 @@ watch(soundEnabled, maybeShowAudioGuide)
 
 const loading = ref(true)
 const spaceLoading = ref(false)
+const nudgeAllConfirmOpen = ref(false)
 // Portal iris reveal — increments on each space switch to retrigger the animation
 const spaceRevealKey = ref(0)
 const errorMessage = ref<string | null>(null)
@@ -462,8 +473,14 @@ watch(currentSpace, (space) => {
 })
 
 // ── Action handlers ────────────────────────────────────────────────
-async function handleBroadcastSpace() {
+function handleBroadcastSpace() {
   if (!selectedSpace.value || broadcasting.value) return
+  nudgeAllConfirmOpen.value = true
+}
+
+async function confirmBroadcastSpace() {
+  if (!selectedSpace.value || broadcasting.value) return
+  nudgeAllConfirmOpen.value = false
   broadcasting.value = true
   try {
     await api.broadcastSpace(selectedSpace.value)
@@ -1571,6 +1588,22 @@ onUnmounted(() => {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    <!-- Nudge-all confirmation dialog -->
+    <AlertDialog v-model:open="nudgeAllConfirmOpen">
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Nudge all agents?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will send a check-in request to every agent in <strong>{{ selectedSpace }}</strong>. Each agent will receive a broadcast nudge.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction @click="confirmBroadcastSpace">Nudge all</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   </TooltipProvider>
 </template>
 

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -49,7 +49,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard, MessageSquare, Crown, Archive, User, Settings } from 'lucide-vue-next'
+import { Radio, AlertCircle, ChevronRight, MoreHorizontal, Trash2, Plus, LayoutDashboard, MessageSquare, Crown, Archive, ArchiveRestore, User, Settings } from 'lucide-vue-next'
 import AgentAvatar from './AgentAvatar.vue'
 
 const props = defineProps<{
@@ -77,7 +77,8 @@ const router = useRouter()
 const route = useRoute()
 
 function handleSelectSpace(name: string) {
-  router.push('/' + name)
+  // Only emit — App.vue's handleSelectSpace handles the router.push (with smart kanban/overview routing).
+  // Previously both emitted AND pushed, causing a route flash (double push).
   emit('select-space', name)
 }
 
@@ -341,7 +342,7 @@ defineExpose({ openNewSpaceDialog })
               </Tooltip>
               <Tooltip v-if="spaceAttentionCount(space) > 0">
                 <TooltipTrigger as-child>
-                  <SidebarMenuBadge class="flex items-center gap-1 text-amber-500 font-semibold group-hover/space-item:opacity-0 transition-opacity">
+                  <SidebarMenuBadge class="flex items-center gap-1 text-amber-500 font-semibold">
                     <AlertCircle class="size-3" aria-hidden="true" />
                     {{ spaceAttentionCount(space) }}
                   </SidebarMenuBadge>
@@ -350,7 +351,7 @@ defineExpose({ openNewSpaceDialog })
                   {{ spaceAttentionCount(space) }} item{{ spaceAttentionCount(space) !== 1 ? 's' : '' }} need{{ spaceAttentionCount(space) === 1 ? 's' : '' }} attention
                 </TooltipContent>
               </Tooltip>
-              <SidebarMenuBadge v-else :title="`${space.agent_count} agent${space.agent_count !== 1 ? 's' : ''} in this space`" class="group-hover/space-item:opacity-0 transition-opacity">
+              <SidebarMenuBadge v-else :title="`${space.agent_count} agent${space.agent_count !== 1 ? 's' : ''} in this space`">
                 {{ space.agent_count }}
               </SidebarMenuBadge>
               <!-- Space context menu -->
@@ -441,7 +442,7 @@ defineExpose({ openNewSpaceDialog })
                         class="cursor-pointer"
                         @click="emit('archive-space', space.name)"
                       >
-                        <Archive class="size-4 mr-2" aria-hidden="true" />
+                        <ArchiveRestore class="size-4 mr-2" aria-hidden="true" />
                         Unarchive space
                       </DropdownMenuItem>
                       <DropdownMenuItem


### PR DESCRIPTION
## Summary

Fixes 4 remaining usability issues from the consolidated audit (sprint 3). H-05, H-07, H-08, H-20 were already fixed in previous sprints.

**H-09: Fix double router.push on space selection (route flash)**
`AppSidebar.handleSelectSpace` was pushing `'/:space'` AND emitting `select-space`, causing `App.vue`'s `handleSelectSpace` to push again (to kanban or overview). Removed the sidebar's own push — App.vue owns routing.

**H-18: Add AlertDialog confirmation before nudge-all broadcast**
Clicking "Check in all agents" / "Nudge All" previously fired immediately. Now shows an AlertDialog with space name context before broadcasting.

**M-02: Keep sidebar attention badge visible on hover**
Removed `group-hover/space-item:opacity-0` from both badge variants — attention counts and agent counts no longer disappear when hovering a space item.

**M-03: Use ArchiveRestore icon for "Unarchive space"**
The "Unarchive space" dropdown item was using the `Archive` icon. Changed to `ArchiveRestore` which correctly signals restoring from archive.

## Test plan
- [ ] `make typecheck` passes
- [ ] Click a space in sidebar — no route flash, goes directly to correct view (kanban if agents, overview if empty)
- [ ] Click "Nudge All" — AlertDialog appears before broadcast fires
- [ ] Hover a space with attention count — amber badge stays visible
- [ ] Open archived spaces — "Unarchive space" shows restore icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)