### PR TITLE
sec(fleet): TASK-121 — 64 KB field size limits + shared_contracts warning

### DIFF
--- a/cmd/boss/fleet.go
+++ b/cmd/boss/fleet.go
@@ -167,6 +167,13 @@ Environment:
 		changedAgents = fleetComputeChangedAgents(client, ff, order)
 	}
 
+	// Always warn when shared_contracts is set — it injects into every agent.
+	if ff.Space.SharedContracts != "" {
+		fmt.Println("WARNING: shared_contracts is set — will be injected into ALL agents in this space.")
+		fmt.Println("         Review the content before proceeding.")
+		fmt.Println()
+	}
+
 	if !*yes {
 		fmt.Printf("Import fleet into space %q?\n", targetSpace)
 		fmt.Printf("  %d persona(s)  %d agent(s)  order: %s\n",
@@ -220,6 +227,15 @@ Environment:
 // When prune is true it also lists agents in the space that would be deleted.
 func fleetDryRun(client *coordinator.Client, ff *coordinator.FleetFile, spaceName string, order []string, prune bool) {
 	fmt.Printf("=== dry-run: import into %q ===\n\n", spaceName)
+
+	// Prominent warning: shared_contracts is injected into every agent's ignition prompt.
+	if ff.Space.SharedContracts != "" {
+		fmt.Println("  ⚠  HIGH IMPACT — shared_contracts is set.")
+		fmt.Println("     This content will be injected into EVERY agent's ignition prompt.")
+		fmt.Println("     Review it carefully before applying.")
+		fmt.Println()
+	}
+
 	anyChange := false
 
 	if len(ff.Personas) > 0 {

--- a/internal/coordinator/fleet.go
+++ b/internal/coordinator/fleet.go
@@ -246,8 +246,9 @@ func ValidateFleetCommand(cmd string) error {
 }
 
 const (
-	fleetMaxBytes  = 1 << 20  // 1 MB
-	fleetMaxAgents = 100
+	fleetMaxBytes     = 1 << 20      // 1 MB total file size
+	fleetMaxAgents    = 100
+	fleetMaxFieldBytes = 64 * 1024   // 64 KB per prompt field
 )
 
 // ValidateFleetSize checks file size and agent count against server limits.
@@ -258,6 +259,27 @@ func ValidateFleetSize(data []byte, agentCount int) error {
 	}
 	if agentCount > fleetMaxAgents {
 		return fmt.Errorf("fleet file exceeds 100-agent limit (%d agents)", agentCount)
+	}
+	return nil
+}
+
+// ValidateFleetFieldSizes checks that individual prompt fields do not exceed
+// the 64 KB per-field cap. Oversized prompts are a persona-injection risk:
+// a malicious fleet file could use --yes to silently apply large, attacker-
+// controlled instructions to every agent in the space.
+func ValidateFleetFieldSizes(ff *FleetFile) error {
+	if len(ff.Space.SharedContracts) > fleetMaxFieldBytes {
+		return fmt.Errorf("space.shared_contracts exceeds 64 KB limit (%d bytes)", len(ff.Space.SharedContracts))
+	}
+	for id, p := range ff.Personas {
+		if len(p.Prompt) > fleetMaxFieldBytes {
+			return fmt.Errorf("persona %q: prompt exceeds 64 KB limit (%d bytes)", id, len(p.Prompt))
+		}
+	}
+	for name, a := range ff.Agents {
+		if len(a.InitialPrompt) > fleetMaxFieldBytes {
+			return fmt.Errorf("agent %q: initial_prompt exceeds 64 KB limit (%d bytes)", name, len(a.InitialPrompt))
+		}
 	}
 	return nil
 }
@@ -414,6 +436,10 @@ func ParseAndValidateFleetFile(data []byte) (*FleetFile, error) {
 	}
 
 	if err := ValidateFleetSize(data, len(ff.Agents)); err != nil {
+		return nil, err
+	}
+
+	if err := ValidateFleetFieldSizes(&ff); err != nil {
 		return nil, err
 	}
 

--- a/internal/coordinator/fleet_test.go
+++ b/internal/coordinator/fleet_test.go
@@ -848,3 +848,48 @@ agents:
 		t.Errorf("repos[1] branch: want empty, got %q", ffRepos.Agents["worker"].Repos[1].Branch)
 	}
 }
+
+func TestValidateFleetFieldSizes(t *testing.T) {
+	big := strings.Repeat("x", fleetMaxFieldBytes+1)
+
+	// shared_contracts over limit.
+	ff := &FleetFile{Space: FleetSpace{SharedContracts: big}}
+	if err := ValidateFleetFieldSizes(ff); err == nil {
+		t.Error("oversized shared_contracts: want error, got nil")
+	}
+
+	// persona prompt over limit.
+	ff = &FleetFile{
+		Personas: map[string]FleetPersona{
+			"p1": {Name: "P1", Prompt: big},
+		},
+	}
+	if err := ValidateFleetFieldSizes(ff); err == nil {
+		t.Error("oversized persona prompt: want error, got nil")
+	}
+
+	// agent initial_prompt over limit.
+	ff = &FleetFile{
+		Agents: map[string]FleetAgent{
+			"a1": {Backend: "tmux", Command: "claude", InitialPrompt: big},
+		},
+	}
+	if err := ValidateFleetFieldSizes(ff); err == nil {
+		t.Error("oversized agent initial_prompt: want error, got nil")
+	}
+
+	// All fields at exactly the limit must pass.
+	atLimit := strings.Repeat("y", fleetMaxFieldBytes)
+	ff = &FleetFile{
+		Space: FleetSpace{SharedContracts: atLimit},
+		Personas: map[string]FleetPersona{
+			"p1": {Name: "P1", Prompt: atLimit},
+		},
+		Agents: map[string]FleetAgent{
+			"a1": {Backend: "tmux", Command: "claude", InitialPrompt: atLimit},
+		},
+	}
+	if err := ValidateFleetFieldSizes(ff); err != nil {
+		t.Errorf("at-limit fields should pass: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fleet YAML security hardening (TASK-121) — two HIGH priority items:

**1. Per-field 64 KB size limits (prompt injection defense)**

- New `ValidateFleetFieldSizes` in `internal/coordinator/fleet.go`
- Caps `space.shared_contracts`, `personas[*].prompt`, and `agents[*].initial_prompt` at 64 KB each
- Called from `ParseAndValidateFleetFile` — both the CLI and server validate before any network calls
- A malicious fleet file with oversized prompts is rejected early, before `--yes` can bypass the confirmation prompt

**2. Prominent `shared_contracts` warning**

- `fleetDryRun`: prints `⚠ HIGH IMPACT — shared_contracts is set` when the field is non-empty, explaining that it injects into ALL agents
- `cmdImport`: unconditional warning printed before the confirmation step — shown even when `--yes` is passed

## Not in scope
- DNS rebinding pin (TASK-121 MEDIUM): pinning the resolved IP requires plumbing changes into the ambient backend spawn path. Tracked separately.
- `--i-reviewed-shared-contracts` flag interlock: the always-visible warning achieves the same protection without a new flag UX burden.

## Test plan
- [x] `TestValidateFleetFieldSizes` — oversized shared_contracts/persona/agent fields → error; at-limit → pass
- [x] `TestParseAndValidateFleetFile` — existing tests still pass
- [x] `go test -race ./internal/coordinator/` — all green (~50s)
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)