### PR TITLE
fix(ambient): sanitize space/agent names to valid K8s label values

### DIFF
--- a/internal/coordinator/session_backend_ambient.go
+++ b/internal/coordinator/session_backend_ambient.go
@@ -171,16 +171,10 @@ func (b *AmbientSessionBackend) CreateSession(ctx context.Context, opts SessionC
 		// Labels for session discovery and ownership tracking.
 		labels := map[string]string{"managed-by": "agent-boss"}
 		if ao.SpaceName != "" {
-			if !validLabelValue(ao.SpaceName) {
-				return "", fmt.Errorf("create session: space name %q is not a valid Kubernetes label value (must be alphanumeric, '-', '_', or '.', max 63 chars, no spaces)", ao.SpaceName)
-			}
-			labels["boss-space"] = ao.SpaceName
+			labels["boss-space"] = sanitizeLabelValue(ao.SpaceName)
 		}
 		if ao.DisplayName != "" {
-			if !validLabelValue(ao.DisplayName) {
-				return "", fmt.Errorf("create session: agent name %q is not a valid Kubernetes label value (must be alphanumeric, '-', '_', or '.', max 63 chars, no spaces)", ao.DisplayName)
-			}
-			labels["boss-agent"] = ao.DisplayName
+			labels["boss-agent"] = sanitizeLabelValue(ao.DisplayName)
 		}
 		body["labels"] = labels
 	} else if opts.SessionID != "" {

--- a/internal/coordinator/session_backend_ambient_handler_test.go
+++ b/internal/coordinator/session_backend_ambient_handler_test.go
@@ -326,30 +326,36 @@ func TestHandlerAmbientSpawnEnvVarSplit(t *testing.T) {
 	}
 }
 
