### PR TITLE
perf(api): TASK-122 — lazy-load Documents[] via dedicated endpoint

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -15,6 +15,7 @@ import type {
   Persona,
   PersonaVersion,
   PersonaAgentInfo,
+  AgentDocument,
 } from '@/types'
 
 /**
@@ -199,6 +200,12 @@ class ApiClient {
   fetchAgent(space: string, agent: string): Promise<AgentUpdate> {
     return this.request<AgentUpdate>(
       `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}`,
+    )
+  }
+
+  fetchAgentDocuments(space: string, agent: string): Promise<AgentDocument[]> {
+    return this.request<AgentDocument[]>(
+      `/spaces/${encodeURIComponent(space)}/agent/${encodeURIComponent(agent)}/documents`,
     )
   }
 

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AgentUpdate, AgentMessage, SessionAgentStatus, SessionDisplayState, IntrospectResponse, Task, AgentConfig, Persona } from '@/types'
+import type { AgentUpdate, AgentMessage, AgentDocument, SessionAgentStatus, SessionDisplayState, IntrospectResponse, Task, AgentConfig, Persona } from '@/types'
 import { SESSION_STATUS_DISPLAY, getSessionDisplayState } from '@/types'
 import { ref, computed, watch, onUnmounted, onMounted } from 'vue'
 import { Card, CardContent } from '@/components/ui/card'
@@ -434,6 +434,13 @@ watch(() => props.agentName, () => {
   configEditMode.value = false
   loadPersonaData()
 })
+
+const agentDocuments = ref<AgentDocument[]>([])
+async function loadAgentDocuments() {
+  agentDocuments.value = await api.fetchAgentDocuments(props.spaceName, props.agentName)
+}
+onMounted(loadAgentDocuments)
+watch(() => props.agentName, loadAgentDocuments)
 </script>
 
 <template>
@@ -1109,11 +1116,11 @@ watch(() => props.agentName, () => {
       </section>
 
       <!-- Documents -->
-      <section v-if="agent.documents?.length" aria-label="Agent documents">
+      <section v-if="agentDocuments.length" aria-label="Agent documents">
         <h2 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">Documents</h2>
         <nav class="space-y-1" aria-label="Document links">
           <a
-            v-for="doc in agent.documents"
+            v-for="doc in agentDocuments"
             :key="doc.slug"
             :href="`/spaces/${spaceName}/agent/${agentName}/${doc.slug}`"
             target="_blank"

--- a/internal/coordinator/handlers_agent.go
+++ b/internal/coordinator/handlers_agent.go
@@ -524,6 +524,35 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, spac
 	}
 }
 
+// handleAgentDocumentsList serves GET /spaces/{space}/agent/{name}/documents.
+// Returns the agent's document list on-demand so the default space GET can omit
+// the Documents[] array (which can be 20KB+ per agent across 5+ agents).
+func (s *Server) handleAgentDocumentsList(w http.ResponseWriter, r *http.Request, spaceName, agentName string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	ks, ok := s.getSpace(spaceName)
+	if !ok {
+		writeJSONError(w, fmt.Sprintf("space %q not found", spaceName), http.StatusNotFound)
+		return
+	}
+	s.mu.RLock()
+	canonical := resolveAgentName(ks, agentName)
+	agent, exists := ks.agentStatusOk(canonical)
+	s.mu.RUnlock()
+	if !exists {
+		writeJSONError(w, fmt.Sprintf("agent %q not found", agentName), http.StatusNotFound)
+		return
+	}
+	docs := agent.Documents
+	if docs == nil {
+		docs = []AgentDocument{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(docs)
+}
+
 func (s *Server) handleAgentDocument(w http.ResponseWriter, r *http.Request, spaceName, agentName, documentSlug string) {
 	agentName = strings.TrimRight(agentName, "/")
 

--- a/internal/coordinator/handlers_space.go
+++ b/internal/coordinator/handlers_space.go
@@ -180,6 +180,8 @@ func (s *Server) handleSpaceRoute(w http.ResponseWriter, r *http.Request) {
 				s.handleAgentConfig(w, r, spaceName, agentName)
 			case "duplicate":
 				s.handleAgentDuplicate(w, r, spaceName, agentName)
+			case "documents":
+				s.handleAgentDocumentsList(w, r, spaceName, agentName)
 			default:
 				// Handle document path: /spaces/{space}/agent/{agent}/{slug}
 				s.handleAgentDocument(w, r, spaceName, agentName, action)
@@ -368,7 +370,7 @@ func agentUpdateToPublic(st *AgentUpdate) *agentStatusPublic {
 		Worktree: st.Worktree, PR: st.PR, Phase: st.Phase, Mood: st.Mood,
 		TestCount: st.TestCount, Items: st.Items, Sections: st.Sections,
 		Questions: st.Questions, Blockers: st.Blockers, NextSteps: st.NextSteps,
-		FreeText: st.FreeText, Documents: st.Documents, SessionID: st.SessionID,
+		FreeText: st.FreeText, SessionID: st.SessionID,
 		BackendType: st.BackendType, RepoURL: st.RepoURL, UpdatedAt: st.UpdatedAt,
 		Parent: st.Parent, Children: st.Children, Role: st.Role,
 		InferredStatus: st.InferredStatus, Stale: st.Stale,


### PR DESCRIPTION
## Summary

- Strips `documents` array from space GET response (`agentUpdateToPublic`) — documents can be 20KB+ per agent and were loaded on every space poll
- Adds `GET /spaces/:space/agent/:name/documents` endpoint that returns `[]AgentDocument` on demand
- Frontend `AgentDetail.vue` fetches documents lazily on mount and whenever the viewed agent changes, replacing the previous prop-based `agent.documents` access

## Test plan

- [ ] Open agent detail panel — documents section still appears if agent has documents
- [ ] Switch between agents — documents reload correctly per agent
- [ ] Agent with no documents — documents section hidden (empty array)
- [ ] Verify space GET payload is smaller (no `documents` key in agent objects)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)