### PR TITLE
perf(frontend): TASK-092 — spaceMessages TTL cache + kanban done collapse

### DIFF
--- a/frontend/src/components/ConversationsView.vue
+++ b/frontend/src/components/ConversationsView.vue
@@ -51,9 +51,15 @@ interface Conversation {
   lastMessageAt: string
 }
 
+// Module-level TTL cache — survives ConversationsView unmount/remount (tab switches).
+// Eliminates the 300-500 KB re-fetch that happened on every Conversations tab visit.
+type MessageBucket = { messages: import('@/types').AgentMessage[]; has_more: boolean }
+const _msgCache: Record<string, { data: Record<string, MessageBucket>; fetchedAt: number }> = {}
+const MSG_CACHE_TTL = 60_000 // 60 s
+
 // Messages fetched from /spaces/:space/messages — decoupled from the space JSON
 // (which no longer embeds message histories after the perf fix in PR #195).
-const spaceMessages = ref<Record<string, { messages: import('@/types').AgentMessage[]; has_more: boolean }>>({})
+const spaceMessages = ref<Record<string, MessageBucket>>({})
 const messagesLoading = ref(false)
 const loadingEarlier = ref(false)
 // Tracks whether any agent in the current conversation has more messages to load.
@@ -68,12 +74,21 @@ const MESSAGE_LIMIT = 50
 let _loadMessagesCtrl: AbortController | null = null
 
 async function loadSpaceMessages() {
+  const spaceName = props.space.name
+  // Serve from cache if fresh — avoids re-fetch on tab switch back to Conversations.
+  const cached = _msgCache[spaceName]
+  if (cached && Date.now() - cached.fetchedAt < MSG_CACHE_TTL) {
+    spaceMessages.value = cached.data
+    return
+  }
   _loadMessagesCtrl?.abort()
   _loadMessagesCtrl = new AbortController()
   const { signal } = _loadMessagesCtrl
   messagesLoading.value = true
   try {
-    spaceMessages.value = await api.fetchSpaceMessages(props.space.name, { limit: MESSAGE_LIMIT, signal })
+    const data = await api.fetchSpaceMessages(spaceName, { limit: MESSAGE_LIMIT, signal })
+    spaceMessages.value = data
+    _msgCache[spaceName] = { data, fetchedAt: Date.now() }
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') return  // superseded by newer request
     // non-fatal: falls back to agentData.messages (empty after PR #195)

--- a/frontend/src/components/KanbanColumn.vue
+++ b/frontend/src/components/KanbanColumn.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import type { Task, TaskStatus } from '@/types'
 import { TASK_STATUS_LABELS } from '@/types'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import TaskCard from './TaskCard.vue'
-import { LayoutList, Plus } from 'lucide-vue-next'
+import { LayoutList, Plus, ChevronDown, ChevronUp } from 'lucide-vue-next'
+
+const DONE_COLLAPSE_THRESHOLD = 8
 
 const props = defineProps<{
   status: TaskStatus
@@ -12,12 +14,33 @@ const props = defineProps<{
   draggingTaskId?: string | null
 }>()
 
-// For each top-level task in this column, look up its subtasks from allTasks.
+// Collapse done column by default when it has many tasks to avoid 700+ DOM nodes.
+const doneExpanded = ref(false)
+const visibleTasks = computed(() => {
+  if (props.status !== 'done' || doneExpanded.value || props.tasks.length <= DONE_COLLAPSE_THRESHOLD) {
+    return props.tasks
+  }
+  return props.tasks.slice(0, DONE_COLLAPSE_THRESHOLD)
+})
+const hiddenDoneCount = computed(() =>
+  props.status === 'done' && !doneExpanded.value ? Math.max(0, props.tasks.length - DONE_COLLAPSE_THRESHOLD) : 0
+)
+
+// Memoized subtask lookup — avoids allocating a new array on every render pass.
+const subtaskMap = computed((): Map<string, Task[]> => {
+  const map = new Map<string, Task[]>()
+  if (!props.allTasks) return map
+  for (const task of props.tasks) {
+    if (!task.subtasks?.length) continue
+    const subs = task.subtasks
+      .map(id => props.allTasks!.find(t => t.id === id))
+      .filter((t): t is Task => t !== undefined)
+    if (subs.length) map.set(task.id, subs)
+  }
+  return map
+})
 function subtasksOf(task: Task): Task[] {
-  if (!props.allTasks || !task.subtasks?.length) return []
-  return task.subtasks
-    .map(id => props.allTasks!.find(t => t.id === id))
-    .filter((t): t is Task => t !== undefined)
+  return subtaskMap.value.get(task.id) ?? []
 }
 
 const emit = defineEmits<{
@@ -91,7 +114,7 @@ const statusHeaderClass: Record<TaskStatus, string> = {
     <!-- Cards -->
     <div class="flex flex-col gap-2 p-2 flex-1 min-h-24 overflow-y-auto">
       <TransitionGroup name="kanban-card" tag="div" class="flex flex-col gap-2">
-        <div v-for="task in tasks" :key="task.id" class="flex flex-col gap-1">
+        <div v-for="task in visibleTasks" :key="task.id" class="flex flex-col gap-1">
           <TaskCard
             :task="task"
             :dragging="draggingTaskId === task.id"
@@ -112,6 +135,16 @@ const statusHeaderClass: Record<TaskStatus, string> = {
           </div>
         </div>
       </TransitionGroup>
+      <!-- Done column expand/collapse toggle -->
+      <button
+        v-if="hiddenDoneCount > 0 || (status === 'done' && doneExpanded && tasks.length > DONE_COLLAPSE_THRESHOLD)"
+        class="w-full flex items-center justify-center gap-1 py-1.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+        @click="doneExpanded = !doneExpanded"
+      >
+        <ChevronDown v-if="!doneExpanded" class="size-3" />
+        <ChevronUp v-else class="size-3" />
+        {{ doneExpanded ? 'Show fewer' : `Show ${hiddenDoneCount} more` }}
+      </button>
       <div
         v-if="tasks.length === 0"
         class="flex-1 flex flex-col items-center justify-center py-8 text-center gap-2 cursor-pointer select-none rounded-md hover:bg-muted/60 transition-colors"


### PR DESCRIPTION
## Summary

- **ConversationsView**: adds a module-level 60s TTL cache for `spaceMessages`. On tab switch, data is served instantly from cache instead of re-fetching 300-500KB from the server. SSE mutations update the cached object by reference, so messages appended by live events stay in cache without a new fetch.
- **KanbanColumn**: collapses the done column to 8 tasks by default with an expand toggle. Eliminates 700-1000 DOM nodes on spaces with many completed tasks. Also converts `subtasksOf()` from a plain function (called per task per render) to a memoized computed `Map`, computing once per render cycle.

## Test plan

- [ ] Switch away from Conversations tab and back — no loading spinner, data appears instantly
- [ ] New SSE messages still arrive and display in real time
- [ ] Kanban done column shows ≤8 tasks with "Show N more" toggle
- [ ] Clicking toggle expands/collapses done column
- [ ] Subtasks still render correctly under parent tasks
- [ ] `make typecheck` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)