### PR TITLE
perf(frontend): debounce hierarchy/messages, gate SSE poll, GPU animations (TASK-091)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -762,8 +762,21 @@ function scheduleSpacesReload(delayMs = 1000) {
   }, delayMs)
 }
 
+// Debounced hierarchy reload — hierarchy changes are rare and effectiveHierarchy
+// computes client-side from agent.parent fields. Batch rapid agent_updated bursts
+// into a single fetch; 500ms delay avoids hammering /hierarchy on busy fleets.
+let _hierarchyReloadTimer: ReturnType<typeof setTimeout> | null = null
+function scheduleHierarchyReload(space: string, delayMs = 500) {
+  if (_hierarchyReloadTimer !== null) clearTimeout(_hierarchyReloadTimer)
+  _hierarchyReloadTimer = setTimeout(() => {
+    _hierarchyReloadTimer = null
+    loadHierarchy(space)
+  }, delayMs)
+}
+
 function setupSSE() {
   sse.on('agent_updated', (data) => {
+    lastSSEEventMs = Date.now()
     // Capture prevStatus BEFORE the in-place patch so mood/alert transitions fire correctly.
     const prevStatus = currentSpace.value?.agents[data.agent]?.status
     // Patch agent in-place immediately for instant UI feedback — no HTTP round-trip.
@@ -781,8 +794,10 @@ function setupSSE() {
         // New agent in this space — fetch immediately so it appears without delay
         loadSpace(data.space)
       }
-      // Refresh hierarchy in case parent/children changed
-      loadHierarchy(data.space)
+      // Refresh hierarchy in case parent/children changed — debounced to avoid
+      // 13+ concurrent requests on busy fleets. effectiveHierarchy computes
+      // client-side; this just keeps the fallback hierarchyTree in sync.
+      scheduleHierarchyReload(data.space)
     }
     // Update sidebar attention counts — debounced to avoid per-keystroke fetches
     scheduleSpacesReload()
@@ -940,13 +955,17 @@ function setupSSE() {
 // ── Polling fallback ───────────────────────────────────────────────
 // SSE handles real-time updates. Polling is a reliability fallback only —
 // 15s interval since SSE covers most updates. Skip polls when tab is hidden.
+// Skip polls when SSE is healthy and has delivered an event in the last 15s.
 const POLL_INTERVAL_MS = 15000
+let lastSSEEventMs = 0
 
 function startPolling() {
   stopPolling()
   pollTimer = setInterval(() => {
     // No point fetching when the tab isn't visible
     if (document.hidden) return
+    // SSE is healthy and recent — polling would be redundant
+    if (sse.connected.value && Date.now() - lastSSEEventMs < 15000) return
     if (selectedSpace.value) {
       loadSpace(selectedSpace.value)
       loadSessionStatus(selectedSpace.value)

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -855,13 +855,24 @@ defineExpose({ openNewSpaceDialog })
 }
 
 /* Status dot animations — pulse, breathe, jitter */
+/* GPU-accelerated sonar ping: ::after uses transform+opacity (compositor only),
+   replacing the former box-shadow animation which forced CPU paint every frame. */
 .dot-pulse-active {
+  overflow: visible;
+}
+.dot-pulse-active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-color: rgba(34, 197, 94, 0.7);
   animation: dot-sonar-ping 2s ease-out infinite;
+  pointer-events: none;
 }
 @keyframes dot-sonar-ping {
-  0%   { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7); }
-  60%  { box-shadow: 0 0 0 6px rgba(34, 197, 94, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+  0%   { transform: scale(1);   opacity: 0.7; }
+  60%  { transform: scale(2.5); opacity: 0; }
+  100% { transform: scale(2.5); opacity: 0; }
 }
 
 .dot-breathe-idle {
@@ -910,5 +921,6 @@ defineExpose({ openNewSpaceDialog })
   .agent-spawn { animation: none; }
   .typing-dots span { animation: none; opacity: 0.6; }
   .dot-pulse-active, .dot-breathe-idle, .dot-jitter-blocked { animation: none; }
+  .dot-pulse-active::after { animation: none; }
 }
 </style>

--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -110,16 +110,26 @@ watch(() => props.space.name, loadSpaceMessages)
 // Subscribe to SSE agent_message events so conversations refresh in real time.
 // Post PR #195, messages aren't embedded in the space JSON — the only source of
 // truth is the /messages API, so we must re-fetch when new messages arrive.
+// Debounced to 500ms to batch rapid bursts (e.g. bulk message deliveries).
 const sse = useSSE()
 let _unsubMessage: (() => void) | null = null
+let _msgReloadTimer: ReturnType<typeof setTimeout> | null = null
+function scheduleMessagesReload() {
+  if (_msgReloadTimer !== null) clearTimeout(_msgReloadTimer)
+  _msgReloadTimer = setTimeout(() => {
+    _msgReloadTimer = null
+    loadSpaceMessages()
+  }, 500)
+}
 onMounted(() => {
   _unsubMessage = sse.on('agent_message', (data) => {
     if (data.space === props.space.name) {
-      loadSpaceMessages()
+      scheduleMessagesReload()
     }
   })
 })
 onUnmounted(() => {
+  if (_msgReloadTimer !== null) clearTimeout(_msgReloadTimer)
   _unsubMessage?.()
 })
 


### PR DESCRIPTION
## Summary

Frontend performance fixes from TASK-091 investigation (child of TASK-085).

### P1 — High-frequency SSE event optimizations

**1. Debounce `loadHierarchy` on `agent_updated`** (`App.vue`)
- Direct `loadHierarchy()` call fired on every SSE event → 13+ concurrent hierarchy requests on busy fleets
- Added `scheduleHierarchyReload(space, 500ms)` following the existing `scheduleSpaceReload` pattern
- Safe: `effectiveHierarchy` computed already builds the tree client-side from `currentSpace.value.agents`; the HTTP call only refreshes the API fallback

**2. Gate 15s polling fallback on SSE health** (`App.vue`)
- Poll fired unconditionally every 15s even when SSE was healthy
- Added `lastSSEEventMs` tracking (set on `agent_updated`) + 2-line guard: skip poll when `sse.connected && age < 15s`
- Eliminates redundant full-space fetches during healthy SSE sessions

**3. Debounce `loadSpaceMessages` in ConversationsView** (`ConversationsView.vue`)
- Every `agent_message` SSE event immediately triggered a 300-500KB messages fetch
- Added `scheduleMessagesReload()` with 500ms debounce, batching message bursts into one request

### P2 — GPU animation optimization

**4. GPU-accelerate `dot-sonar-ping`** (`AppSidebar.vue`)
- Old: `box-shadow` keyframe animation → CPU paint every frame × N active agents
- New: `::after` pseudo-element with `transform: scale()` + `opacity` → pure compositor, zero paint
- `prefers-reduced-motion` query extended to cover `::after`

### Not in this PR
- Item 4 (SSE extended payload, `agent_updated` in-place patch) → depends on arch TASK-090
- `pr-shimmer` GPU migration → needs fuller redesign to preserve text-clip effect

## Test plan
- [ ] TypeScript typecheck: `npx vue-tsc -b` — passes clean
- [ ] Busy fleet (10+ agents posting): confirm hierarchy endpoint no longer receives concurrent requests per update
- [ ] Verified: with SSE active, 15s poll skipped; after SSE disconnect, poll resumes normally
- [ ] Sonar ping animation visually unchanged, but now GPU-composited

🤖 Generated with [Claude Code](https://claude.com/claude-code)