### PR TITLE
fix(ui): checklist work_dir check looks in config.work_dir

### DIFF
--- a/frontend/src/components/SpaceOverview.vue
+++ b/frontend/src/components/SpaceOverview.vue
@@ -365,7 +365,7 @@ const showChecklist = computed(
 )
 const hasAgent = computed(() => agentCount.value > 0)
 const hasAgentWithWorkDir = computed(() =>
-  Object.values(props.space.agents ?? {}).some((a) => (a as any).work_dir)
+  Object.values(props.space.agents ?? {}).some((a) => (a as any).config?.work_dir)
 )
 const hasSpawnedSession = computed(() =>
   Object.values(props.space.agents ?? {}).some((a) => (a as any).session_id)


### PR DESCRIPTION
## Summary

- Fixes #265: Getting-started checklist shows "working directory" as not set even when one was provided at agent creation time
- Root cause: `hasAgentWithWorkDir` computed checked `a.work_dir` (top-level, always undefined) instead of `a.config?.work_dir` where `work_dir` actually lives in `AgentConfig`
- Fix is a one-line change in `SpaceOverview.vue`

## Test plan
- [ ] Create a space and add an agent with a work directory set
- [ ] Verify the "Working directory configured" checklist item turns green
- [ ] Verify agents without a work directory still show the item as incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)