### PR TITLE
fix(ui): remove remaining 'boss' visible text in frontend (follow-up)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -228,7 +228,7 @@ const showSettings = computed(() => false)
 const pendingDecisionCount = computed(() => {
   if (!currentSpace.value) return 0
   const operatorAgent = Object.values(currentSpace.value.agents).find((a: any) => a.agent_type === 'human')
-  return (operatorAgent as any)?.unread_count ?? (currentSpace.value.agents['operator'] as any)?.unread_count ?? (currentSpace.value.agents['boss'] as any)?.unread_count ?? 0
+  return (operatorAgent as any)?.unread_count ?? (currentSpace.value.agents['operator'] as any)?.unread_count ?? 0
 })
 
 const selectedAgentData = computed<AgentUpdate | null>(() => {
@@ -708,7 +708,7 @@ async function handleReplyToQuestion(agentName: string, questionIndex: number, q
   if (!selectedSpace.value) return
   try {
     // 1. Send as persistent message so agent sees it on next check-in
-    await api.sendMessage(selectedSpace.value, agentName, `Re: ${questionText}\n\n${replyText}`, 'Boss')
+    await api.sendMessage(selectedSpace.value, agentName, `Re: ${questionText}\n\n${replyText}`, 'operator')
     // 2. Dismiss the question
     await api.dismissItem(selectedSpace.value, agentName, questionIndex, 'question')
     // 3. Nudge the agent to trigger a check-in so they read the message
@@ -729,7 +729,7 @@ async function handleReplyToBlocker(agentName: string, blockerIndex: number, blo
   if (!selectedSpace.value) return
   try {
     // 1. Send as persistent message so agent sees it on next check-in
-    await api.sendMessage(selectedSpace.value, agentName, `Re: [Blocker] ${blockerText}\n\n${replyText}`, 'Boss')
+    await api.sendMessage(selectedSpace.value, agentName, `Re: [Blocker] ${blockerText}\n\n${replyText}`, 'operator')
     // 2. Dismiss the blocker
     await api.dismissItem(selectedSpace.value, agentName, blockerIndex, 'blocker')
     // 3. Nudge the agent to trigger a check-in so they read the message

--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -1292,7 +1292,7 @@ watch(() => props.agentName, loadAgentDocuments)
           <Tooltip>
             <TooltipTrigger as-child>
               <h2 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground cursor-default">
-                Boss ↔ {{ agentName }} Messages
+                Operator ↔ {{ agentName }} Messages
               </h2>
             </TooltipTrigger>
             <TooltipContent>Direct channel between you (operator) and {{ agentName }}. Messages sent here go directly to the agent's inbox.</TooltipContent>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -221,7 +221,7 @@ function spaceBossUnreadCount(space: SpaceSummary): number {
   if (space.name === props.selectedSpace && props.currentSpace) {
     const agents = props.currentSpace.agents
     const operatorAgent = Object.values(agents).find((a: any) => a.agent_type === 'human')
-    return (operatorAgent as any)?.unread_count ?? (agents['operator'] as any)?.unread_count ?? (agents['boss'] as any)?.unread_count ?? 0
+    return (operatorAgent as any)?.unread_count ?? (agents['operator'] as any)?.unread_count ?? 0
   }
   return space.boss_unread_count ?? 0
 }
@@ -253,7 +253,7 @@ const operatorUnreadCount = computed(() => {
   // Post-PR #195 the space response strips message bodies but includes unread_count.
   // Fall back to iterating messages for older server payloads that still embed them.
   const agents = props.currentSpace.agents
-  const operatorAgent = Object.values(agents).find((a: any) => a.agent_type === 'human') ?? agents['operator'] ?? agents['boss']
+  const operatorAgent = Object.values(agents).find((a: any) => a.agent_type === 'human') ?? agents['operator']
   if (!operatorAgent) return 0
   if (typeof operatorAgent.unread_count === 'number') return operatorAgent.unread_count
   // Legacy fallback: count unread messages from the embedded messages array
@@ -309,7 +309,7 @@ defineExpose({ openNewSpaceDialog })
       </div>
       <div class="flex items-center gap-1.5 mt-1 text-xs text-amber-600 dark:text-amber-400">
         <Crown class="size-3 shrink-0" aria-hidden="true" />
-        <span class="font-medium">You (Boss)</span>
+        <span class="font-medium">You (Operator)</span>
       </div>
     </SidebarHeader>
 


### PR DESCRIPTION
## Summary

Follow-up to #267 — fixes remaining visible 'boss' text the operator sees in the UI:

- **AgentDetail.vue**: Section heading `Boss ↔ Agent Messages` → `Operator ↔ Agent Messages`
- **App.vue**: `handleReplyToQuestion` and `handleReplyToBlocker` were sending messages with sender `'Boss'` (capital B) — changed to `'operator'`
- **AppSidebar.vue**: Sidebar label `You (Boss)` → `You (Operator)`
- **App.vue / AppSidebar.vue**: Removed dead `agents['boss']` fallback lookups (the `agents['operator']` fallback was already in place before them)

## Test plan

- [ ] `make typecheck` passes ✓
- [ ] Sidebar shows "You (Operator)" instead of "You (Boss)"
- [ ] Agent detail messages section shows "Operator ↔ {agent} Messages"
- [ ] Replies to questions/blockers sent with sender `'operator'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)