### PR TITLE
fix(frontend): prevent duplicate message on send in ConversationsView

### DIFF
--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -506,26 +506,33 @@ async function sendInlineCompose() {
   if (!text || !recipient) return
   inlineSending.value = true
   inlineSendError.value = null
+
+  // Optimistic: inject the sent message BEFORE the API call so it is in the
+  // bucket when the SSE event arrives (the server fires SSE before returning
+  // the HTTP response, so pushing after the await causes a duplicate).
+  const optimisticId = `optimistic-${Date.now()}`
+  const optimistic: AgentMessage = {
+    id: optimisticId,
+    message: text,
+    sender: 'boss',
+    timestamp: new Date().toISOString(),
+    read: true,
+  }
+  const bucket = spaceMessages.value[recipient]
+  if (bucket) {
+    bucket.messages.push(optimistic)
+  } else {
+    spaceMessages.value[recipient] = { messages: [optimistic], has_more: false }
+  }
+  scrollThreadToBottom()
+
   try {
     await api.sendMessage(props.space.name, recipient, text, 'boss')
     inlineMessage.value = ''
-    // Optimistic: inject the sent message so it appears immediately without
-    // waiting for the SSE round-trip + API re-fetch.
-    const optimistic: AgentMessage = {
-      id: `optimistic-${Date.now()}`,
-      message: text,
-      sender: 'boss',
-      timestamp: new Date().toISOString(),
-      read: true,
-    }
-    const bucket = spaceMessages.value[recipient]
-    if (bucket) {
-      bucket.messages.push(optimistic)
-    } else {
-      spaceMessages.value[recipient] = { messages: [optimistic], has_more: false }
-    }
-    scrollThreadToBottom()
   } catch (err) {
+    // Roll back the optimistic message on failure.
+    const b = spaceMessages.value[recipient]
+    if (b) b.messages = b.messages.filter(m => m.id !== optimisticId)
     inlineSendError.value = err instanceof Error ? err.message : 'Failed to send message'
   } finally {
     inlineSending.value = false


### PR DESCRIPTION
## Problem

When boss sends a message in the Conversations view, the message appears twice — then disappears to one on page reload.

## Root Cause

Race between the optimistic update and the SSE event:

1. `sendInlineCompose()` calls `await api.sendMessage()`
2. The server saves the message and **fires the SSE `agent_message` event before returning the HTTP response**
3. The browser receives the SSE event and adds the message to the bucket
4. `api.sendMessage()` resolves, code continues
5. The optimistic push adds the message **again** → duplicate visible

The existing SSE dedup check (`last.message === incoming.message`) was designed to prevent SSE from duplicating an optimistic message, but the ordering was reversed — SSE arrived first.

## Fix

Move the optimistic push to **before** the `await api.sendMessage()` call. This ensures the message is in the bucket before any SSE event can arrive, so the existing dedup correctly suppresses the SSE copy.

On send failure: the optimistic message is filtered out by its generated ID.

## Test Plan
- [ ] Send a message in Conversations view — should appear once immediately
- [ ] Reload page — should still show once
- [ ] Simulate send failure — optimistic message should disappear
- [ ] TypeScript typecheck passes (`make typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)