### PR TITLE
refactor(rebrand): align ambient workflow and backend with oDispatch naming

### DIFF
--- a/ambient-workflow/.ambient/ambient.json
+++ b/ambient-workflow/.ambient/ambient.json
@@ -1,6 +1,6 @@
 {
-  "name": "Agent Boss Coordination",
-  "description": "Multi-agent coordination workflow for Agent Boss. Registers boss-mcp MCP server for coordinator communication.",
-  "systemPrompt": "You are an autonomous AI agent in the Agent Boss multi-agent coordination system, running inside an ACP (Ambient Code Platform) session. There is no human at this terminal. You interact with the coordinator using your **boss-mcp** MCP tools. Await ignition — the coordinator will send your full protocol, identity, and task assignments after boot.",
-  "startupPrompt": "Check that the $AGENT_NAME environment variable is set. Verify the boss-mcp MCP tools are available by listing your tools. Then await instructions — do not start work until you receive an ignition prompt or a direct task assignment."
+  "name": "OpenDispatch Coordination",
+  "description": "Multi-agent coordination workflow for OpenDispatch. Registers odis-mcp MCP server for coordinator communication.",
+  "systemPrompt": "You are an autonomous AI agent in the OpenDispatch multi-agent coordination system, running inside an ACP (Ambient Code Platform) session. There is no human at this terminal. You interact with the coordinator using your **odis-mcp** MCP tools. Await ignition — the coordinator will send your full protocol, identity, and task assignments after boot.",
+  "startupPrompt": "Check that the $AGENT_NAME environment variable is set. Verify the odis-mcp MCP tools are available by listing your tools. Then await instructions — do not start work until you receive an ignition prompt or a direct task assignment."
 }

--- a/ambient-workflow/.claude/settings.json
+++ b/ambient-workflow/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "mcp__boss-mcp__*"
+      "mcp__odis-mcp__*"
     ]
   }
 }

