### PR TITLE
fix(e2e): TASK-133 — update E2E senders from 'boss' to 'operator'

### DIFF
--- a/e2e/tests/03-api-tasks.spec.ts
+++ b/e2e/tests/03-api-tasks.spec.ts
@@ -10,7 +10,7 @@ test.describe('API: Tasks', () => {
     const task = await api.postJSON<{ id: string; title: string; status: string }>(
       `/spaces/${space}/tasks`,
       { title: 'My E2E Task', description: 'Testing task creation', priority: 'medium' },
-      'boss',
+      'operator',
     )
     expect(task.id).toMatch(/^TASK-/)
     expect(task.title).toBe('My E2E Task')
@@ -18,18 +18,18 @@ test.describe('API: Tasks', () => {
   })
 
   test('list tasks returns array with total', async ({ space, api }) => {
-    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Task 1' }, 'boss')
-    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Task 2' }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Task 1' }, 'operator')
+    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Task 2' }, 'operator')
     const result = await api.getJSON<{ tasks: unknown[]; total: number }>(`/spaces/${space}/tasks`)
     expect(Array.isArray(result.tasks)).toBe(true)
     expect(result.total).toBeGreaterThanOrEqual(2)
   })
 
   test('filter tasks by status', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Backlog task' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Backlog task' }, 'operator')
 
     // Move to in_progress
-    await api.postJSON(`/spaces/${space}/tasks/${t.id}/move`, { status: 'in_progress' }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks/${t.id}/move`, { status: 'in_progress' }, 'operator')
 
     const inProgress = await api.getJSON<{ tasks: { id: string; status: string }[] }>(
       `/spaces/${space}/tasks?status=in_progress`,
@@ -43,7 +43,7 @@ test.describe('API: Tasks', () => {
   })
 
   test('filter tasks by assigned_to', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Assigned task', assigned_to: 'DevAgent' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Assigned task', assigned_to: 'DevAgent' }, 'operator')
     const assigned = await api.getJSON<{ tasks: { id: string }[] }>(
       `/spaces/${space}/tasks?assigned_to=DevAgent`,
     )
@@ -51,32 +51,32 @@ test.describe('API: Tasks', () => {
   })
 
   test('GET /spaces/{space}/tasks/{id} returns task', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Fetch by ID' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Fetch by ID' }, 'operator')
     const fetched = await api.getJSON<{ id: string; title: string }>(`/spaces/${space}/tasks/${t.id}`)
     expect(fetched.id).toBe(t.id)
     expect(fetched.title).toBe('Fetch by ID')
   })
 
   test('PUT /tasks/{id} updates task fields', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Old Title', priority: 'low' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Old Title', priority: 'low' }, 'operator')
     const updated = await api.putJSON<{ title: string; priority: string }>(
       `/spaces/${space}/tasks/${t.id}`,
       { title: 'New Title', priority: 'urgent' },
-      'boss',
+      'operator',
     )
     expect(updated.title).toBe('New Title')
     expect(updated.priority).toBe('urgent')
   })
 
   test('move task through all statuses', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Lifecycle task' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Lifecycle task' }, 'operator')
     const statuses = ['in_progress', 'review', 'done'] as const
 
     for (const status of statuses) {
       const moved = await api.postJSON<{ status: string }>(
         `/spaces/${space}/tasks/${t.id}/move`,
         { status },
-        'boss',
+        'operator',
       )
       expect(moved.status).toBe(status)
     }
@@ -90,29 +90,29 @@ test.describe('API: Tasks', () => {
     const t = await api.postJSON<{ id: string; events: unknown[] }>(
       `/spaces/${space}/tasks`,
       { title: 'Event task' },
-      'boss',
+      'operator',
     )
-    await api.postJSON(`/spaces/${space}/tasks/${t.id}/move`, { status: 'in_progress', reason: 'starting work' }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks/${t.id}/move`, { status: 'in_progress', reason: 'starting work' }, 'operator')
     const task = await api.getJSON<{ events: { type: string; detail?: string }[] }>(`/spaces/${space}/tasks/${t.id}`)
     expect(task.events.some(e => e.type === 'moved')).toBe(true)
   })
 
   test('assign task to agent', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Unassigned' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Unassigned' }, 'operator')
     const assigned = await api.postJSON<{ assigned_to: string }>(
       `/spaces/${space}/tasks/${t.id}/assign`,
       { assigned_to: 'DevBot' },
-      'boss',
+      'operator',
     )
     expect(assigned.assigned_to).toBe('DevBot')
   })
 
   test('add comment to task', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Commented task' }, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Commented task' }, 'operator')
     const commented = await api.postJSON<{ comments: { body: string; by: string }[] }>(
       `/spaces/${space}/tasks/${t.id}/comment`,
       { body: 'This is a test comment.' },
-      'boss',
+      'operator',
     )
     expect(commented.comments).toBeDefined()
     expect(commented.comments.some(c => c.body === 'This is a test comment.')).toBe(true)