-func TestHandlerAmbientSpawnLabelValidation(t *testing.T) {
+func TestHandlerAmbientSpawnLabelSanitization(t *testing.T) {
 	mock := newAmbientAPIMock("test-project")
 	_, base := mustStartAmbientServer(t, mock)
 
+	// Space name with spaces should succeed — label value is sanitized, not rejected.
 	resp := postJSON(t, base+"/spaces/has spaces/agent/worker1/spawn", map[string]any{
 		"backend": "ambient",
 	})
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 
-	// Should fail because "has spaces" is not a valid K8s label value.
-	if resp.StatusCode == http.StatusAccepted {
-		t.Fatal("expected error for space name with spaces, got 202")
-	}
-	if !strings.Contains(string(body), "not a valid Kubernetes label") {
-		t.Errorf("expected label validation error, got: %s", body)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 202 for space name with spaces, got %d: %s", resp.StatusCode, body)
 	}
 
-	// Verify no create call was made to the mock.
+	// Verify the create call was made and the label was sanitized.
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	sessionID, _ := result["session_id"].(string)
+
 	mock.mu.Lock()
 	defer mock.mu.Unlock()
-	creates := mock.findCalls(http.MethodPost, "agentic-sessions")
-	if len(creates) != 0 {
-		t.Errorf("expected 0 create calls (validation should prevent API call), got %d", len(creates))
+	cr, ok := mock.sessions[sessionID]
+	if !ok {
+		t.Fatalf("session %q not found in mock", sessionID)
+	}
+	if cr.Metadata.Labels["boss-space"] != "has-spaces" {
+		t.Errorf("expected boss-space=has-spaces, got %q", cr.Metadata.Labels["boss-space"])
 	}
 }
 

--- a/internal/coordinator/session_backend_ambient_helpers.go
+++ b/internal/coordinator/session_backend_ambient_helpers.go
@@ -71,30 +71,28 @@ func generateMsgID() string {
 
 
 
-// validLabelValue reports whether s is a valid Kubernetes label value.
-// A valid label value must be 63 characters or less, and must match
-// (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])? — i.e. empty or
-// alphanumeric at start/end with [-_.a-zA-Z0-9] in between.
-func validLabelValue(s string) bool {
-	if len(s) > 63 {
-		return false
-	}
+// sanitizeLabelValue converts an arbitrary string into a valid Kubernetes label
+// value. Spaces are replaced with '-'; any character that is not alphanumeric,
+// '-', '_', or '.' is dropped. Leading/trailing non-alphanumeric characters are
+// trimmed, and the result is truncated to 63 characters.
+func sanitizeLabelValue(s string) string {
 	if s == "" {
-		return true
+		return ""
 	}
-	for i, c := range s {
-		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
-			continue
+	var b strings.Builder
+	for _, c := range s {
+		switch {
+		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.':
+			b.WriteRune(c)
+		case c == ' ':
+			b.WriteByte('-')
 		}
-		if c == '-' || c == '_' || c == '.' {
-			if i == 0 || i == len(s)-1 {
-				return false // must start/end with alphanumeric
-			}
-			continue
-		}
-		return false
 	}
-	return true
+	v := strings.Trim(b.String(), "-_.")
+	if len(v) > 63 {
+		v = strings.TrimRight(v[:63], "-_.")
+	}
+	return v
 }
 
 // lastMessagesSnapshot finds the last MESSAGES_SNAPSHOT event in aguiEvents

--- a/internal/coordinator/session_backend_ambient_test.go
+++ b/internal/coordinator/session_backend_ambient_test.go
@@ -687,64 +687,30 @@ func TestAmbientSessionPath(t *testing.T) {
 	}
 }
 
-func TestAmbientCreateSessionRejectsInvalidLabelValue(t *testing.T) {
-	b := NewAmbientSessionBackend(AmbientBackendConfig{
-		APIURL:  "http://localhost",
-		Project: "test",
-	})
-
-	// Space name with spaces is invalid for K8s labels.
-	_, err := b.CreateSession(context.Background(), SessionCreateOpts{
-		Command: "test",
-		BackendOpts: AmbientCreateOpts{
-			DisplayName: "agent1",
-			SpaceName:   "My Space Name",
-		},
-	})
-	if err == nil {
-		t.Fatal("expected error for space name with spaces")
-	}
-	if !strings.Contains(err.Error(), "not a valid Kubernetes label") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Agent name with spaces is also invalid.
-	_, err = b.CreateSession(context.Background(), SessionCreateOpts{
-		Command: "test",
-		BackendOpts: AmbientCreateOpts{
-			DisplayName: "my agent",
-			SpaceName:   "valid-space",
-		},
-	})
-	if err == nil {
-		t.Fatal("expected error for agent name with spaces")
-	}
-}
-
-func TestValidLabelValue(t *testing.T) {
+func TestSanitizeLabelValue(t *testing.T) {
 	tests := []struct {
-		value string
-		valid bool
+		input string
+		want  string
 	}{
-		{"", true},
-		{"simple", true},
-		{"with-hyphens", true},
-		{"with_underscores", true},
-		{"with.dots", true},
-		{"MixedCase123", true},
-		{"a", true},
-		{"has spaces", false},
-		{"-starts-with-hyphen", false},
-		{"ends-with-hyphen-", false},
-		{"has/slash", false},
-		{"has:colon", false},
-		{strings.Repeat("a", 63), true},
-		{strings.Repeat("a", 64), false},
+		{"", ""},
+		{"simple", "simple"},
+		{"with-hyphens", "with-hyphens"},
+		{"with_underscores", "with_underscores"},
+		{"with.dots", "with.dots"},
+		{"MixedCase123", "MixedCase123"},
+		{"has spaces", "has-spaces"},
+		{"ROSA DevEnv E2E", "ROSA-DevEnv-E2E"},
+		{"-starts-with-hyphen", "starts-with-hyphen"},
+		{"ends-with-hyphen-", "ends-with-hyphen"},
+		{"has/slash", "hasslash"},
+		{"has:colon", "hascolon"},
+		{strings.Repeat("a", 63), strings.Repeat("a", 63)},
+		{strings.Repeat("a", 64), strings.Repeat("a", 63)},
 	}
 	for _, tt := range tests {
-		t.Run(tt.value, func(t *testing.T) {
-			if got := validLabelValue(tt.value); got != tt.valid {
-				t.Errorf("validLabelValue(%q) = %v, want %v", tt.value, got, tt.valid)
+		t.Run(tt.input, func(t *testing.T) {
+			if got := sanitizeLabelValue(tt.input); got != tt.want {
+				t.Errorf("sanitizeLabelValue(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Space and agent names with spaces (e.g. `ROSA DevEnv E2E`) caused a `500 Internal Server Error` when spawning ambient sessions, because the raw name was used directly as a Kubernetes label value
- Replaced the validate-and-reject approach with `sanitizeLabelValue()`: spaces become `-`, other invalid characters are dropped, leading/trailing separators are trimmed, and the result is capped at 63 chars
- Both `boss-space` and `boss-agent` labels now use sanitization, so neither space names nor agent names are restricted by K8s label syntax

## Test plan

- [ ] `TestSanitizeLabelValue` — covers sanitization cases including `"ROSA DevEnv E2E"` → `"ROSA-DevEnv-E2E"`, truncation, and stripping invalid chars
- [ ] `TestHandlerAmbientSpawnLabelSanitization` — verifies a space name with spaces succeeds (202) and the stored label is correctly sanitized
- [ ] `go test -race ./internal/coordinator/` passes