### PR TITLE
feat(fleet): add repos list to agent-compose YAML for ambient sessions

### DIFF
--- a/cmd/boss/fleet.go
+++ b/cmd/boss/fleet.go
@@ -431,12 +431,18 @@ func fleetApply(client *coordinator.Client, ff *coordinator.FleetFile, spaceName
 		for _, pid := range fa.Personas {
 			personaRefs = append(personaRefs, coordinator.PersonaRef{ID: pid})
 		}
+		// Convert FleetRepo → SessionRepo.
+		sessionRepos := make([]coordinator.SessionRepo, 0, len(fa.Repos))
+		for _, fr := range fa.Repos {
+			sessionRepos = append(sessionRepos, coordinator.SessionRepo{URL: fr.URL, Branch: fr.Branch})
+		}
 		cfg := &coordinator.AgentConfig{
 			WorkDir:       fa.WorkDir,
 			InitialPrompt: fa.InitialPrompt,
 			Backend:       fa.Backend,
 			Command:       fa.Command,
 			RepoURL:       fa.RepoURL,
+			Repos:         sessionRepos,
 			Model:         fa.Model,
 			Personas:      personaRefs,
 		}
@@ -469,10 +475,26 @@ func fleetAgentConfigDiff(cfg *coordinator.AgentConfig, fa coordinator.FleetAgen
 	if fa.RepoURL != "" && cfg.RepoURL != fa.RepoURL {
 		diffs = append(diffs, "repo_url")
 	}
+	if len(fa.Repos) > 0 && !reposEqual(cfg.Repos, fa.Repos) {
+		diffs = append(diffs, "repos")
+	}
 	if fa.Model != "" && cfg.Model != fa.Model {
 		diffs = append(diffs, "model")
 	}
 	return diffs
+}
+
+// reposEqual returns true if the stored SessionRepo list matches the fleet FleetRepo list.
+func reposEqual(stored []coordinator.SessionRepo, fleet []coordinator.FleetRepo) bool {
+	if len(stored) != len(fleet) {
+		return false
+	}
+	for i := range stored {
+		if stored[i].URL != fleet[i].URL || stored[i].Branch != fleet[i].Branch {
+			return false
+		}
+	}
+	return true
 }
 
 // printPromptDiff prints a line-by-line diff of two prompt strings.

--- a/internal/coordinator/fleet.go
+++ b/internal/coordinator/fleet.go
@@ -43,18 +43,25 @@ type FleetPersona struct {
 	Prompt      string `yaml:"prompt"`
 }
 
+// FleetRepo is a git repository reference in the fleet file.
+type FleetRepo struct {
+	URL    string `yaml:"url"`
+	Branch string `yaml:"branch,omitempty"`
+}
+
 // FleetAgent is one agent's config entry in the fleet file.
 type FleetAgent struct {
-	Role          string   `yaml:"role,omitempty"`
-	Description   string   `yaml:"description,omitempty"`
-	Parent        string   `yaml:"parent,omitempty"`
-	Personas      []string `yaml:"personas,omitempty"`
-	WorkDir       string   `yaml:"work_dir,omitempty"`
-	Backend       string   `yaml:"backend"`    // always explicit for round-trip fidelity
-	Command       string   `yaml:"command"`    // always explicit
-	InitialPrompt string   `yaml:"initial_prompt,omitempty"`
-	RepoURL       string   `yaml:"repo_url,omitempty"` // userinfo stripped on export
-	Model         string   `yaml:"model,omitempty"`
+	Role          string      `yaml:"role,omitempty"`
+	Description   string      `yaml:"description,omitempty"`
+	Parent        string      `yaml:"parent,omitempty"`
+	Personas      []string    `yaml:"personas,omitempty"`
+	WorkDir       string      `yaml:"work_dir,omitempty"`
+	Backend       string      `yaml:"backend"`    // always explicit for round-trip fidelity
+	Command       string      `yaml:"command"`    // always explicit
+	InitialPrompt string      `yaml:"initial_prompt,omitempty"`
+	RepoURL       string      `yaml:"repo_url,omitempty"` // userinfo stripped on export
+	Repos         []FleetRepo `yaml:"repos,omitempty"`    // git repos for ambient sessions
+	Model         string      `yaml:"model,omitempty"`
 }
 
 // ─── Export handler ───────────────────────────────────────────────────────────
@@ -117,6 +124,19 @@ func (s *Server) handleSpaceExport(w http.ResponseWriter, r *http.Request, space
 			}
 		}
 
+		// Convert SessionRepo → FleetRepo (strip userinfo from each URL).
+		var fleetRepos []FleetRepo
+		for _, sr := range cfg.Repos {
+			repoU := sr.URL
+			if repoU != "" {
+				if u, err := url.Parse(repoU); err == nil {
+					u.User = nil
+					repoU = u.String()
+				}
+			}
+			fleetRepos = append(fleetRepos, FleetRepo{URL: repoU, Branch: sr.Branch})
+		}
+
 		// Determine role/parent from runtime status if not in config.
 		role := ""
 		parent := ""
@@ -144,6 +164,7 @@ func (s *Server) handleSpaceExport(w http.ResponseWriter, r *http.Request, space
 			Command:       command,
 			InitialPrompt: cfg.InitialPrompt,
 			RepoURL:       repoURL,
+			Repos:         fleetRepos,
 			Model:         cfg.Model,
 		}
 	}

--- a/internal/coordinator/fleet_test.go
+++ b/internal/coordinator/fleet_test.go
@@ -84,6 +84,82 @@ func TestHandleSpaceExport(t *testing.T) {
 	}
 }
 
