### PR TITLE
docs(lifecycle): TASK-023 — clarify Width/Height omission in restart paths

### DIFF
--- a/internal/coordinator/lifecycle.go
+++ b/internal/coordinator/lifecycle.go
@@ -641,6 +641,8 @@ func (s *Server) restartAgentService(spaceName, agentName string, req spawnReque
 			SessionID: newSession,
 			Command:   command,
 			BackendOpts: TmuxCreateOpts{
+				// Width/Height intentionally omitted — session_backend_tmux.go applies
+				// the same 220×50 defaults as the spawn path when these are zero.
 				WorkDir:              restartWorkDir,
 				MCPServerURL:         s.localURL(),
 				MCPServerName:        s.mcpServerName(),
@@ -869,6 +871,8 @@ func (s *Server) handleRestartAll(w http.ResponseWriter, r *http.Request, spaceN
 				SessionID: newSession,
 				Command:   command,
 				BackendOpts: TmuxCreateOpts{
+					// Width/Height intentionally omitted — session_backend_tmux.go applies
+					// the same 220×50 defaults as the spawn path when these are zero.
 					WorkDir:              workDir,
 					MCPServerURL:         s.localURL(),
 					MCPServerName:        s.mcpServerName(),


### PR DESCRIPTION
## Summary

Resolves TASK-023 audit item. The restart code paths in `lifecycle.go` intentionally omit `Width` and `Height` in `TmuxCreateOpts` — `session_backend_tmux.go` applies the same `220×50` defaults when these fields are zero, producing identical terminal dimensions to the spawn path. Added a comment at both restart sites so future readers don't mistake this for an oversight.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)