### PR TITLE
fix(ux): show conversation unreads in notification bell and space button (TASK-130)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -221,18 +221,13 @@ const showKanban = computed(() => route.name === 'kanban')
 const showPersonas = computed(() => false)
 const showSettings = computed(() => false)
 
-// Pending decision count across all agents in current space
+// Boss conversation unread count for the notification bell.
+// Message bodies are stripped from the space API response (post-PR #195),
+// so iterating messages client-side always yields 0. Read unread_count directly —
+// it is kept current by the agent_message SSE handler patch at line ~931.
 const pendingDecisionCount = computed(() => {
   if (!currentSpace.value) return 0
-  let count = 0
-  for (const agent of Object.values(currentSpace.value.agents ?? {})) {
-    const a = agent as any
-    const messages = a?.messages || a?.Messages || []
-    for (const msg of messages) {
-      if (msg.type === 'decision' && !msg.resolved) count++
-    }
-  }
-  return count
+  return (currentSpace.value.agents['boss'] as any)?.unread_count ?? 0
 })
 
 const selectedAgentData = computed<AgentUpdate | null>(() => {

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -216,6 +216,14 @@ function spaceAttentionCount(space: SpaceSummary): number {
   return space.attention_count ?? 0
 }
 
+// Unread message count for boss in a space: current space reads live data, others use server summary.
+function spaceBossUnreadCount(space: SpaceSummary): number {
+  if (space.name === props.selectedSpace && props.currentSpace) {
+    return (props.currentSpace.agents['boss'] as any)?.unread_count ?? 0
+  }
+  return space.boss_unread_count ?? 0
+}
+
 // Count questions + blockers for a specific agent
 function agentAttentionCount(agent: { questions?: string[]; blockers?: string[] }): number {
   return (agent.questions?.length ?? 0) + (agent.blockers?.length ?? 0)
@@ -343,7 +351,18 @@ defineExpose({ openNewSpaceDialog })
                   <div class="text-xs text-muted-foreground">Last active: {{ relativeTime(space.updated_at) }}</div>
                 </TooltipContent>
               </Tooltip>
-              <Tooltip v-if="spaceAttentionCount(space) > 0">
+              <Tooltip v-if="spaceBossUnreadCount(space) > 0">
+                <TooltipTrigger as-child>
+                  <SidebarMenuBadge class="flex items-center gap-1 text-violet-500 font-semibold">
+                    <MessageSquare class="size-3" aria-hidden="true" />
+                    {{ spaceBossUnreadCount(space) }}
+                  </SidebarMenuBadge>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  {{ spaceBossUnreadCount(space) }} unread message{{ spaceBossUnreadCount(space) !== 1 ? 's' : '' }} for boss
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip v-else-if="spaceAttentionCount(space) > 0">
                 <TooltipTrigger as-child>
                   <SidebarMenuBadge class="flex items-center gap-1 text-amber-500 font-semibold">
                     <AlertCircle class="size-3" aria-hidden="true" />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -141,6 +141,7 @@ export interface SpaceSummary {
   name: string
   agent_count: number
   attention_count: number
+  boss_unread_count?: number
   archive?: string
   created_at: string
   updated_at: string

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -48,30 +48,40 @@ func (s *Server) handleListSpaces(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type spaceSummary struct {
-		Name           string    `json:"name"`
-		AgentCount     int       `json:"agent_count"`
-		AttentionCount int       `json:"attention_count"`
-		Archive        string    `json:"archive,omitempty"`
-		CreatedAt      time.Time `json:"created_at"`
-		UpdatedAt      time.Time `json:"updated_at"`
+		Name            string    `json:"name"`
+		AgentCount      int       `json:"agent_count"`
+		AttentionCount  int       `json:"attention_count"`
+		BossUnreadCount int       `json:"boss_unread_count,omitempty"`
+		Archive         string    `json:"archive,omitempty"`
+		CreatedAt       time.Time `json:"created_at"`
+		UpdatedAt       time.Time `json:"updated_at"`
 	}
 
 	s.mu.RLock()
 	summaries := make([]spaceSummary, 0, len(s.spaces))
 	for _, ks := range s.spaces {
 		attention := 0
-		for _, rec := range ks.Agents {
+		bossUnread := 0
+		for name, rec := range ks.Agents {
 			if rec != nil && rec.Status != nil {
 				attention += len(rec.Status.Questions) + len(rec.Status.Blockers)
+				if strings.EqualFold(name, "boss") {
+					for _, m := range rec.Status.Messages {
+						if !m.Read {
+							bossUnread++
+						}
+					}
+				}
 			}
 		}
 		summaries = append(summaries, spaceSummary{
-			Name:           ks.Name,
-			AgentCount:     len(ks.Agents),
-			AttentionCount: attention,
-			Archive:        ks.Archive,
-			CreatedAt:      ks.CreatedAt,
-			UpdatedAt:      ks.UpdatedAt,
+			Name:            ks.Name,
+			AgentCount:      len(ks.Agents),
+			AttentionCount:  attention,
+			BossUnreadCount: bossUnread,
+			Archive:         ks.Archive,
+			CreatedAt:       ks.CreatedAt,
+			UpdatedAt:       ks.UpdatedAt,
 		})
 	}
 	s.mu.RUnlock()


### PR DESCRIPTION
## Summary

- **Root cause 1 (notification bell)**: `pendingDecisionCount` in `App.vue` read `a?.messages` to count unreads, but message bodies are stripped from the space API response (post-PR #195). This always evaluated to 0, so the bell never lit up for boss messages. Fixed by reading `boss.unread_count` directly — this field is kept current by the SSE `agent_message` patch handler.

- **Root cause 2 (space button sidebar)**: The `/spaces` list API only included `attention_count` (questions + blockers), not boss message unreads. Space buttons in the sidebar had no data to show a badge. Fixed by adding `boss_unread_count` to `spaceSummary` in the backend list handler (computed from boss agent's unread messages) and rendering a priority violet MessageSquare badge in AppSidebar when non-zero.

## Changes

| File | Change |
|------|--------|
| `internal/coordinator/handlers_space.go` | Added `BossUnreadCount` to `spaceSummary` struct; computed in `/spaces` list loop |
| `frontend/src/types/index.ts` | Added `boss_unread_count?: number` to `SpaceSummary` interface |
| `frontend/src/App.vue` | `pendingDecisionCount` reads `boss.unread_count` directly |
| `frontend/src/components/AppSidebar.vue` | Added `spaceBossUnreadCount()` + violet MessageSquare badge on space buttons |

## Test plan

- [ ] Send a message to boss in any space; verify the notification bell shows a count
- [ ] Verify the space button in the sidebar shows a violet message badge when boss has unread messages
- [ ] Switch between spaces; verify the badge reflects each space's unread count independently
- [ ] Mark messages as read; verify counts decrement

🤖 Generated with [Claude Code](https://claude.com/claude-code)