+func TestHandleSpaceExportRepos(t *testing.T) {
+	srv, stop := mustStartServer(t)
+	defer stop()
+	base := serverBaseURL(srv)
+
+	space := "export-repos-test"
+	agent := "ambient-worker"
+
+	postJSON(t, fmt.Sprintf("%s/spaces/%s/agent/%s", base, space, agent), &AgentUpdate{
+		Status:  StatusActive,
+		Summary: "working",
+	})
+
+	srv.mu.Lock()
+	ks := srv.spaces[space]
+	if ks.Agents[agent] == nil {
+		ks.Agents[agent] = &AgentRecord{}
+	}
+	ks.Agents[agent].Config = &AgentConfig{
+		Backend: "ambient",
+		Command: "claude",
+		Repos: []SessionRepo{
+			{URL: "https://user:token@gitea.example.com/org/repo-a.git", Branch: "main"},
+			{URL: "https://gitea.example.com/org/repo-b.git"},
+		},
+	}
+	srv.mu.Unlock()
+
+	resp, err := http.Get(fmt.Sprintf("%s/spaces/%s/export", base, space))
+	if err != nil {
+		t.Fatalf("export GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("export: want 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var ff FleetFile
+	if err := yaml.Unmarshal(body, &ff); err != nil {
+		t.Fatalf("export: unmarshal YAML: %v", err)
+	}
+
+	agentEntry, ok := ff.Agents[agent]
+	if !ok {
+		t.Fatalf("export: agent %q missing from output", agent)
+	}
+	if len(agentEntry.Repos) != 2 {
+		t.Fatalf("export: want 2 repos, got %d", len(agentEntry.Repos))
+	}
+	// Credentials must be stripped from repo URLs.
+	if strings.Contains(agentEntry.Repos[0].URL, "token") {
+		t.Errorf("export: repos[0] URL still contains credentials: %q", agentEntry.Repos[0].URL)
+	}
+	if agentEntry.Repos[0].URL != "https://gitea.example.com/org/repo-a.git" {
+		t.Errorf("export: repos[0] URL: want https://gitea.example.com/org/repo-a.git, got %q", agentEntry.Repos[0].URL)
+	}
+	if agentEntry.Repos[0].Branch != "main" {
+		t.Errorf("export: repos[0] branch: want main, got %q", agentEntry.Repos[0].Branch)
+	}
+	if agentEntry.Repos[1].URL != "https://gitea.example.com/org/repo-b.git" {
+		t.Errorf("export: repos[1] URL: want https://gitea.example.com/org/repo-b.git, got %q", agentEntry.Repos[1].URL)
+	}
+
+	// Round-trip: ParseAndValidateFleetFile must accept the exported YAML with repos.
+	ff2, err := ParseAndValidateFleetFile(body)
+	if err != nil {
+		t.Fatalf("round-trip: parse exported YAML with repos: %v", err)
+	}
+	if len(ff2.Agents[agent].Repos) != 2 {
+		t.Errorf("round-trip: want 2 repos after parse, got %d", len(ff2.Agents[agent].Repos))
+	}
+}
+
 func TestHandleSpaceExportNotFound(t *testing.T) {
 	srv, stop := mustStartServer(t)
 	defer stop()
@@ -743,5 +819,32 @@ agents:
 	relDir := "version: \"1\"\nspace:\n  name: \"X\"\nagents:\n  a:\n    backend: tmux\n    command: claude\n    work_dir: relative/path\n"
 	if _, err := ParseAndValidateFleetFile([]byte(relDir)); err == nil {
 		t.Error("relative work_dir: want error, got nil")
+	}
+
+	// Fleet file with repos list.
+	withRepos := `version: "1"
+space:
+  name: "RepoTest"
+agents:
+  worker:
+    backend: ambient
+    command: claude
+    repos:
+      - url: "https://gitea.example.com/org/repo-a.git"
+        branch: main
+      - url: "https://gitea.example.com/org/repo-b.git"
+`
+	ffRepos, err := ParseAndValidateFleetFile([]byte(withRepos))
+	if err != nil {
+		t.Fatalf("fleet with repos: %v", err)
+	}
+	if len(ffRepos.Agents["worker"].Repos) != 2 {
+		t.Errorf("want 2 repos, got %d", len(ffRepos.Agents["worker"].Repos))
+	}
+	if ffRepos.Agents["worker"].Repos[0].Branch != "main" {
+		t.Errorf("repos[0] branch: want main, got %q", ffRepos.Agents["worker"].Repos[0].Branch)
+	}
+	if ffRepos.Agents["worker"].Repos[1].Branch != "" {
+		t.Errorf("repos[1] branch: want empty, got %q", ffRepos.Agents["worker"].Repos[1].Branch)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `FleetRepo` type and `repos` field to `FleetAgent` so agent-compose YAML can declare a list of git repositories per agent
- Export serializes `cfg.Repos` → `FleetRepo` list with userinfo stripping
- Import converts `FleetRepo` → `SessionRepo` and sets `Repos` on `AgentConfig`
- Diff helper detects `repos` changes for `--restart-changed`

The fleet export/import format only supported `repo_url` (single string) which is insufficient for ambient agents that need multiple repos cloned into their session.

## Test plan
- [x] Existing fleet tests pass (`TestHandleSpaceExport`, `TestExportRoundTrip`, `TestParseAndValidateFleetFile`)
- [x] New `TestHandleSpaceExportRepos` — verifies repos export with credential stripping and round-trip parsing
- [x] New repos parsing case in `TestParseAndValidateFleetFile` — verifies YAML with repos list parses correctly
- [x] Validated end-to-end: exported space from localhost, modified to ambient backend with repos, imported to timslab cluster