### PR TITLE
fix(ux): add flex-wrap to AgentDetail control rows for mobile (TASK-139)

### DIFF
--- a/frontend/src/components/AgentDetail.vue
+++ b/frontend/src/components/AgentDetail.vue
@@ -449,7 +449,7 @@ watch(() => props.agentName, loadAgentDocuments)
       <!-- Header -->
       <div class="flex items-start justify-between gap-4 flex-wrap">
         <div class="space-y-1">
-          <div class="flex items-center gap-3">
+          <div class="flex items-center gap-3 flex-wrap">
             <AgentAvatar :name="agentName" :size="36" />
             <h1 class="text-2xl font-semibold tracking-tight">{{ agentName }}</h1>
             <StatusBadge :status="agent.status" />
@@ -549,7 +549,7 @@ watch(() => props.agentName, loadAgentDocuments)
         <!-- Action buttons: two rows for clarity -->
         <div class="flex flex-col items-end gap-2 shrink-0">
           <!-- Row 1: Primary actions -->
-          <div class="flex items-center gap-1.5">
+          <div class="flex items-center gap-1.5 flex-wrap">
             <Tooltip>
               <TooltipTrigger as-child>
                 <Button
@@ -587,7 +587,7 @@ watch(() => props.agentName, loadAgentDocuments)
           </div>
 
           <!-- Row 2: Session / lifecycle controls -->
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 flex-wrap">
             <!-- Terminal status -->
             <Tooltip>
               <TooltipTrigger as-child>
@@ -623,7 +623,7 @@ watch(() => props.agentName, loadAgentDocuments)
             </Tooltip>
 
             <!-- Lifecycle actions grouped -->
-            <div class="flex items-center rounded-md border border-border bg-muted/20 p-0.5 gap-0.5">
+            <div class="flex items-center flex-wrap rounded-md border border-border bg-muted/20 p-0.5 gap-0.5">
               <Tooltip>
                 <TooltipTrigger as-child>
                   <Button


### PR DESCRIPTION
## Summary

Fixes #284 — AgentDetail session/lifecycle control buttons overflowed on mobile/small screens due to missing `flex-wrap`.

Added `flex-wrap` to four control rows:
- **Header row**: avatar + name + status badges now wrap on very small screens
- **Row 1** (primary actions): Conversations, Nudge, Delete buttons wrap
- **Row 2** (session controls): Session badge, Attach, lifecycle group, Inspect, Duplicate wrap
- **Lifecycle group** (inner): Spawn, Restart, Interrupt, Kill buttons wrap within their bordered container

Desktop layout is unchanged — buttons only stack when the viewport is too narrow to display them inline.

## Test plan

- [ ] `make typecheck` passes ✓
- [ ] On desktop: buttons display in a single row as before
- [ ] On mobile/narrow viewport: buttons wrap to next line gracefully, no overflow/clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)