### PR TITLE
perf(db): TASK-096 — composite indexes for hot query paths

### DIFF
--- a/internal/coordinator/db/models.go
+++ b/internal/coordinator/db/models.go
@@ -102,8 +102,8 @@ func (Agent) TableName() string { return "agents" }
 // AgentMessage represents a message delivered to an agent.
 type AgentMessage struct {
 	ID        string    `gorm:"primarykey"`
-	SpaceName string    `gorm:"index;not null"`
-	AgentName string    `gorm:"index;not null"`
+	SpaceName string    `gorm:"not null;index:idx_msg_space_agent,priority:1"`
+	AgentName string    `gorm:"not null;index:idx_msg_space_agent,priority:2"`
 	Message   string    `gorm:"type:text;not null"`
 	Sender    string    `gorm:"not null"`
 	Priority  string    `gorm:"default:'info'"`
@@ -117,8 +117,8 @@ func (AgentMessage) TableName() string { return "agent_messages" }
 // AgentNotification represents a typed notification for an agent.
 type AgentNotification struct {
 	ID        string    `gorm:"primarykey"`
-	SpaceName string    `gorm:"index;not null"`
-	AgentName string    `gorm:"index;not null"`
+	SpaceName string    `gorm:"not null;index:idx_notif_space_agent,priority:1"`
+	AgentName string    `gorm:"not null;index:idx_notif_space_agent,priority:2"`
 	Type      string    `gorm:"not null"`
 	Title     string    `gorm:"not null"`
 	Body      string    `gorm:"type:text"`
@@ -135,12 +135,12 @@ func (AgentNotification) TableName() string { return "agent_notifications" }
 // primary key (space_name, id) prevents cross-space collisions in the DB.
 type Task struct {
 	ID        string `gorm:"primaryKey;not null"`
-	SpaceName string `gorm:"primaryKey;not null;index"`
+	SpaceName string `gorm:"primaryKey;not null;index:idx_task_space_status,priority:1;index:idx_task_space_assigned,priority:1"`
 	Title        string    `gorm:"not null"`
 	Description  string    `gorm:"type:text"`
-	Status       string    `gorm:"not null;default:'backlog'"`
+	Status       string    `gorm:"not null;default:'backlog';index:idx_task_space_status,priority:2"`
 	Priority     string    `gorm:"default:'medium'"`
-	AssignedTo   string
+	AssignedTo   string    `gorm:"index:idx_task_space_assigned,priority:2"`
 	CreatedBy    string    `gorm:"not null"`
 	Labels       string    `gorm:"type:text"` // JSON array
 	ParentTask   string    `gorm:"index"`
@@ -183,12 +183,12 @@ func (TaskEvent) TableName() string { return "task_events" }
 // StatusSnapshot records a point-in-time agent status for history/Gantt.
 type StatusSnapshot struct {
 	ID             uint      `gorm:"primarykey;autoIncrement"`
-	AgentName      string    `gorm:"index;not null"`
-	SpaceName      string    `gorm:"index;not null"`
+	AgentName      string    `gorm:"not null;index:idx_snap_space_agent_ts,priority:2"`
+	SpaceName      string    `gorm:"not null;index:idx_snap_space_agent_ts,priority:1"`
 	Status         string    `gorm:"not null"`
 	InferredStatus string
 	Stale          bool
-	Timestamp      time.Time `gorm:"index"`
+	Timestamp      time.Time `gorm:"index:idx_snap_space_agent_ts,priority:3"`
 }
 
 func (StatusSnapshot) TableName() string { return "status_snapshots" }


### PR DESCRIPTION
## Summary

Adds composite DB indexes to the five most-queried table patterns, closing TASK-096.

| Index | Columns | Why |
|-------|---------|-----|
| `idx_msg_space_agent` | `agent_messages(space_name, agent_name)` | Every `check_messages` call filters by both columns |
| `idx_notif_space_agent` | `agent_notifications(space_name, agent_name)` | Same pattern |
| `idx_snap_space_agent_ts` | `status_snapshots(space_name, agent_name, timestamp)` | `GetSnapshots` + `PruneOldSnapshots` filter by space+agent, order by timestamp — composite covers filter and sort |
| `idx_task_space_status` | `tasks(space_name, status)` | `ListTasks` with status filter |
| `idx_task_space_assigned` | `tasks(space_name, assigned_to)` | `ListTasks` with assigned_to filter |

GORM `AutoMigrate` creates new indexes alongside existing individual-column indexes — fully backward compatible with running DBs.

## Not in scope (left as follow-up)
- N+1 startup queries (ListTasks + GetTask×N) — requires batch-load of comments/events
- O(N) `resolveSpaceNameLocked` — small map, low real-world impact

## Test plan
- [x] `go build ./...` — clean
- [x] `go test -race ./internal/coordinator/db/` — green
- [x] `go test -race ./internal/coordinator/` — all green (~52s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)