### PR TITLE
fix(workflow): pre-grant boss-mcp tool permissions

### DIFF
--- a/ambient-workflow/.claude/settings.json
+++ b/ambient-workflow/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__boss-mcp__*"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` to `ambient-workflow/` to pre-grant all `mcp__boss-mcp__*` tool permissions
- Fixes agents blocking on "Awaiting permission grant for boss-mcp tools" when spawned via the ambient backend

## Problem
The platform runner's `build_allowed_tools()` generates permission wildcards only for MCP servers it discovers from its own `.mcp.json` (baked into the runner image) and `MCP_SERVERS_JSON` env var. The `boss-mcp` server is defined in the workflow's `.mcp.json` — Claude Code discovers it independently from the CWD, but the runner never includes `mcp__boss-mcp__*` in its `allowed_tools` list. This causes every agent to block waiting for permission approval that never comes.

## Fix
The runner passes `setting_sources: ["project"]` to Claude Code, which reads `.claude/settings.json` from the project root (= the workflow CWD). Adding `permissions.allow: ["mcp__boss-mcp__*"]` here grants all boss-mcp tools automatically at session startup.

## Test plan
- [x] Verified `.claude/settings.json` is cloned into runner pods via init container
- [x] Confirmed 6/6 agents successfully called `check_messages` after fix (previously 0/6)
- [x] Tested on deployed instance at `jsell-agent-boss.apps.okd1.timslab`