### PR TITLE
fix(db): persist agent config on upsert + GIT_SSL_NO_VERIFY for self-signed certs

### DIFF
--- a/internal/coordinator/db/repository.go
+++ b/internal/coordinator/db/repository.go
@@ -75,6 +75,7 @@ func (r *Repository) UpsertAgent(a *Agent) error {
 			"documents", "next_steps", "free_text", "session_id", "backend_type", "repo_url",
 			"parent", "children", "role", "inferred_status", "stale",
 			"registration", "last_heartbeat", "heartbeat_stale", "updated_at",
+			"config", "agent_type", "mood",
 		}),
 	}).Create(a).Error
 }

--- a/internal/coordinator/session_backend_ambient.go
+++ b/internal/coordinator/session_backend_ambient.go
@@ -214,11 +214,12 @@ func (b *AmbientSessionBackend) CreateSession(ctx context.Context, opts SessionC
 		}
 	}
 
-	// The Node.js MCP HTTP transport rejects self-signed certs by default.
 	// When TLS verification is skipped for the ambient backend, propagate
-	// this to runner pods so the SDK can connect to the coordinator.
+	// this to runner pods so the SDK can connect to the coordinator and
+	// the init container can clone repos from hosts with self-signed certs.
 	if b.skipTLSVerify {
 		envVars["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
+		envVars["GIT_SSL_NO_VERIFY"] = "true"
 	}
 
 	if len(envVars) > 0 {


### PR DESCRIPTION
## Summary
- Fix agent config/type/mood not persisting across coordinator restarts
- Propagate GIT_SSL_NO_VERIFY=true to runner pods when TLS skip is enabled

## Bug: config lost on restart
UpsertAgent's ON CONFLICT DoUpdates clause listed specific columns but was missing `config`, `agent_type`, and `mood`. When an agent row already existed (created by PostAgentUpdate), subsequent PatchAgentConfig calls would set config in memory but the DB upsert silently dropped it. Configs imported via fleet were lost on coordinator restart.

## Fix: GIT_SSL_NO_VERIFY
When `AMBIENT_SKIP_TLS_VERIFY=true`, the coordinator now sets `GIT_SSL_NO_VERIFY=true` on runner pod env vars alongside `NODE_TLS_REJECT_UNAUTHORIZED=0`. This lets the init container clone repos from hosts with self-signed certs.

## Test plan
- [x] Full test suite passes with -race
- [x] Verified configs persist in PostgreSQL after fleet import
- [x] Verified configs survive coordinator restart
- [x] Verified repo cloning succeeds with self-signed Gitea certs