--- a/ambient-workflow/.mcp.json
+++ b/ambient-workflow/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "boss-mcp": {
+    "odis-mcp": {
       "type": "http",
       "url": "${ODIS_URL}/mcp"
     }

--- a/ambient-workflow/CLAUDE.md
+++ b/ambient-workflow/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agent Boss — ACP Session Safety Rules
+# OpenDispatch — ACP Session Safety Rules
 
 - Do NOT commit directly to `main` — work on feature branches
 - Do NOT include secrets, tokens, or credentials in status updates or messages

--- a/ambient-workflow/README.md
+++ b/ambient-workflow/README.md
@@ -1,13 +1,13 @@
-# Agent Boss Coordination Workflow
+# OpenDispatch Coordination Workflow
 
-ACP workflow that equips remote agent sessions with the commands and protocol needed to participate in the Agent Boss multi-agent coordination system.
+ACP workflow that equips remote agent sessions with the commands and protocol needed to participate in the OpenDispatch multi-agent coordination system.
 
 ## What This Provides
 
 When attached to an ACP session, this workflow:
 
 1. **Injects slash commands** (`/boss.plan`, `/boss.check`, `/boss.ignite`) that agents use to coordinate
-2. **Sets a system prompt** with the full Agent Boss protocol (golden rules, API reference, status format)
+2. **Sets a system prompt** with the full OpenDispatch protocol (golden rules, API reference, status format)
 3. **Provides behavioral guidelines** via `CLAUDE.md` for safe multi-agent operation
 
 ## Commands
@@ -24,14 +24,14 @@ These must be set on the ACP session for commands to work:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `BOSS_URL` | Coordinator API base URL | `https://jsell-agent-boss.apps.okd1.timslab` |
+| `ODIS_URL` | Coordinator API base URL | `https://odispatch.apps.example.com` |
 | `AGENT_NAME` | Agent identity | `ProtocolDev` |
 
 ## Usage with ACP
 
 ### Automatic (via backend config)
 
-When the Agent Boss coordinator is configured with `AMBIENT_WORKFLOW_*` environment variables, every agent session spawned through the ambient backend automatically gets this workflow attached. See the deployment configmap for details.
+When the OpenDispatch coordinator is configured with `AMBIENT_WORKFLOW_*` environment variables, every agent session spawned through the ambient backend automatically gets this workflow attached. See the deployment configmap for details.
 
 ### Manual (via ACP API)
 
@@ -39,12 +39,12 @@ When the Agent Boss coordinator is configured with `AMBIENT_WORKFLOW_*` environm
 {
   "task": "Your task prompt here",
   "activeWorkflow": {
-    "gitUrl": "https://github.com/ambient-code/jsell-agent-boss",
+    "gitUrl": "https://github.com/jsell-rh/agent-boss",
     "branch": "main",
     "path": "ambient-workflow"
   },
   "environmentVariables": {
-    "BOSS_URL": "https://jsell-agent-boss.apps.okd1.timslab",
+    "ODIS_URL": "https://odispatch.apps.example.com",
     "AGENT_NAME": "MyAgent"
   }
 }
@@ -61,6 +61,8 @@ ambient-workflow/
       boss.plan.md        # Factory plan creation
       boss.check.md       # Status sync procedure
       boss.ignite.md      # Agent bootstrap procedure
+    settings.json         # Pre-grants odis-mcp tool permissions
+  .mcp.json               # Registers odis-mcp MCP server
   CLAUDE.md               # Behavioral guidelines
   README.md               # This file
 ```

--- a/internal/coordinator/session_backend.go
+++ b/internal/coordinator/session_backend.go
@@ -117,7 +117,7 @@ type TmuxCreateOpts struct {
 	Width                int    // terminal width (default 220)
 	Height               int    // terminal height (default 50)
 	MCPServerURL         string // if set, run "claude mcp add" before launching
-	MCPServerName        string // MCP server name (e.g. "boss-mcp", "boss-mcp-8889"); defaults to "boss-mcp"
+	MCPServerName        string // MCP server name (e.g. "odis-mcp", "odis-mcp-8889"); defaults to "odis-mcp"
 	AgentToken           string // bearer token embedded inline in --mcp-config JSON for MCP auth; never written to ~/.claude.json
 	AllowSkipPermissions bool   // if true, append --dangerously-skip-permissions to command
 	Model                string // model override e.g. "sonnet", "opus", "claude-sonnet-4-6"

--- a/internal/coordinator/session_backend_ambient.go
+++ b/internal/coordinator/session_backend_ambient.go
@@ -48,7 +48,7 @@ type AmbientBackendConfig struct {
 	WorkflowURL        string // Git URL of workflow repo
 	WorkflowBranch     string // Branch (optional, defaults to main)
 	WorkflowPath       string // Path within repo to workflow dir
-	CoordinatorExternalURL string // e.g. "https://jsell-agent-boss.apps.okd1.timslab"
+	CoordinatorExternalURL string // e.g. "https://odispatch.apps.example.com"
 }
 
 // NewAmbientSessionBackend creates an AmbientSessionBackend from the given config.
@@ -169,12 +169,12 @@ func (b *AmbientSessionBackend) CreateSession(ctx context.Context, opts SessionC
 			wf = ao.Workflow
 		}
 		// Labels for session discovery and ownership tracking.
-		labels := map[string]string{"managed-by": "agent-boss"}
+		labels := map[string]string{"managed-by": "odispatch"}
 		if ao.SpaceName != "" {
-			labels["boss-space"] = sanitizeLabelValue(ao.SpaceName)
+			labels["odis-space"] = sanitizeLabelValue(ao.SpaceName)
 		}
 		if ao.DisplayName != "" {
-			labels["boss-agent"] = sanitizeLabelValue(ao.DisplayName)
+			labels["odis-agent"] = sanitizeLabelValue(ao.DisplayName)
 		}
 		body["labels"] = labels
 	} else if opts.SessionID != "" {
@@ -473,7 +473,11 @@ func (b *AmbientSessionBackend) DiscoverSessions() (map[string]string, error) {
 		}
 		// Prefer label-based matching, fall back to spec.displayName.
 		// Sessions without either are unmanaged and skipped.
-		name := cr.Metadata.Labels["boss-agent"]
+		// Check new label first, fall back to legacy label for backward compat.
+		name := cr.Metadata.Labels["odis-agent"]
+		if name == "" {
+			name = cr.Metadata.Labels["boss-agent"]
+		}
 		if name == "" {
 			name = cr.Spec.DisplayName
 		}

--- a/internal/coordinator/session_backend_ambient_handler_test.go
+++ b/internal/coordinator/session_backend_ambient_handler_test.go
@@ -244,14 +244,14 @@ func TestHandlerAmbientSpawn(t *testing.T) {
 	if !ok {
 		t.Fatalf("session %q not found in mock", sessionID)
 	}
-	if cr.Metadata.Labels["managed-by"] != "agent-boss" {
-		t.Errorf("expected managed-by=agent-boss, got %q", cr.Metadata.Labels["managed-by"])
+	if cr.Metadata.Labels["managed-by"] != "odispatch" {
+		t.Errorf("expected managed-by=odispatch, got %q", cr.Metadata.Labels["managed-by"])
 	}
-	if cr.Metadata.Labels["boss-agent"] != "worker1" {
-		t.Errorf("expected boss-agent=worker1, got %q", cr.Metadata.Labels["boss-agent"])
+	if cr.Metadata.Labels["odis-agent"] != "worker1" {
+		t.Errorf("expected odis-agent=worker1, got %q", cr.Metadata.Labels["odis-agent"])
 	}
-	if cr.Metadata.Labels["boss-space"] != "e2e" {
-		t.Errorf("expected boss-space=e2e, got %q", cr.Metadata.Labels["boss-space"])
+	if cr.Metadata.Labels["odis-space"] != "e2e" {
+		t.Errorf("expected odis-space=e2e, got %q", cr.Metadata.Labels["odis-space"])
 	}
 	if cr.Spec.DisplayName != "worker1" {
 		t.Errorf("expected displayName=worker1, got %q", cr.Spec.DisplayName)
@@ -354,8 +354,8 @@ func TestHandlerAmbientSpawnLabelSanitization(t *testing.T) {
 	if !ok {
 		t.Fatalf("session %q not found in mock", sessionID)
 	}
-	if cr.Metadata.Labels["boss-space"] != "has-spaces" {
-		t.Errorf("expected boss-space=has-spaces, got %q", cr.Metadata.Labels["boss-space"])
+	if cr.Metadata.Labels["odis-space"] != "has-spaces" {
+		t.Errorf("expected odis-space=has-spaces, got %q", cr.Metadata.Labels["odis-space"])
 	}
 }
 
@@ -614,10 +614,10 @@ func TestHandlerAmbientAutoDiscover(t *testing.T) {
 		"summary": "orphan1: working",
 	})
 
-	// Inject a session into the mock with boss-agent=orphan1 label.
+	// Inject a session into the mock with odis-agent=orphan1 label.
 	mock.mu.Lock()
 	mock.sessions["discovered-sess"] = backendCR("discovered-sess", "Running", "orphan1",
-		map[string]string{"boss-agent": "orphan1", "managed-by": "agent-boss"})
+		map[string]string{"odis-agent": "orphan1", "managed-by": "odispatch"})
 	mock.mu.Unlock()
 
 	// GET session-status triggers AutoDiscoverAll.

--- a/internal/coordinator/session_backend_ambient_test.go
+++ b/internal/coordinator/session_backend_ambient_test.go
@@ -143,14 +143,14 @@ func TestAmbientCreateSession(t *testing.T) {
 		if !ok {
 			t.Error("missing labels")
 		} else {
-			if labels["managed-by"] != "agent-boss" {
+			if labels["managed-by"] != "odispatch" {
 				t.Errorf("unexpected managed-by label: %v", labels["managed-by"])
 			}
-			if labels["boss-agent"] != "test-agent" {
-				t.Errorf("unexpected boss-agent label: %v", labels["boss-agent"])
+			if labels["odis-agent"] != "test-agent" {
+				t.Errorf("unexpected odis-agent label: %v", labels["odis-agent"])
 			}
-			if labels["boss-space"] != "test-space" {
-				t.Errorf("unexpected boss-space label: %v", labels["boss-space"])
+			if labels["odis-space"] != "test-space" {
+				t.Errorf("unexpected odis-space label: %v", labels["odis-space"])
 			}
 		}
 
@@ -545,9 +545,9 @@ func TestAmbientDiscoverSessions(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(testSessionsPath, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(backendSessionList{Items: []backendSessionCR{
-			backendCR("s1", "Running", "agent-a", map[string]string{"boss-agent": "agent-a", "managed-by": "agent-boss"}),
-			backendCR("s2", "Completed", "agent-b", map[string]string{"boss-agent": "agent-b"}),
-			backendCR("s3", "Pending", "agent-c", map[string]string{"boss-agent": "agent-c"}),
+			backendCR("s1", "Running", "agent-a", map[string]string{"odis-agent": "agent-a", "managed-by": "odispatch"}),
+			backendCR("s2", "Completed", "agent-b", map[string]string{"odis-agent": "agent-b"}),
+			backendCR("s3", "Pending", "agent-c", map[string]string{"boss-agent": "agent-c"}), // legacy label
 			backendCR("s4", "Running", "", nil),
 		}})
 	})
@@ -574,7 +574,7 @@ func TestAmbientDiscoverSessions(t *testing.T) {
 func TestAmbientDiscoverSessionsFallbackDisplayName(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(testSessionsPath, func(w http.ResponseWriter, r *http.Request) {
-		// Session without boss-agent label but with displayName.
+		// Session without odis-agent label but with displayName.
 		json.NewEncoder(w).Encode(backendSessionList{Items: []backendSessionCR{
 			backendCR("s1", "Running", "agent-x", nil),
 		}})

--- a/internal/coordinator/session_backend_tmux.go
+++ b/internal/coordinator/session_backend_tmux.go
@@ -67,7 +67,7 @@ func (b *TmuxSessionBackend) CreateSession(ctx context.Context, opts SessionCrea
 		model = tmuxOpts.Model
 	}
 	if mcpServerName == "" {
-		mcpServerName = "boss-mcp"
+		mcpServerName = "odis-mcp"
 	}
 
 	// Append --dangerously-skip-permissions when global toggle is on.


### PR DESCRIPTION
## Summary
- Rename boss-mcp → odis-mcp in workflow and tmux backend default
- Update workflow env vars: BOSS_URL → ODIS_URL
- Update K8s labels: managed-by:agent-boss → odispatch, boss-agent → odis-agent, boss-space → odis-space
- Discovery backward compat: checks odis-agent first, falls back to boss-agent for existing sessions

## Changes

**Workflow (ambient-workflow/):**
- .mcp.json: boss-mcp → odis-mcp, ${BOSS_URL} → ${ODIS_URL}
- .claude/settings.json: mcp__boss-mcp__* → mcp__odis-mcp__*
- .ambient/ambient.json: Agent Boss → OpenDispatch, boss-mcp → odis-mcp
- CLAUDE.md + README.md: all references updated

**Backend:**
- session_backend_tmux.go: default MCP name boss-mcp → odis-mcp
- session_backend_ambient.go: labels renamed, discovery has legacy fallback
- session_backend.go: comment update

## Test plan
- [x] All ambient tests pass with -race
- [x] Full coordinator test suite passes (46s)
- [x] Discovery test includes legacy boss-agent label case for backward compat