### PR TITLE
docs(operator): TASK-133 — replace 'boss agent' with 'operator' in protocol and MCP tool descriptions

### DIFF
--- a/docs/exec-plans/doc-gardening-agent.md
+++ b/docs/exec-plans/doc-gardening-agent.md
@@ -278,6 +278,24 @@ grep '@agent-name\|@mention\|mention' internal/coordinator/protocol.md
 
 ---
 
+### Check 8 — Operator naming is consistent (no phantom "boss" agent)
+
+After any sprint touching messaging, `request_decision`, or operator infrastructure, verify that:
+
+1. `internal/coordinator/protocol.md` Rule 6 says `send_message(to: "operator")` (not "boss agent") for human input.
+2. `send_message` tool description in `mcp_tools.go` mentions `'operator'` as the target for the human operator.
+3. No agent-facing docs instruct agents to `send_message(to="boss")` — that alias still works but `"operator"` is canonical.
+
+```bash
+grep -n '"boss"' internal/coordinator/protocol.md | grep -v 'boss://'
+grep -n "to.*boss\|boss.*operator" internal/coordinator/mcp_tools.go
+```
+
+**Pass:** protocol.md instructs `send_message(to: "operator")` and mcp_tools.go mentions `'operator'` as the human operator target.
+**Fail:** Update protocol.md Rule 6 and the `to` parameter description in `addToolSendMessage`.
+
+---
+
 ### Drift found → action matrix
 
 | Drift type | Action |

--- a/internal/coordinator/mcp_tools.go
+++ b/internal/coordinator/mcp_tools.go
@@ -336,11 +336,11 @@ func (s *Server) addToolCheckMessages(srv *mcp.Server) {
 func (s *Server) addToolSendMessage(srv *mcp.Server) {
 	srv.AddTool(&mcp.Tool{
 		Name:        "send_message",
-		Description: "Send a message to another agent for coordination or escalation.",
+		Description: "Send a message to another agent for coordination or escalation. Use to='operator' to send a message to the human operator (legacy alias: 'boss').",
 		InputSchema: jsonSchema([]string{"space", "from", "to", "message"}, map[string]map[string]any{
 			"space":    prop("string", "The workspace name"),
 			"from":     prop("string", "Your agent name (the sender)"),
-			"to":       prop("string", "Target agent name, or 'parent' to message your parent agent"),
+			"to":       prop("string", "Target agent name, 'parent' to message your parent agent, or 'operator' to reach the human operator (legacy alias: 'boss')"),
 			"message":  prop("string", "The message content"),
 			"priority": prop("string", "Message priority: info (default), directive, or urgent"),
 		}),

--- a/internal/coordinator/protocol.md
+++ b/internal/coordinator/protocol.md
@@ -34,7 +34,7 @@ An HTTP REST API is available at `{COORDINATOR_URL}` for non-MCP clients (webhoo
 3. **Summary format required.** Always use `"{name}: {one-line description}"` in the summary field.
 4. **Include location fields** in every status update: `branch`, `pr`, `repo_url` (sticky — send once), `phase`.
 5. **Register your session.** Include `session_id` in your first `post_status`. Sticky — server remembers it.
-6. **Escalate by messaging**, not by tagging. Use `send_message` to your manager when blocked. Message the boss agent for decisions that require human input.
+6. **Escalate by messaging**, not by tagging. Use `send_message` to your manager when blocked. Use `send_message(to: "operator")` or `request_decision` for decisions that require human input. (`"boss"` is a legacy alias for `"operator"` and still works, but prefer `"operator"`.)
 7. **ACK messages** you have acted on using `ack_message`.
 
 ### Collaboration Norms


### PR DESCRIPTION
## Summary

Updates agent-facing documentation and MCP tool descriptions to reflect the operator refactor — agents should now use `send_message(to: "operator")` (or `request_decision`) to reach the human operator, not "boss".

## Changes

### `internal/coordinator/protocol.md`
- Rule 6: replaced "Message the boss agent for decisions that require human input" with `send_message(to: "operator")` / `request_decision`, noting `"boss"` as a legacy alias that still works.

### `internal/coordinator/mcp_tools.go`
- `send_message` tool description: added note that `to='operator'` reaches the human operator (legacy alias: `'boss'`)
- `to` parameter description: added `'operator'` as a documented option

### `docs/exec-plans/doc-gardening-agent.md`
- Added **Check 8 — Operator naming consistency**: audit checklist item for future gardening runs to verify operator nomenclature stays correct after messaging/spawn sprints.

## Testing
- `go test -race ./internal/coordinator/ ./internal/domain/...` — all pass

Closes TASK-133. Coordinate with arch on backend routing (they are updating `request_decision` delivery code from the phantom `"boss"` agent to the first-class operator record).