### PR TITLE
perf(db): snapshot per-agent row cap + GetMessages LIMIT (TASK-111)

### DIFF
--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -133,9 +133,15 @@ func (r *Repository) SaveMessage(m *AgentMessage) error {
 	}).Create(m).Error
 }
 
+// messageQueryLimit caps the number of messages returned per GetMessages call
+// to prevent unbounded full-table scans on busy spaces.
+const messageQueryLimit = 500
+
 // GetMessages returns messages for an agent, optionally since a timestamp.
+// Results are capped at messageQueryLimit rows to bound query cost.
 func (r *Repository) GetMessages(spaceName, agentName string, since *time.Time) ([]*AgentMessage, error) {
-	q := r.db.Where("space_name = ? AND agent_name = ?", spaceName, agentName).Order("timestamp ASC")
+	q := r.db.Where("space_name = ? AND agent_name = ?", spaceName, agentName).
+		Order("timestamp ASC").Limit(messageQueryLimit)
 	if since != nil {
 		q = q.Where("timestamp > ?", *since)
 	}
@@ -342,11 +348,37 @@ func (r *Repository) GetSnapshots(spaceName string, agentName string, since *tim
 	return snaps, q.Find(&snaps).Error
 }
 
-// PruneOldSnapshots deletes status_snapshots older than the given cutoff.
-// Keeps at most keepPerAgent recent rows per (space_name, agent_name) pair beyond the cutoff.
+// snapshotPerAgentCap is the maximum number of status_snapshots rows retained
+// per (space_name, agent_name) pair. Rows beyond this cap are deleted oldest-first,
+// regardless of age. At ~34k rows/day across all agents this keeps the table small.
+const snapshotPerAgentCap = 500
+
+// PruneOldSnapshots deletes status_snapshots older than the given cutoff AND
+// enforces a per-agent row cap (snapshotPerAgentCap) on the remaining rows.
+// The two steps run sequentially; errors in either step are returned.
 // Called from a background goroutine; errors are logged by the caller.
 func (r *Repository) PruneOldSnapshots(cutoff time.Time) error {
-	return r.db.Where("timestamp < ?", cutoff).Delete(&StatusSnapshot{}).Error
+	// Step 1: age-based deletion — remove rows older than the retention window.
+	if err := r.db.Where("timestamp < ?", cutoff).Delete(&StatusSnapshot{}).Error; err != nil {
+		return fmt.Errorf("prune by age: %w", err)
+	}
+
+	// Step 2: per-agent row cap — for each (space_name, agent_name) pair, keep only
+	// the most recent snapshotPerAgentCap rows and delete the rest.
+	// SQLite window functions are available since SQLite 3.25 (2018).
+	return r.db.Exec(`
+		DELETE FROM status_snapshots
+		WHERE id IN (
+			SELECT id FROM (
+				SELECT id,
+				       ROW_NUMBER() OVER (
+				           PARTITION BY space_name, agent_name
+				           ORDER BY timestamp DESC
+				       ) AS rn
+				FROM status_snapshots
+			) ranked
+			WHERE rn > ?
+		)`, snapshotPerAgentCap).Error
 }
 
 // ---- SpaceEventLog operations ----

--- a/internal/coordinator/db/repository_test.go
+++ b/internal/coordinator/db/repository_test.go
@@ -1,0 +1,170 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	glebarez "github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// openTestDB opens an in-memory SQLite DB with the full schema applied.
+func openTestDB(t *testing.T) *Repository {
+	t.Helper()
+	db, err := gorm.Open(glebarez.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return New(db)
+}
+
+// mustSaveSnapshot is a test helper that creates a snapshot and fails the test on error.
+func mustSaveSnapshot(t *testing.T, repo *Repository, spaceName, agentName string, ts time.Time) {
+	t.Helper()
+	if err := repo.SaveSnapshot(&StatusSnapshot{
+		SpaceName: spaceName,
+		AgentName: agentName,
+		Status:    "active",
+		Timestamp: ts,
+	}); err != nil {
+		t.Fatalf("SaveSnapshot: %v", err)
+	}
+}
+
+// ─── PruneOldSnapshots — age-based cutoff ────────────────────────────────────
+
+func TestPruneOldSnapshotsAgeCutoff(t *testing.T) {
+	repo := openTestDB(t)
+
+	old := time.Now().UTC().Add(-48 * time.Hour)
+	recent := time.Now().UTC()
+
+	mustSaveSnapshot(t, repo, "s", "a", old)
+	mustSaveSnapshot(t, repo, "s", "a", recent)
+
+	cutoff := time.Now().UTC().Add(-24 * time.Hour)
+	if err := repo.PruneOldSnapshots(cutoff); err != nil {
+		t.Fatalf("PruneOldSnapshots: %v", err)
+	}
+
+	snaps, err := repo.GetSnapshots("s", "a", nil)
+	if err != nil {
+		t.Fatalf("GetSnapshots: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Errorf("want 1 snapshot after age prune, got %d", len(snaps))
+	}
+}
+
+// ─── PruneOldSnapshots — per-agent row cap ────────────────────────────────────
+
+func TestPruneOldSnapshotsPerAgentCap(t *testing.T) {
+	repo := openTestDB(t)
+
+	// Insert snapshotPerAgentCap + 10 rows for a single agent, all within retention window.
+	base := time.Now().UTC().Add(-1 * time.Hour)
+	for i := 0; i < snapshotPerAgentCap+10; i++ {
+		mustSaveSnapshot(t, repo, "s", "agent", base.Add(time.Duration(i)*time.Minute))
+	}
+
+	// Prune with a cutoff far in the past (age prune removes nothing; cap applies).
+	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	if err := repo.PruneOldSnapshots(cutoff); err != nil {
+		t.Fatalf("PruneOldSnapshots: %v", err)
+	}
+
+	snaps, err := repo.GetSnapshots("s", "agent", nil)
+	if err != nil {
+		t.Fatalf("GetSnapshots: %v", err)
+	}
+	if len(snaps) > snapshotPerAgentCap {
+		t.Errorf("want at most %d snapshots per agent after cap, got %d", snapshotPerAgentCap, len(snaps))
+	}
+}
+
+func TestPruneOldSnapshotsPerAgentCapIsolated(t *testing.T) {
+	repo := openTestDB(t)
+
+	// Two agents each with cap+5 rows. Cap should be enforced independently.
+	base := time.Now().UTC().Add(-1 * time.Hour)
+	for _, agent := range []string{"alice", "bob"} {
+		for i := 0; i < snapshotPerAgentCap+5; i++ {
+			mustSaveSnapshot(t, repo, "s", agent, base.Add(time.Duration(i)*time.Minute))
+		}
+	}
+
+	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	if err := repo.PruneOldSnapshots(cutoff); err != nil {
+		t.Fatalf("PruneOldSnapshots: %v", err)
+	}
+
+	for _, agent := range []string{"alice", "bob"} {
+		snaps, err := repo.GetSnapshots("s", agent, nil)
+		if err != nil {
+			t.Fatalf("GetSnapshots(%s): %v", agent, err)
+		}
+		if len(snaps) > snapshotPerAgentCap {
+			t.Errorf("agent %s: want at most %d snapshots, got %d", agent, snapshotPerAgentCap, len(snaps))
+		}
+	}
+}
+
+// ─── GetMessages LIMIT ────────────────────────────────────────────────────────
+
+func TestGetMessagesLimit(t *testing.T) {
+	repo := openTestDB(t)
+
+	// Insert messageQueryLimit + 50 messages for the same agent.
+	base := time.Now().UTC().Add(-1 * time.Hour)
+	for i := 0; i < messageQueryLimit+50; i++ {
+		repo.db.Create(&AgentMessage{
+			ID:        fmt.Sprintf("msg-%05d", i),
+			SpaceName: "s",
+			AgentName: "agent",
+			Sender:    "boss",
+			Message:   fmt.Sprintf("message %d", i),
+			Priority:  "info",
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	msgs, err := repo.GetMessages("s", "agent", nil)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) > messageQueryLimit {
+		t.Errorf("GetMessages should return at most %d messages, got %d", messageQueryLimit, len(msgs))
+	}
+}
+
+func TestGetMessagesSpaceFilter(t *testing.T) {
+	repo := openTestDB(t)
+
+	// Insert messages for two different spaces with the same agent name.
+	repo.db.Create(&AgentMessage{
+		ID: "msg-s1", SpaceName: "space1", AgentName: "agent",
+		Sender: "boss", Message: "s1", Priority: "info", Timestamp: time.Now().UTC(),
+	})
+	repo.db.Create(&AgentMessage{
+		ID: "msg-s2", SpaceName: "space2", AgentName: "agent",
+		Sender: "boss", Message: "s2", Priority: "info", Timestamp: time.Now().UTC(),
+	})
+
+	msgs, err := repo.GetMessages("space1", "agent", nil)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Errorf("want 1 message for space1, got %d", len(msgs))
+	}
+	if len(msgs) == 1 && msgs[0].ID != "msg-s1" {
+		t.Errorf("expected msg-s1, got %q", msgs[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary

Two backend stability/correctness fixes from the perf sprint.

### P0-1: status_snapshots per-agent row cap

`PruneOldSnapshots` now enforces a **500-row cap per `(space_name, agent_name)` pair** via SQLite window function (`ROW_NUMBER() OVER PARTITION BY`), in addition to the existing 7-day age cutoff. This bounds table growth to ~500 rows × N agents regardless of status update frequency, eliminating the observed 34k rows/day unbounded growth that would reach 1M rows in weeks.

The cap runs on the existing 6h background ticker — no new goroutines or infrastructure needed.

### P1-7: GetMessages LIMIT

`GetMessages` now caps results at 500 rows (`messageQueryLimit`) to prevent full-table scans on spaces with high message volume.

### P2-1/P2-2/P2-3 verified (already fixed in TASK-090 / PR #223)

- GetTask space_name filter: ✅ already present on task + comments + events queries
- status_changed_at DDL: ✅ already included in migrateTasksCompositeKey recreate SQL
- NextTaskSeqForSpace: ✅ already wrapped in a transaction

## New tests (5, all pass with `-race`)

| Test | Covers |
|------|--------|
| `TestPruneOldSnapshotsAgeCutoff` | Age-based deletion keeps recent rows |
| `TestPruneOldSnapshotsPerAgentCap` | Cap enforced for single agent |
| `TestPruneOldSnapshotsPerAgentCapIsolated` | Cap enforced independently per agent pair |
| `TestGetMessagesLimit` | Returns at most `messageQueryLimit` rows |
| `TestGetMessagesSpaceFilter` | Messages correctly isolated by space |

Closes TASK-111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)