### PR TITLE
feat(model): TASK-134 — per-agent model selection

### DIFF
--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -1463,6 +1463,7 @@ type createAgentRequest struct {
 	Parent         string `json:"parent,omitempty"`
 	Role           string `json:"role,omitempty"`
 	InitialMessage string `json:"initial_message,omitempty"` // one-time message sent to agent after ignite
+	Model string `json:"model,omitempty"` // model override e.g. "sonnet", "opus", "claude-sonnet-4-6"
 	// Ambient-specific fields
 	Repos []SessionRepo `json:"repos,omitempty"`
 	Task  string        `json:"task,omitempty"` // initial prompt for ambient sessions
@@ -1507,6 +1508,7 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 				DisplayName: req.Name,
 				Repos:       req.Repos,
 				SpaceName:   spaceName,
+				Model:       req.Model,
 				EnvVars: func() map[string]string {
 					if s.apiToken == "" {
 						return nil
@@ -1532,6 +1534,7 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 				MCPServerName:        s.mcpServerName(),
 				AgentToken:           s.generateAgentToken(spaceName, req.Name),
 				AllowSkipPermissions: s.allowSkipPermissions,
+				Model:                req.Model,
 			},
 		}
 	}
@@ -1564,14 +1567,19 @@ func (s *Server) handleCreateAgents(w http.ResponseWriter, r *http.Request, spac
 	if req.Role != "" && agent.Role == "" {
 		agent.Role = req.Role
 	}
-	// Persist work_dir (and any future create-time config) to AgentConfig so it
+	// Persist work_dir, model (and any future create-time config) to AgentConfig so it
 	// is visible in the agent detail view and survives restarts.
-	if req.WorkDir != "" {
+	if req.WorkDir != "" || req.Model != "" {
 		cfg := ks.agentConfig(canonical)
 		if cfg == nil {
 			cfg = &AgentConfig{}
 		}
-		cfg.WorkDir = req.WorkDir
+		if req.WorkDir != "" {
+			cfg.WorkDir = req.WorkDir
+		}
+		if req.Model != "" {
+			cfg.Model = req.Model
+		}
 		ks.setAgentConfig(canonical, cfg)
 	}
 	if err := s.saveSpace(ks); err != nil {

--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -559,14 +559,16 @@ func (s *Server) restartAgentService(spaceName, agentName string, req spawnReque
 	if exists {
 		oldSession = agent.SessionID
 	}
-	// Load AgentConfig to restore cwd, command, and initial_prompt on restart.
+	// Load AgentConfig to restore cwd, command, model, and initial_prompt on restart.
 	var restartWorkDir string
 	var restartInitialPrompt string
 	var restartCommand string
+	var restartModel string
 	if cfg := ks.agentConfig(canonical); cfg != nil {
 		restartWorkDir = cfg.WorkDir
 		restartInitialPrompt = cfg.InitialPrompt
 		restartCommand = cfg.Command
+		restartModel = cfg.Model
 	}
 	s.mu.RUnlock()
 
@@ -618,6 +620,7 @@ func (s *Server) restartAgentService(spaceName, agentName string, req spawnReque
 			BackendOpts: AmbientCreateOpts{
 				DisplayName: canonical,
 				SpaceName:   spaceName,
+				Model:       restartModel,
 				EnvVars: func() map[string]string {
 					if s.apiToken == "" {
 						return nil
@@ -640,6 +643,7 @@ func (s *Server) restartAgentService(spaceName, agentName string, req spawnReque
 				MCPServerName:        s.mcpServerName(),
 				AgentToken:           s.generateAgentToken(spaceName, canonical),
 				AllowSkipPermissions: s.allowSkipPermissions,
+				Model:                restartModel,
 			},
 		}
 	}
@@ -836,19 +840,21 @@ func (s *Server) handleRestartAll(w http.ResponseWriter, r *http.Request, spaceN
 			cancel()
 			time.Sleep(1 * time.Second)
 
-			// Determine work dir and command from stored config
+			// Determine work dir, model, and command from stored config
 			workDir := ""
 			command := "claude"
 			if s.allowSkipPermissions {
 				command = "claude --dangerously-skip-permissions"
 			}
 			initialPrompt := ""
+			model := ""
 			if cfg != nil {
 				workDir = cfg.WorkDir
 				if cfg.Command != "" {
 					command = cfg.Command
 				}
 				initialPrompt = cfg.InitialPrompt
+				model = cfg.Model
 			}
 
 			// Create new session
@@ -865,6 +871,7 @@ func (s *Server) handleRestartAll(w http.ResponseWriter, r *http.Request, spaceN
 					MCPServerName:        s.mcpServerName(),
 					AgentToken:           s.generateAgentToken(spaceName, t.name),
 					AllowSkipPermissions: s.allowSkipPermissions,
+					Model:                model,
 				},
 			}
 			sessionID, err := backend.CreateSession(context.Background(), createOpts)

--- a/internal/coordinator/session_backend.go
+++ b/internal/coordinator/session_backend.go
@@ -120,6 +120,7 @@ type TmuxCreateOpts struct {
 	MCPServerName        string // MCP server name (e.g. "boss-mcp", "boss-mcp-8889"); defaults to "boss-mcp"
 	AgentToken           string // bearer token embedded inline in --mcp-config JSON for MCP auth; never written to ~/.claude.json
 	AllowSkipPermissions bool   // if true, append --dangerously-skip-permissions to command
+	Model                string // model override e.g. "sonnet", "opus", "claude-sonnet-4-6"
 }
 
 // AmbientCreateOpts holds Ambient-specific session creation options.

--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -50,6 +50,7 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 	var mcpServerName string
 	var agentToken string
 	var allowSkipPermissions bool
+	var model string
 
 	if tmuxOpts, ok := opts.BackendOpts.(TmuxCreateOpts); ok {
 		if tmuxOpts.Width > 0 {
@@ -63,6 +64,7 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 		mcpServerName = tmuxOpts.MCPServerName
 		agentToken = tmuxOpts.AgentToken
 		allowSkipPermissions = tmuxOpts.AllowSkipPermissions
+		model = tmuxOpts.Model
 	}
 	if mcpServerName == "" {
 		mcpServerName = "boss-mcp"
@@ -71,6 +73,11 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 	// Append --dangerously-skip-permissions when global toggle is on.
 	if allowSkipPermissions && !strings.Contains(command, "--dangerously-skip-permissions") {
 		command += " --dangerously-skip-permissions"
+	}
+
+	// Append --model if a model override is specified.
+	if model != "" {
+		command += " --model " + shellQuote(model)
 	}
 
 	// Preflight: verify work_dir exists before creating the tmux session.


### PR DESCRIPTION
## Summary

Implements TASK-134: per-agent model selection for both tmux and ambient backends.

**Changes:**
- `createAgentRequest`: add `model` field (e.g. `"sonnet"`, `"opus"`, `"claude-sonnet-4-6"`)
- `TmuxCreateOpts`: add `Model string` field
- `TmuxSessionBackend.CreateSession`: appends `--model <model>` to the base claude command when set (before `--mcp-config` so it's on the base command, not the wrapper)
- `handleCreateAgents` tmux path: passes `req.Model` → `TmuxCreateOpts.Model`
- `handleCreateAgents` ambient path: passes `req.Model` → `AmbientCreateOpts.Model`
- `AgentConfig.Model` persisted on spawn (alongside `WorkDir`) so model survives restarts
- `restartAgentService`: reads `agentCfg.Model` and passes to both tmux/ambient opts
- Auto-restart liveness loop: reads `cfg.Model` and passes to `TmuxCreateOpts`

`AgentConfig` is already serialized in `agentRecordPublic.Config`, so `model` is visible in the API with no extra work.

## Test plan
- [x] All existing coordinator tests pass with `-race` (47s)
- [x] `go build ./internal/coordinator/...` clean

Closes TASK-134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)