### PR TITLE
fix(tmux): preflight CWD check before session creation (TASK-131)

### DIFF
--- a/internal/coordinator/lifecycle_test.go
+++ b/internal/coordinator/lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -483,5 +484,48 @@ func TestSpawnDoesNotOverrideChildWorkDir(t *testing.T) {
 		}
 	default:
 		t.Fatal("CreateSession was not called")
+	}
+}
+
+// TestTmuxCreateSessionMissingWorkDir verifies that CreateSession returns an
+// error immediately (before any tmux call) when work_dir does not exist.
+func TestTmuxCreateSessionMissingWorkDir(t *testing.T) {
+	b := NewTmuxSessionBackend()
+	_, err := b.CreateSession(context.Background(), SessionCreateOpts{
+		SessionID: "test-missing-cwd",
+		BackendOpts: TmuxCreateOpts{
+			WorkDir: "/nonexistent/path/that/does/not/exist",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing work_dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error %q should mention 'does not exist'", err.Error())
+	}
+}
+
+// TestTmuxCreateSessionWorkDirIsFile verifies that CreateSession returns an
+// error when work_dir points to a file rather than a directory.
+func TestTmuxCreateSessionWorkDirIsFile(t *testing.T) {
+	f, err := os.CreateTemp("", "boss-cwd-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.Close()
+
+	b := NewTmuxSessionBackend()
+	_, err = b.CreateSession(context.Background(), SessionCreateOpts{
+		SessionID: "test-cwd-is-file",
+		BackendOpts: TmuxCreateOpts{
+			WorkDir: f.Name(),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when work_dir is a file, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("error %q should mention 'not a directory'", err.Error())
 	}
 }

--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -70,6 +71,20 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 	// Append --dangerously-skip-permissions when global toggle is on.
 	if allowSkipPermissions && !strings.Contains(command, "--dangerously-skip-permissions") {
 		command += " --dangerously-skip-permissions"
+	}
+
+	// Preflight: verify work_dir exists before creating the tmux session.
+	// Without this check, a missing directory causes `cd` to fail silently
+	// inside the shell, and the agent starts in the wrong working directory.
+	if workDir != "" {
+		if info, err := os.Stat(workDir); err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("work_dir %q does not exist", workDir)
+			}
+			return "", fmt.Errorf("work_dir %q: %w", workDir, err)
+		} else if !info.IsDir() {
+			return "", fmt.Errorf("work_dir %q is not a directory", workDir)
+		}
 	}
 
 	if b.SessionExists(sessionID) {


### PR DESCRIPTION
Replaces PR #251 which had rebase conflicts due to squash-merged upstream commits.

Cherry-pick of commit 41043c7 onto clean main.

## Summary
- Added `os.Stat` preflight check in `TmuxSessionBackend.CreateSession` before any tmux calls
- If `work_dir` is missing or is not a directory, returns a clear error immediately
- Two new tests: `TestTmuxCreateSessionMissingWorkDir` and `TestTmuxCreateSessionWorkDirIsFile`