@@ -122,12 +122,12 @@ test.describe('API: Tasks', () => {
     const parent = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Parent Epic' },
-      'boss',
+      'operator',
     )
     const subtask = await api.postJSON<{ id: string; parent_task: string }>(
       `/spaces/${space}/tasks/${parent.id}/subtasks`,
       { title: 'Subtask 1', description: 'child work' },
-      'boss',
+      'operator',
     )
     expect(subtask.parent_task).toBe(parent.id)
 
@@ -137,8 +137,8 @@ test.describe('API: Tasks', () => {
   })
 
   test('delete task removes it from list', async ({ space, api }) => {
-    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Temporary' }, 'boss')
-    const r = await api.del(`/spaces/${space}/tasks/${t.id}`, 'boss')
+    const t = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Temporary' }, 'operator')
+    const r = await api.del(`/spaces/${space}/tasks/${t.id}`, 'operator')
     expect([200, 204]).toContain(r.status)
 
     const list = await api.getJSON<{ tasks: { id: string }[] }>(`/spaces/${space}/tasks`)
@@ -146,8 +146,8 @@ test.describe('API: Tasks', () => {
   })
 
   test('task search filter returns matching tasks', async ({ space, api }) => {
-    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Unique Banana Task' }, 'boss')
-    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Apple Task' }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Unique Banana Task' }, 'operator')
+    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Apple Task' }, 'operator')
 
     const results = await api.getJSON<{ tasks: { title: string }[] }>(
       `/spaces/${space}/tasks?search=Banana`,
@@ -157,7 +157,7 @@ test.describe('API: Tasks', () => {
   })
 
   test('task with labels can be filtered by label', async ({ space, api }) => {
-    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Labeled task', labels: ['frontend', 'urgent'] }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks`, { title: 'Labeled task', labels: ['frontend', 'urgent'] }, 'operator')
     const results = await api.getJSON<{ tasks: { id: string; labels: string[] }[] }>(
       `/spaces/${space}/tasks?label=frontend`,
     )
@@ -179,7 +179,7 @@ test.describe('API: Tasks', () => {
     const t = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Task to assign', assigned_to: 'NotifyAgent' },
-      'boss',
+      'operator',
     )
 
     // Check messages for NotifyAgent

--- a/e2e/tests/07-persistence.spec.ts
+++ b/e2e/tests/07-persistence.spec.ts
@@ -48,35 +48,35 @@ test.describe('Persistence: Data Survives Restart', () => {
     const task1 = await api.postJSON<{ id: string }>(
       `/spaces/${PERSIST_SPACE}/tasks`,
       { title: 'Persistent Task', description: 'Must survive restart', priority: 'urgent' },
-      'boss',
+      'operator',
     )
 
     // Move task to in_progress
     await api.postJSON(
       `/spaces/${PERSIST_SPACE}/tasks/${task1.id}/move`,
       { status: 'in_progress', reason: 'pre-restart' },
-      'boss',
+      'operator',
     )
 
     // Add comment
     await api.postJSON(
       `/spaces/${PERSIST_SPACE}/tasks/${task1.id}/comment`,
       { body: 'Comment before restart' },
-      'boss',
+      'operator',
     )
 
     // Create a second task
     await api.postJSON(
       `/spaces/${PERSIST_SPACE}/tasks`,
       { title: 'Second Persistent Task', assigned_to: 'PersistedAgent' },
-      'boss',
+      'operator',
     )
 
     // Send a message
     await api.post(
       `/spaces/${PERSIST_SPACE}/agent/PersistedAgent/message`,
       { message: 'Message sent before restart' },
-      'boss',
+      'operator',
     )
 
     // Update contracts

--- a/e2e/tests/10-ui-kanban.spec.ts
+++ b/e2e/tests/10-ui-kanban.spec.ts
@@ -28,9 +28,9 @@ test.describe('UI: Kanban Board', () => {
     const task = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Kanban Test Task', priority: 'high' },
-      'boss',
+      'operator',
     )
-    await api.postJSON(`/spaces/${space}/tasks/${task.id}/move`, { status: 'in_progress' }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks/${task.id}/move`, { status: 'in_progress' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban`)
     await page.waitForTimeout(1500)
@@ -40,14 +40,14 @@ test.describe('UI: Kanban Board', () => {
 
   test('kanban shows tasks across all status columns', async ({ page, space, api }) => {
     // Create tasks in different statuses
-    const t1 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Backlog Item' }, 'boss')
-    const t2 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'In Progress Item' }, 'boss')
-    const t3 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Review Item' }, 'boss')
-    const t4 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Done Item' }, 'boss')
+    const t1 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Backlog Item' }, 'operator')
+    const t2 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'In Progress Item' }, 'operator')
+    const t3 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Review Item' }, 'operator')
+    const t4 = await api.postJSON<{ id: string }>(`/spaces/${space}/tasks`, { title: 'Done Item' }, 'operator')
 
-    await api.postJSON(`/spaces/${space}/tasks/${t2.id}/move`, { status: 'in_progress' }, 'boss')
-    await api.postJSON(`/spaces/${space}/tasks/${t3.id}/move`, { status: 'review' }, 'boss')
-    await api.postJSON(`/spaces/${space}/tasks/${t4.id}/move`, { status: 'done' }, 'boss')
+    await api.postJSON(`/spaces/${space}/tasks/${t2.id}/move`, { status: 'in_progress' }, 'operator')
+    await api.postJSON(`/spaces/${space}/tasks/${t3.id}/move`, { status: 'review' }, 'operator')
+    await api.postJSON(`/spaces/${space}/tasks/${t4.id}/move`, { status: 'done' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban`)
     await page.waitForTimeout(1500)
@@ -62,7 +62,7 @@ test.describe('UI: Kanban Board', () => {
     const task = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Clickable Task', description: 'Click me to see details' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban`)
@@ -81,7 +81,7 @@ test.describe('UI: Kanban Board', () => {
     await api.postJSON(
       `/spaces/${space}/tasks`,
       { title: 'Urgent Priority Task', priority: 'urgent' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban`)
@@ -97,7 +97,7 @@ test.describe('UI: Kanban Board', () => {
     await api.postJSON(
       `/spaces/${space}/tasks`,
       { title: 'Assigned Task', assigned_to: 'DevAgent' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban`)
@@ -112,7 +112,7 @@ test.describe('UI: Kanban Board', () => {
     const task = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Deep Link Task' },
-      'boss',
+      'operator',
     )
 
     // Navigate directly to kanban with task deep link

--- a/e2e/tests/11-ui-agent-detail.spec.ts
+++ b/e2e/tests/11-ui-agent-detail.spec.ts
@@ -106,7 +106,7 @@ test.describe('UI: Agent Detail View', () => {
     await api.post(
       `/spaces/${space}/agent/ThreadBot/message`,
       { message: 'Check this out ThreadBot!' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/ThreadBot`)

--- a/e2e/tests/12-ui-deep-links.spec.ts
+++ b/e2e/tests/12-ui-deep-links.spec.ts
@@ -27,7 +27,7 @@ test.describe('UI: Deep Link Navigation', () => {
     const task = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Deep Link Target Task' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban?task=${task.id}`)
@@ -42,7 +42,7 @@ test.describe('UI: Deep Link Navigation', () => {
     const task = await api.postJSON<{ id: string }>(
       `/spaces/${space}/tasks`,
       { title: 'Highlighted Card Task' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/kanban?task=${task.id}`)

--- a/e2e/tests/13-ui-conversations.spec.ts
+++ b/e2e/tests/13-ui-conversations.spec.ts
@@ -51,8 +51,8 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'ConvBot2: in conversation' },
       'ConvBot2',
     )
-    await api.post(`/spaces/${space}/agent/ConvBot1/message`, { message: 'Hello ConvBot1!' }, 'boss')
-    await api.post(`/spaces/${space}/agent/ConvBot2/message`, { message: 'Hello ConvBot2!' }, 'boss')
+    await api.post(`/spaces/${space}/agent/ConvBot1/message`, { message: 'Hello ConvBot1!' }, 'operator')
+    await api.post(`/spaces/${space}/agent/ConvBot2/message`, { message: 'Hello ConvBot2!' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
     await page.waitForTimeout(1500)
@@ -67,7 +67,7 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'ParticipantBot' },
       'ParticipantBot',
     )
-    await api.post(`/spaces/${space}/agent/ParticipantBot/message`, { message: 'Hi' }, 'boss')
+    await api.post(`/spaces/${space}/agent/ParticipantBot/message`, { message: 'Hi' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
     await page.waitForTimeout(1500)
@@ -88,8 +88,8 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'BetaBot' },
       'BetaBot',
     )
-    await api.post(`/spaces/${space}/agent/AlphaBot/message`, { message: 'Alpha msg' }, 'boss')
-    await api.post(`/spaces/${space}/agent/BetaBot/message`, { message: 'Beta msg' }, 'boss')
+    await api.post(`/spaces/${space}/agent/AlphaBot/message`, { message: 'Alpha msg' }, 'operator')
+    await api.post(`/spaces/${space}/agent/BetaBot/message`, { message: 'Beta msg' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
     await page.waitForTimeout(1500)
@@ -120,7 +120,7 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'FilterBot' },
       'FilterBot',
     )
-    await api.post(`/spaces/${space}/agent/FilterBot/message`, { message: 'Hi' }, 'boss')
+    await api.post(`/spaces/${space}/agent/FilterBot/message`, { message: 'Hi' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
     await page.waitForTimeout(1500)
@@ -197,7 +197,7 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/ThreadAgent/message`,
       { message: 'Thread message content' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
@@ -220,7 +220,7 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/DirectConvBot/message`,
       { message: 'Direct URL message' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/DirectConvBot`)
@@ -239,8 +239,8 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'CountBot' },
       'CountBot',
     )
-    await api.post(`/spaces/${space}/agent/CountBot/message`, { message: 'Msg one' }, 'boss')
-    await api.post(`/spaces/${space}/agent/CountBot/message`, { message: 'Msg two' }, 'boss')
+    await api.post(`/spaces/${space}/agent/CountBot/message`, { message: 'Msg one' }, 'operator')
+    await api.post(`/spaces/${space}/agent/CountBot/message`, { message: 'Msg two' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/CountBot`)
     await page.waitForTimeout(1500)
@@ -258,7 +258,7 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/SenderBot/message`,
       { message: 'hello-from-boss-unique-msg' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/SenderBot`)
@@ -269,7 +269,7 @@ test.describe('UI: Conversations View', () => {
       .first()
       .isVisible()
       .catch(() => false)
-    const hasSender = await page.getByText('boss').first().isVisible().catch(() => false)
+    const hasSender = await page.getByText('operator').first().isVisible().catch(() => false)
 
     await expect(page.locator('#app')).toBeVisible()
     if (!hasMsg && !hasSender) {
@@ -398,7 +398,7 @@ test.describe('UI: Conversations View', () => {
       'DeliveredBot',
     )
     // Boss sends message — not yet acked, so read=false
-    await api.post(`/spaces/${space}/agent/DeliveredBot/message`, { message: 'Unread message' }, 'boss')
+    await api.post(`/spaces/${space}/agent/DeliveredBot/message`, { message: 'Unread message' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/DeliveredBot`)
     await page.waitForTimeout(1500)
@@ -421,7 +421,7 @@ test.describe('UI: Conversations View', () => {
     const sentResp = await api.post(
       `/spaces/${space}/agent/ReadReceiptBot/message`,
       { message: 'Please read me' },
-      'boss',
+      'operator',
     )
     const sent = (await sentResp.json()) as { messageId: string }
     const msgId = sent.messageId
@@ -457,12 +457,12 @@ test.describe('UI: Conversations View', () => {
       'BadgeBot2',
     )
     // Boss sends message to BadgeBot1 (unread)
-    await api.post(`/spaces/${space}/agent/BadgeBot1/message`, { message: 'Unread 1' }, 'boss')
-    await api.post(`/spaces/${space}/agent/BadgeBot1/message`, { message: 'Unread 2' }, 'boss')
+    await api.post(`/spaces/${space}/agent/BadgeBot1/message`, { message: 'Unread 1' }, 'operator')
+    await api.post(`/spaces/${space}/agent/BadgeBot1/message`, { message: 'Unread 2' }, 'operator')
     // Boss sends message to BadgeBot2 (will be auto-selected, clearing its badge)
     // Send BadgeBot2 message slightly later so it appears first in the list
     await new Promise(r => setTimeout(r, 50))
-    await api.post(`/spaces/${space}/agent/BadgeBot2/message`, { message: 'Different conv' }, 'boss')
+    await api.post(`/spaces/${space}/agent/BadgeBot2/message`, { message: 'Different conv' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
     await page.waitForTimeout(2000)
@@ -494,7 +494,7 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/ClearBadgeBot/message`,
       { message: 'Unread message' },
-      'boss',
+      'operator',
     )
 
     // Navigate to the conversations page
@@ -529,7 +529,7 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/UrgentBot/message`,
       { message: 'URGENT: attention needed!', priority: 'urgent' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
@@ -552,7 +552,7 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/DirectiveBot/message`,
       { message: 'This is a directive.', priority: 'directive' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
@@ -572,12 +572,12 @@ test.describe('UI: Conversations View', () => {
     await api.post(
       `/spaces/${space}/agent/OrderBot/message`,
       { message: 'First chronological message' },
-      'boss',
+      'operator',
     )
     await api.post(
       `/spaces/${space}/agent/OrderBot/message`,
       { message: 'Second chronological message' },
-      'boss',
+      'operator',
     )
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/OrderBot`)
@@ -608,7 +608,7 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'DayBot' },
       'DayBot',
     )
-    await api.post(`/spaces/${space}/agent/DayBot/message`, { message: 'Today message' }, 'boss')
+    await api.post(`/spaces/${space}/agent/DayBot/message`, { message: 'Today message' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/DayBot`)
     await page.waitForTimeout(1500)
@@ -625,7 +625,7 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'AriaBot' },
       'AriaBot',
     )
-    await api.post(`/spaces/${space}/agent/AriaBot/message`, { message: 'ARIA test' }, 'boss')
+    await api.post(`/spaces/${space}/agent/AriaBot/message`, { message: 'ARIA test' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations/AriaBot`)
     await page.waitForTimeout(1500)
@@ -641,7 +641,7 @@ test.describe('UI: Conversations View', () => {
       { status: 'active', summary: 'ListboxBot' },
       'ListboxBot',
     )
-    await api.post(`/spaces/${space}/agent/ListboxBot/message`, { message: 'Hello' }, 'boss')
+    await api.post(`/spaces/${space}/agent/ListboxBot/message`, { message: 'Hello' }, 'operator')
 
     await page.goto(`${BASE}/${encodeURIComponent(space)}/conversations`)
     await page.waitForTimeout(1500)

--- a/e2e/tests/14-agent-behavior.spec.ts
+++ b/e2e/tests/14-agent-behavior.spec.ts
@@ -44,7 +44,7 @@ test.describe('Agent Behavior: Full Lifecycle', () => {
     const msgR = await api.post(
       `/spaces/${space}/agent/LifecycleBot/message`,
       { message: 'LifecycleBot: your task is TASK-999: Write tests', priority: 'directive' },
-      'boss',
+      'operator',
     )
     const msgBody = await msgR.json() as { status: string; messageId: string }
     expect(msgBody.status).toBe('delivered')
@@ -95,7 +95,7 @@ test.describe('Agent Behavior: Full Lifecycle', () => {
     await api.post(
       `/spaces/${space}/agent/LifecycleBot/message`,
       { message: 'Yes, include performance tests too.' },
-      'boss',
+      'operator',
     )
 
     // Step 9: Agent fetches only new messages via cursor

--- a/e2e/tests/15-api-read-receipts.spec.ts
+++ b/e2e/tests/15-api-read-receipts.spec.ts
@@ -25,7 +25,7 @@ test.describe('API: Read Receipts', () => {
     await api.post(
       `/spaces/${space}/agent/ReadBot/message`,
       { message: 'You have unread mail' },
-      'boss',
+      'operator',
     )
 
     const msgs = await api.getJSON<{
@@ -48,7 +48,7 @@ test.describe('API: Read Receipts', () => {
     const sentResp = await api.post(
       `/spaces/${space}/agent/AckBot/message`,
       { message: 'Please ack me' },
-      'boss',
+      'operator',
     )
     const sent = await sentResp.json() as { messageId: string }
     const msgId = sent.messageId
@@ -92,7 +92,7 @@ test.describe('API: Read Receipts', () => {
     const sentResp = await api.post(
       `/spaces/${space}/agent/VictimBot/message`,
       { message: 'Private message' },
-      'boss',
+      'operator',
     )
     const sent = await sentResp.json() as { messageId: string }
     const msgId = sent.messageId
@@ -137,7 +137,7 @@ test.describe('API: Read Receipts', () => {
       const r = await api.post(
         `/spaces/${space}/agent/MultiMsgBot/message`,
         { message: `Message ${i}` },
-        'boss',
+        'operator',
       )
       const body = await r.json() as { messageId: string }
       ids.push(body.messageId)
@@ -175,7 +175,7 @@ test.describe('API: Read Receipts', () => {
     await api.post(
       `/spaces/${space}/agent/CursorReadBot/message`,
       { message: 'First' },
-      'boss',
+      'operator',
     )
     const first = await api.getJSON<{ cursor: string; messages: { id: string; read?: boolean }[] }>(
       `/spaces/${space}/agent/CursorReadBot/messages`,
@@ -193,7 +193,7 @@ test.describe('API: Read Receipts', () => {
     await api.post(
       `/spaces/${space}/agent/CursorReadBot/message`,
       { message: 'Second' },
-      'boss',
+      'operator',
     )
 
     // Fetch only new messages via cursor
@@ -215,7 +215,7 @@ test.describe('API: Read Receipts', () => {
     const r = await api.post(
       `/spaces/${space}/agent/HeaderBot/message`,
       { message: 'Need header' },
-      'boss',
+      'operator',
     )
     const body = await r.json() as { messageId: string }
 
@@ -236,7 +236,7 @@ test.describe('API: Read Receipts', () => {
     const r = await api.post(
       `/spaces/${space}/agent/PersistReadBot/message`,
       { message: 'Persist my read state' },
-      'boss',
+      'operator',
     )
     const body = await r.json() as { messageId: string }
     const msgId = body.messageId
@@ -268,7 +268,7 @@ test.describe('API: Read Receipts', () => {
     await api.postJSON(
       `/spaces/${space}/tasks`,
       { title: 'Auto-read task', assigned_to: 'NotifBot' },
-      'boss',
+      'operator',
     )
 
     // Post a status update — server should auto-mark notifications as read
@@ -298,7 +298,7 @@ test.describe('API: Read Receipts', () => {
     const r = await api.post(
       `/spaces/${space}/agent/IdBot/message`,
       { message: 'Check my ID' },
-      'boss',
+      'operator',
     )
     const sent = await r.json() as { messageId: string }
 

--- a/e2e/tests/16-ui-mobile-and-personas.spec.ts
+++ b/e2e/tests/16-ui-mobile-and-personas.spec.ts
@@ -52,7 +52,7 @@ test.describe('UI: ConversationsView mobile single-column', () => {
     await api.post(
       `/spaces/${space}/agent/TapBot/message`,
       { message: 'Tap to open this thread' },
-      'boss',
+      'operator',
     )
 
     await page.setViewportSize(MOBILE_VIEWPORT)
@@ -85,7 +85,7 @@ test.describe('UI: ConversationsView mobile single-column', () => {
     await api.post(
       `/spaces/${space}/agent/BackBot/message`,
       { message: 'Back button test' },
-      'boss',
+      'operator',
     )
 
     await page.setViewportSize(MOBILE_VIEWPORT)
@@ -125,7 +125,7 @@ test.describe('UI: ConversationsView mobile single-column', () => {
     await api.post(
       `/spaces/${space}/agent/DesktopBot/message`,
       { message: 'Desktop test' },
-      'boss',
+      'operator',
     )
 
     // Desktop viewport


### PR DESCRIPTION
## Summary

Fixes 3 failing E2E tests introduced by the TASK-133 operator refactor (PR #261).

**Root cause:** E2E tests sent messages with `X-Agent-Name: 'boss'` as the sender. After the TASK-133 frontend refactor, `resolveConversationKey()` fallback changed from `[agent, 'boss']` to `[agent, operatorName]` (= 'operator'). When messages weren't loaded yet on navigation, the key resolved to `Agent↔operator`. When messages loaded with `sender: 'boss'`, the conversation key was `Agent↔boss` — mismatch → empty thread panel.

**Fix:** Replace all `'boss'` sender references with `'operator'` in 9 E2E test files (86 occurrences). The canonical human operator name is now 'operator' throughout the stack.

**Failing tests fixed:**
- `tests/13-ui-conversations.spec.ts` — thread shows messages in chronological order
- `tests/16-ui-mobile-and-personas.spec.ts` — mobile thread panel shows/hides
- `tests/16-ui-mobile-and-personas.spec.ts` — mobile back button returns to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)